### PR TITLE
Fix admin token config import and preserve HTTP 400 in refresh endpoint

### DIFF
--- a/app/api/v1/admin/token.py
+++ b/app/api/v1/admin/token.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 
 from app.core.auth import get_app_key, verify_app_key
 from app.core.batch import create_task, expire_task, get_task
+from app.core.config import get_config
 from app.core.logger import logger
 from app.core.storage import get_storage
 from app.services.grok.batch_services.usage import UsageService
@@ -161,6 +162,8 @@ async def refresh_tokens(data: dict):
 
         response = {"status": "success", "results": results}
         return response
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -225,10 +228,8 @@ async def refresh_tokens_async(data: dict):
         except Exception as e:
             task.fail_task(str(e))
         finally:
-            import asyncio
             asyncio.create_task(expire_task(task.id, 300))
 
-    import asyncio
     asyncio.create_task(_run())
 
     return {
@@ -419,10 +420,8 @@ async def enable_nsfw_async(data: dict):
         except Exception as e:
             task.fail_task(str(e))
         finally:
-            import asyncio
             asyncio.create_task(expire_task(task.id, 300))
 
-    import asyncio
     asyncio.create_task(_run())
 
     return {


### PR DESCRIPTION
## Summary

  Fix two issues in the admin token API.

  `GET /tokens` was using `get_config` without importing it, which could cause a runtime error when returning
  `consumed_mode_enabled`.

  `POST /tokens/refresh` was also catching `HTTPException` in the generic exception block, causing expected `400` errors
  such as `No tokens provided` to be returned as `500`.

  ## Changes

  - [ ] Feature
  - [x] Bug fix
  - [x] Refactor / cleanup
  - [ ] Documentation
  - [ ] Other (please specify)

  ## Related Issues

  N/A

  ## Verification

  - [x] Local runtime verification
  - [ ] Unit / integration tests
  - [ ] Docker build
  - [ ] Not verified (reason below)

  Verification notes:


  - Ran `ruff check app/api/v1/admin/token.py`
  - Ran `python -m py_compile app/api/v1/admin/token.py`
  - Verified with Python 3.13 via `uv run --python 3.13`
  - Confirmed `refresh_tokens({})` returns `400 No tokens provided`
  - Confirmed `get_tokens()` returns `consumed_mode_enabled` correctly

  ## Breaking Changes

  - [x] None
  - [ ] Yes (migration required)