### PR TITLE
fix: Add configuration import in get_tokens endpoint

### DIFF
--- a/app/api/v1/admin/token.py
+++ b/app/api/v1/admin/token.py
@@ -46,6 +46,8 @@ def _sanitize_token_text(value) -> str:
 @router.get("/tokens", dependencies=[Depends(verify_app_key)])
 async def get_tokens():
     """获取所有 Token"""
+    # 获取消耗模式配置
+    from app.core.config import get_config
     mgr = await get_token_manager()
     results = {}
     for pool_name, pool in mgr.pools.items():


### PR DESCRIPTION

## Summary

Import configuration for consumption mode in get_tokens.

## Changes

- [ ] 功能新增
- [x] Bug 修复
- [ ] 重构/清理
- [ ] 文档更新
- [ ] 其他（请说明）

## Related Issues
Closes #345
<!-- 关联 Issue，例如：Closes #123 -->

## Verification

<!-- 请填写你做过的验证，至少一种。 -->

- [ ] 本地运行验证
- [ ] 单元/集成测试
- [x] Docker 构建通过
- [ ] 未验证（请说明原因）

验证说明：

```text
例如：
- uv run main.py / uv run granian ... 启动正常
- 调用 /v1/chat/completions 返回符合预期
```

## Breaking Changes

- [x] 无
- [ ] 有（请说明迁移方式）
