### PR TITLE
fix: 将 disableMemory 改为可配置项，默认禁用服务端记忆

### DIFF
--- a/app/services/grok/services/chat.py
+++ b/app/services/grok/services/chat.py
@@ -238,7 +238,7 @@ class ChatRequestBuilder:
                 "modelConfigOverride": {"modelMap": {}},
                 "requestModelDetails": {"modelId": model},
             },
-            "disableMemory": False,
+            "disableMemory": get_config("grok.disable_memory", True),
             "forceSideBySide": False,
             "isAsyncChat": False,
             "disableSelfHarmShortCircuit": False,


### PR DESCRIPTION
共享 token 池场景下，disableMemory: False 会导致：
1. 不同用户的对话记忆相互污染
2. 历史记忆覆盖当前用户指令

现改为通过 grok.disable_memory 配置，默认 True