### PR TITLE
fix: improve final image selection in stream processor

### DIFF
--- a/app/services/grok/services/image.py
+++ b/app/services/grok/services/image.py
@@ -541,22 +541,21 @@ class ImageWSStreamProcessor(ImageWSBaseProcessor):
                     )
 
         if self.n == 1:
-            if self._target_id and self._target_id in images:
-                selected = [(self._target_id, images[self._target_id])]
+            target_item = images.get(self._target_id) if self._target_id else None
+            if target_item and target_item.get("is_final", False):
+                selected = [(self._target_id, target_item)]
+            elif images:
+                selected = [
+                    max(
+                        images.items(),
+                        key=lambda x: (
+                            x[1].get("is_final", False),
+                            x[1].get("blob_size", 0),
+                        ),
+                    )
+                ]
             else:
-                selected = (
-                    [
-                        max(
-                            images.items(),
-                            key=lambda x: (
-                                x[1].get("is_final", False),
-                                x[1].get("blob_size", 0),
-                            ),
-                        )
-                    ]
-                    if images
-                    else []
-                )
+                selected = []
         else:
             selected = [
                 (image_id, images[image_id])


### PR DESCRIPTION
## 修改：流式模式最终图片选择逻辑

**文件：** `app/services/grok/services/image.py`

### 问题描述

`ImageWSStreamProcessor`（流式处理器）在 `n=1` 时会将**第一个到达**的图片锁定为 target（第 456-458 行）。WebSocket 循环在 `_stream_once` 中收到任意一张 final 图后就会 break（`completed >= n`）。

但 Grok 会同时生成多张图片（通常 4-6 张），每张都经历 medium → final 阶段。**第一个到达的图片不一定是第一个拿到 final 的**。

实际场景：

```
Grok 发送：
  ① a0f0b05c medium (33KB)   ← 第一个到达，被锁定为 target
  ② 86941b68 medium (34KB)
  ③ ba462378 medium (33KB)
  ④ ba462378 final  (303KB)  ← 另一张拿到 final → completed=1 → break
```

旧代码在最终选择时：

```python
if self._target_id and self._target_id in images:
    selected = [(self._target_id, images[self._target_id])]
```

直接选了 `a0f0b05c` 的 medium 数据（33KB）当作 final 保存，真正的 final `ba462378`（303KB）被丢弃。

### 修改内容（第 513-528 行）

```python
if self.n == 1:
    target_item = images.get(self._target_id) if self._target_id else None
    if target_item and target_item.get("is_final", False):
        selected = [(self._target_id, target_item)]
    elif images:
        selected = [
            max(
                images.items(),
                key=lambda x: (
                    x[1].get("is_final", False),
                    x[1].get("blob_size", 0),
                ),
            )
        ]
    else:
        selected = []
```

改动逻辑：

1. 如果 target **有** `is_final=True`，优先使用 target（和旧行为一致）
2. 如果 target **没有** final，回退到按质量排序选择——优先 `is_final=True`，其次 `blob_size` 最大
3. 这样即使 target 的 final 没到，也能拿到其他图片的真正 final

---