### PR TITLE
fix: Missing get_config import

### DIFF
--- a/app/api/v1/admin/token.py
+++ b/app/api/v1/admin/token.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 
 from app.core.auth import get_app_key, verify_app_key
 from app.core.batch import create_task, expire_task, get_task
+from app.core.config import get_config
 from app.core.logger import logger
 from app.core.storage import get_storage
 from app.services.grok.batch_services.usage import UsageService


### PR DESCRIPTION
Missing get_config import

## Summary

修复了get_config没有导入导致500报错

## Changes

- [ ] 功能新增
- [x] Bug 修复
- [ ] 重构/清理
- [ ] 文档更新
- [ ] 其他（请说明）

## Related Issues

https://github.com/chenyme/grok2api/issues/348

## Verification

<!-- 请填写你做过的验证，至少一种。 -->

- [x] 本地运行验证
- [ ] 单元/集成测试
- [ ] Docker 构建通过
- [ ] 未验证（请说明原因）

验证说明：

```text
例如：
- uv run main.py / uv run granian ... 启动正常
- 调用 /v1/chat/completions 返回符合预期
```

## Breaking Changes

- [x] 无
- [ ] 有（请说明迁移方式）
