### PR TITLE
修复代理问题

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -65,8 +65,16 @@ class ConfigManager:
             toml.dump(default, f)
     
     def _normalize_proxy(self, proxy: str) -> str:
-        """标准化代理URL（socks5:// → socks5h://）"""
-        if proxy and proxy.startswith("socks5://"):
+        """标准化代理URL（sock5/socks5 → socks5h://）"""
+        if not proxy:
+            return proxy
+
+        proxy = proxy.strip()
+        if proxy.startswith("sock5h://"):
+            proxy = proxy.replace("sock5h://", "socks5h://", 1)
+        if proxy.startswith("sock5://"):
+            proxy = proxy.replace("sock5://", "socks5://", 1)
+        if proxy.startswith("socks5://"):
             return proxy.replace("socks5://", "socks5h://", 1)
         return proxy
     
@@ -90,6 +98,8 @@ class ConfigManager:
             if section == "grok":
                 if "proxy_url" in config:
                     config["proxy_url"] = self._normalize_proxy(config["proxy_url"])
+                if "cache_proxy_url" in config:
+                    config["cache_proxy_url"] = self._normalize_proxy(config["cache_proxy_url"])
                 if "cf_clearance" in config:
                     config["cf_clearance"] = self._normalize_cf(config["cf_clearance"])
 

--- a/app/services/grok/cache.py
+++ b/app/services/grok/cache.py
@@ -71,7 +71,7 @@ class CacheService:
                 retry_403_count = 0
                 
                 while retry_403_count <= max_403_retries:
-                    proxy = setting.get_proxy("cache")
+                    proxy = await setting.get_proxy_async("cache")
                     proxies = {"http": proxy, "https": proxy} if proxy else {}
                     
                     if proxy and outer_retry == 0 and retry_403_count == 0:


### PR DESCRIPTION
本次合并修复代理配置与代理池误用导致的连接问题，并统一代理读取路径。新增对 sock5/socks5 写法的规范化，代理池返回值也会被规范化；若误将代理地址填入 proxy_pool_url，系统会自动当作静态代理并提示，避免错误请求代理池 API；缓存下载改为异步获取代理，确保与其他请求一致。

使用之前版本代理，sock5://127.0.0.1:xxxx 是不可用的报错403，经过修复后可用。