### PR TITLE
fix: 修复 grok-imagine-0.9 纯文本生成图片的bug

### DIFF
--- a/app/models/grok_models.py
+++ b/app/models/grok_models.py
@@ -103,13 +103,13 @@ _MODEL_CONFIG: Dict[str, Dict[str, Any]] = {
         "cost": {"type": "low_cost", "multiplier": 1, "description": "计1次调用"},
         "requires_super": False,
         "display_name": "Grok Imagine 0.9",
-        "description": "Video generation model powered by Grok",
+        "description": "Image generation model powered by Grok",
         "raw_model_path": "xai/grok-imagine-0.9",
         "default_temperature": 1.0,
         "default_max_output_tokens": 8192,
         "supported_max_output_tokens": 131072,
         "default_top_p": 0.95,
-        "is_video_model": True
+        "is_video_model": False
     }
 }
 

--- a/app/services/grok/client.py
+++ b/app/services/grok/client.py
@@ -188,7 +188,8 @@ class GrokClient:
             # 构建请求
             headers = GrokClient._build_headers(token)
             if model == "grok-imagine-0.9":
-                ref_id = post_id or payload.get("fileAttachments", [""])[0]
+                file_attachments = payload.get("fileAttachments", [])
+                ref_id = post_id or (file_attachments[0] if file_attachments else "")
                 if ref_id:
                     headers["Referer"] = f"https://grok.com/imagine/{ref_id}"
             


### PR DESCRIPTION
## 问题描述

当使用 `grok-imagine-0.9` 模型进行纯文本到图片生成时，会抛出 `list index out of range` 错误，导致无法使用该模型生成图片。

## 根本原因

1. **模型配置错误**: `grok-imagine-0.9` 被错误地标记为视频模型 (`is_video_model: True`)，这导致代码走入了视频生成的逻辑分支
2. **数组访问bug**: 在没有图片附件的情况下，代码尝试访问空列表的第一个元素，引发 IndexError

## 修复内容

### 1. app/models/grok_models.py
- 将 `is_video_model` 从 `True` 改为 `False`
- 更新 description 为 Image generation model

### 2. app/services/grok/client.py
修复空列表访问bug，使用安全的访问方式

## 测试结果

✅ 纯文本生成图片：成功
✅ 文本对话：正常
✅ 其他模型：不受影响

根据 xAI 官方文档，Grok Imagine 使用 Aurora 引擎，主要是图像生成模型，支持 text-to-image 功能。