### PR TITLE
fix(): 解决 Docker Compose 下 SERVER_PORT 变量实际不生效的问题，并同步更新了文档说明

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ EXPOSE 8000
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn main:app --host ${SERVER_HOST:-0.0.0.0} --port ${SERVER_PORT:-8000} --workers ${SERVER_WORKERS:-1}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
     container_name: grok2api
     image: ghcr.io/chenyme/grok2api:latest
     ports:
-      - "8000:8000"
+      - "${HOST_PORT:-8000}:${SERVER_PORT:-8000}"
     environment:
       TZ: Asia/Shanghai
-      LOG_LEVEL: INFO
-      SERVER_PORT: 8000
-      SERVER_WORKERS: 1
-      SERVER_STORAGE_TYPE: local
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      SERVER_HOST: ${SERVER_HOST:-0.0.0.0}
+      SERVER_PORT: ${SERVER_PORT:-8000}
+      SERVER_WORKERS: ${SERVER_WORKERS:-1}
+      SERVER_STORAGE_TYPE: ${SERVER_STORAGE_TYPE:-local}
       # 启用 CF 自动刷新: 取消以下三行注释，并取消底部 flaresolverr 服务的注释
       # FLARESOLVERR_URL: http://flaresolverr:8191
       # CF_REFRESH_INTERVAL: "600"
@@ -20,6 +21,12 @@ services:
       #   Redis: redis://localhost:6379/0 or redis://:password@localhost:6379/0
       #   MySQL: mysql+aiomysql://user:pass@localhost/db
       #   PgSQL: postgresql+asyncpg://user:pass@localhost/db
+    command:
+      - sh
+      - -c
+      - >
+        uvicorn main:app --host "$${SERVER_HOST:-0.0.0.0}"
+        --port "$${SERVER_PORT:-8000}" --workers "$${SERVER_WORKERS:-1}"
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -32,6 +32,15 @@ cd grok2api
 docker compose up -d
 ```
 
+> Docker Compose port variables:
+>
+> - `SERVER_PORT`: app listening port inside the container
+> - `HOST_PORT`: host-side published port (Docker Compose only)
+>
+> Tip: mapping follows `HOST_PORT:SERVER_PORT` - users connect to `HOST_PORT`, while the app listens on `SERVER_PORT` inside the container.
+>
+> Example: `HOST_PORT=9000 SERVER_PORT=8011 docker compose up -d`, then access `http://localhost:9000`.
+
 ### Vercel
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,DATA_DIR,SERVER_STORAGE_TYPE,SERVER_STORAGE_URL&envDefaults=%7B%22DATA_DIR%22%3A%22/tmp/data%22%2C%22LOG_FILE_ENABLED%22%3A%22false%22%2C%22LOG_LEVEL%22%3A%22INFO%22%2C%22SERVER_STORAGE_TYPE%22%3A%22local%22%2C%22SERVER_STORAGE_URL%22%3A%22%22%7D)
@@ -52,7 +61,7 @@ docker compose up -d
 
 ## Admin Panel
 
-- Access: `http://<host>:8000/admin`
+- Access: `http://<host>:<port>/admin` (use `SERVER_PORT` for local run and `HOST_PORT` for Docker Compose; both default to `8000`)
 - Default password: `grok2api` (config `app.app_key`, recommended to change)
 
 **Features**:
@@ -77,6 +86,7 @@ docker compose up -d
 | `DATA_DIR` | Data dir (config/tokens/locks) | `./data` | `/data` |
 | `SERVER_HOST` | Bind address | `0.0.0.0` | `0.0.0.0` |
 | `SERVER_PORT` | Server port | `8000` | `8000` |
+| `HOST_PORT` | Host published port for Docker Compose | `8000` | `9000` |
 | `SERVER_WORKERS` | Uvicorn worker count | `1` | `2` |
 | `SERVER_STORAGE_TYPE` | Storage type (`local`/`redis`/`mysql`/`pgsql`) | `local` | `pgsql` |
 | `SERVER_STORAGE_URL` | Storage DSN (optional for local) | `""` | `postgresql+asyncpg://user:password@host:5432/db` |
@@ -116,6 +126,8 @@ docker compose up -d
 <br>
 
 ## API
+
+> The examples below use `localhost:8000` by default; if you set `HOST_PORT` in Docker Compose, replace the port accordingly.
 
 ### `POST /v1/chat/completions`
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,15 @@ cd grok2api
 docker compose up -d
 ```
 
+> Docker Compose 端口变量：
+>
+> - `SERVER_PORT`：容器内应用监听端口
+> - `HOST_PORT`：宿主机映射端口（仅 Docker Compose 使用）
+>
+> 小贴士：端口映射规则是 `HOST_PORT:SERVER_PORT`，你访问的是 `HOST_PORT`，容器内服务实际监听的是 `SERVER_PORT`。
+>
+> 示例：`HOST_PORT=9000 SERVER_PORT=8011 docker compose up -d`，访问 `http://localhost:9000`。
+
 ### Vercel 部署
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,DATA_DIR,SERVER_STORAGE_TYPE,SERVER_STORAGE_URL&envDefaults=%7B%22DATA_DIR%22%3A%22/tmp/data%22%2C%22LOG_FILE_ENABLED%22%3A%22false%22%2C%22LOG_LEVEL%22%3A%22INFO%22%2C%22SERVER_STORAGE_TYPE%22%3A%22local%22%2C%22SERVER_STORAGE_URL%22%3A%22%22%7D)
@@ -52,7 +61,7 @@ docker compose up -d
 
 ## 管理面板
 
-- 访问地址：`http://<host>:8000/admin`
+- 访问地址：`http://<host>:<port>/admin`（本地运行使用 `SERVER_PORT`，Docker Compose 使用 `HOST_PORT`，默认均为 `8000`）
 - 默认密码：`grok2api`（配置项 `app.app_key`，建议修改）
 
 **功能说明**：
@@ -77,6 +86,7 @@ docker compose up -d
 | `DATA_DIR` | 数据目录（配置/Token/锁） | `./data` | `/data` |
 | `SERVER_HOST` | 服务监听地址 | `0.0.0.0` | `0.0.0.0` |
 | `SERVER_PORT` | 服务端口 | `8000` | `8000` |
+| `HOST_PORT` | Docker Compose 宿主机映射端口 | `8000` | `9000` |
 | `SERVER_WORKERS` | Uvicorn worker 数量 | `1` | `2` |
 | `SERVER_STORAGE_TYPE` | 存储类型（`local`/`redis`/`mysql`/`pgsql`） | `local` | `pgsql` |
 | `SERVER_STORAGE_URL` | 存储连接串（local 时可为空） | `""` | `postgresql+asyncpg://user:password@host:5432/db` |
@@ -116,6 +126,8 @@ docker compose up -d
 <br>
 
 ## 接口说明
+
+> 以下示例默认使用 `localhost:8000`；若 Docker Compose 设置了 `HOST_PORT`，请替换为对应端口。
 
 ### `POST /v1/chat/completions`
 


### PR DESCRIPTION
Hi @chenyme，

  我提交了一个修复 PR，主要解决 Docker Compose 下 SERVER_PORT 变量实际不生效的问题，并同步更新了文档说明。

  本次改动包括：

  1. 修复端口变量生效问题

  - docker-compose.yml 中不再固定 8000:8000。
  - 改为 HOST_PORT:SERVER_PORT 映射，支持主机端口与容器内监听端口解耦。
  - Compose 启动命令显式使用 SERVER_HOST / SERVER_PORT / SERVER_WORKERS。

  2. 保持默认行为兼容

  - 默认仍是 8000，不影响现有默认部署。
  - 新增后可用示例：HOST_PORT=9000 SERVER_PORT=8011 docker compose up -d。

  3. 镜像默认启动也支持环境变量

  - Dockerfile 默认 CMD 改为读取 SERVER_HOST / SERVER_PORT / SERVER_WORKERS。

  4. README（中英文）同步更新

  - 补充 HOST_PORT 与 SERVER_PORT 区别说明。
  - 更新部署段落的端口 tips。
  - 修正文档中的访问地址描述，避免端口含义歧义。

  验证结果：

  - docker compose config 默认与自定义端口场景均通过。
  - 自定义场景下验证到 published=HOST_PORT、target=SERVER_PORT，行为符合预期。

  Commit：f6f049f
  提交信息：fix(): decouple compose host/app ports and update README guidance

  Thanks.