### PR TITLE
fix: 修复流式响应长时间无数据导致客户端超时断开的问题

### DIFF
--- a/app/services/grok/upload.py
+++ b/app/services/grok/upload.py
@@ -133,7 +133,7 @@ class ImageUploadManager:
                                 return file_id, file_uri
                             
                             # 其他错误直接返回
-                            logger.error(f"[Upload] 失败，状态码: {response._status_code}")
+                            logger.error(f"[Upload] 失败，状态码: {response.status_code}")
                             return "", ""
                     
                     # 内层循环正常结束（非break），说明403重试全部失败


### PR DESCRIPTION
问题：
- grok-4.1-thinking 等模型在处理图片时需要较长"思考"时间
- 期间不产生输出 token，导致客户端因长时间无数据而超时断开
- 错误表现为 "Server disconnected without sending a response"

解决方案：
- 新增 AsyncLineIterator 类，将同步 iter_lines() 包装为异步迭代器
- 使用生产者-消费者模式，通过 asyncio.Queue 在线程间安全传递数据
- 当等待数据超时（默认15秒）时，发送 SSE 心跳注释 ": heartbeat\n\n"
- 心跳注释会被客户端忽略，但能保持连接活跃

其他修复：
- 修复 upload.py 中 response._status_code 的 typo（应为 status_code）

配置项：
- stream_heartbeat_interval: 心跳间隔（秒），默认 15