### PR TITLE
fix: use Redis.from_url() for proper SSL support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ services:
       # - DATABASE_URL=mysql://user:password@host:3306/grok2api
 
       ## MySQL格式: mysql://user:password@host:port/database
-      ## Redis格式: redis://host:port/db 或 redis://user:password@host:port/db
+      ## Redis格式: redis://host:port/db 或 redis://user:password@host:port/db (SSL: rediss://)
 
 volumes:
   grok_data:


### PR DESCRIPTION
Replace custom _parse_url() with redis.Redis.from_url() which properly handles rediss:// SSL connections and all URL parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)