### PR TITLE
fix: improve reverse transport resilience and restore model/media compatibility

### DIFF
--- a/app/api/v1/admin/config.py
+++ b/app/api/v1/admin/config.py
@@ -66,6 +66,20 @@ def _sanitize_proxy_config_payload(data: dict) -> dict:
             sanitized_proxy["user_agent"] = val
             changed = True
 
+    if "raw_cookie" in sanitized_proxy:
+        raw = sanitized_proxy.get("raw_cookie")
+        val = _sanitize_proxy_text(raw, remove_all_spaces=False)
+        if val != raw:
+            sanitized_proxy["raw_cookie"] = val
+            changed = True
+
+    if "sso_rw" in sanitized_proxy:
+        raw = sanitized_proxy.get("sso_rw")
+        val = _sanitize_proxy_text(raw, remove_all_spaces=True)
+        if val != raw:
+            sanitized_proxy["sso_rw"] = val
+            changed = True
+
     if "cf_cookies" in sanitized_proxy:
         raw = sanitized_proxy.get("cf_cookies")
         val = _sanitize_proxy_text(raw, remove_all_spaces=False)

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -825,6 +825,7 @@ async def chat_completions(request: ChatCompletionRequest):
             stream=bool(is_stream),
             enable_nsfw=image_conf.nsfw,
             chat_format=True,
+            prefer_ws=(request.model == IMAGINE_FAST_MODEL_ID),
         )
 
         if result.stream:

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -187,7 +187,7 @@ def _image_field(response_format: str) -> str:
     return "b64_json"
 
 
-def _imagine_fast_server_image_config() -> ImageConfig:
+def _imagine_fast_server_image_config(client_config: Optional[ImageConfig] = None) -> ImageConfig:
     """Load server-side image generation parameters for grok-imagine-1.0-fast."""
     n = int(get_config("imagine_fast.n", 1) or 1)
     size = str(get_config("imagine_fast.size", "1024x1024") or "1024x1024")
@@ -195,7 +195,11 @@ def _imagine_fast_server_image_config() -> ImageConfig:
         get_config("imagine_fast.response_format", get_config("app.image_format") or "url")
         or "url"
     )
-    nsfw = get_config("imagine_fast.nsfw", get_config("image.nsfw"))
+    nsfw = (
+        client_config.nsfw
+        if client_config and client_config.nsfw is not None
+        else get_config("imagine_fast.nsfw", get_config("image.nsfw"))
+    )
     return ImageConfig(n=n, size=size, response_format=response_format, nsfw=bool(nsfw))
 
 
@@ -603,7 +607,7 @@ def validate_request(request: ChatCompletionRequest):
                 param="messages",
                 code="empty_prompt",
             )
-        image_conf = _imagine_fast_server_image_config() if request.model == IMAGINE_FAST_MODEL_ID else (request.image_config or ImageConfig())
+        image_conf = _imagine_fast_server_image_config(request.image_config) if request.model == IMAGINE_FAST_MODEL_ID else (request.image_config or ImageConfig())
         n = image_conf.n or 1
         if not (1 <= n <= 10):
             raise ValidationException(
@@ -777,7 +781,7 @@ async def chat_completions(request: ChatCompletionRequest):
         is_stream = (
             request.stream if request.stream is not None else get_config("app.stream")
         )
-        image_conf = _imagine_fast_server_image_config() if request.model == IMAGINE_FAST_MODEL_ID else (request.image_config or ImageConfig())
+        image_conf = _imagine_fast_server_image_config(request.image_config) if request.model == IMAGINE_FAST_MODEL_ID else (request.image_config or ImageConfig())
         _validate_image_config(image_conf, stream=bool(is_stream))
         response_format = _resolve_image_format(image_conf.response_format)
         response_field = _image_field(response_format)

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -49,6 +49,7 @@ class ImageConfig(BaseModel):
     n: Optional[int] = Field(1, ge=1, le=10, description="生成数量 (1-10)")
     size: Optional[str] = Field("1024x1024", description="图片尺寸")
     response_format: Optional[str] = Field(None, description="响应格式")
+    nsfw: Optional[bool] = Field(None, description="是否显式开启 NSFW")
 
 
 class ChatCompletionRequest(BaseModel):
@@ -194,7 +195,8 @@ def _imagine_fast_server_image_config() -> ImageConfig:
         get_config("imagine_fast.response_format", get_config("app.image_format") or "url")
         or "url"
     )
-    return ImageConfig(n=n, size=size, response_format=response_format)
+    nsfw = get_config("imagine_fast.nsfw", get_config("image.nsfw"))
+    return ImageConfig(n=n, size=size, response_format=response_format, nsfw=bool(nsfw))
 
 
 async def _safe_sse_stream(stream: AsyncIterable[str]) -> AsyncGenerator[str, None]:
@@ -817,6 +819,7 @@ async def chat_completions(request: ChatCompletionRequest):
             size=size,
             aspect_ratio=aspect_ratio,
             stream=bool(is_stream),
+            enable_nsfw=image_conf.nsfw,
             chat_format=True,
         )
 

--- a/app/api/v1/image.py
+++ b/app/api/v1/image.py
@@ -127,16 +127,9 @@ def _validate_common_request(
 
 def validate_generation_request(request: ImageGenerationRequest):
     """验证图片生成请求参数"""
-    if request.model != "grok-imagine-1.0":
-        raise ValidationException(
-            message="The model `grok-imagine-1.0` is required for image generation.",
-            param="model",
-            code="model_not_supported",
-        )
     # 验证模型 - 通过 is_image 检查
     model_info = ModelService.get(request.model)
     if not model_info or not model_info.is_image:
-        # 获取支持的图片模型列表
         image_models = [m.model_id for m in ModelService.MODELS if m.is_image]
         raise ValidationException(
             message=(

--- a/app/api/v1/image.py
+++ b/app/api/v1/image.py
@@ -53,6 +53,7 @@ class ImageGenerationRequest(BaseModel):
     response_format: Optional[str] = Field(None, description="响应格式")
     style: Optional[str] = Field(None, description="风格 (暂不支持)")
     stream: Optional[bool] = Field(False, description="是否流式输出")
+    nsfw: Optional[bool] = Field(None, description="是否显式开启 NSFW")
 
 
 class ImageEditRequest(BaseModel):
@@ -282,6 +283,7 @@ async def create_image(request: ImageGenerationRequest):
         size=request.size,
         aspect_ratio=aspect_ratio,
         stream=bool(request.stream),
+        enable_nsfw=request.nsfw,
     )
 
     if result.stream:

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -16,6 +16,7 @@ async def list_models():
     data = [
         {
             "id": m.model_id,
+            "name": m.display_name or m.model_id,
             "object": "model",
             "created": 0,
             "owned_by": "grok2api@chenyme",

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -52,6 +52,15 @@ def _normalize_api_keys(value: Optional[object]) -> list[str]:
         return keys
     return []
 
+
+def _compare_token(left: str, right: str) -> bool:
+    """Use byte comparison so non-ASCII tokens do not raise TypeError."""
+    return hmac.compare_digest(
+        left.encode("utf-8", errors="surrogatepass"),
+        right.encode("utf-8", errors="surrogatepass"),
+    )
+
+
 def get_app_key() -> str:
     """
     获取 App Key（后台管理密码）。
@@ -84,7 +93,7 @@ def _match_function_key(credentials: str, function_key: str) -> bool:
     if not normalized:
         return False
     # 常量时间比较，避免基于时序的探测
-    return hmac.compare_digest(credentials, normalized)
+    return _compare_token(credentials, normalized)
 
 
 async def verify_api_key(
@@ -109,7 +118,7 @@ async def verify_api_key(
 
     # 标准 api_key 验证
     for key in api_keys:
-        if hmac.compare_digest(auth.credentials, key):
+        if _compare_token(auth.credentials, key):
             return auth.credentials
 
     raise HTTPException(
@@ -143,7 +152,7 @@ async def verify_app_key(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if not hmac.compare_digest(auth.credentials, app_key):
+    if not _compare_token(auth.credentials, app_key):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication token",

--- a/app/core/ssl_certs.py
+++ b/app/core/ssl_certs.py
@@ -1,0 +1,230 @@
+"""
+TLS / CA bundle helpers.
+
+Features:
+- Always materialize a runtime CA bundle under an ASCII-only path to avoid
+  native library path issues on Windows with non-ASCII project paths.
+- Merge certifi roots with Windows system roots (ROOT/CA stores) when enabled.
+- Optionally append a custom proxy/root CA file via config `proxy.custom_ca_file`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import ssl
+import tempfile
+from pathlib import Path
+from threading import Lock
+from typing import Iterable
+
+import certifi
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+
+try:
+    from cryptography.hazmat.primitives.serialization.pkcs7 import (
+        load_der_pkcs7_certificates,
+    )
+except Exception:  # pragma: no cover - depends on cryptography backend support
+    load_der_pkcs7_certificates = None
+
+from app.core.config import get_config
+from app.core.logger import logger
+
+_BUNDLE_LOCK = Lock()
+_BUNDLE_SIGNATURE: tuple | None = None
+_BUNDLE_PATH: str = ""
+_PEM_PATTERN = re.compile(
+    rb"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", re.DOTALL
+)
+
+
+def _runtime_cert_dir() -> Path:
+    base = Path(os.getenv("LOCALAPPDATA") or tempfile.gettempdir()) / "grok2api" / "certs"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _sha256_fingerprint(cert: x509.Certificate) -> str:
+    return cert.fingerprint(hashes.SHA256()).hex()
+
+
+def _parse_pem_certificates(raw: bytes) -> list[x509.Certificate]:
+    certs: list[x509.Certificate] = []
+    for block in _PEM_PATTERN.findall(raw):
+        try:
+            certs.append(x509.load_pem_x509_certificate(block))
+        except Exception as exc:
+            logger.debug("Skip invalid PEM certificate block: {}", exc)
+    return certs
+
+
+def _parse_der_or_pkcs7_certificates(raw: bytes) -> list[x509.Certificate]:
+    try:
+        return [x509.load_der_x509_certificate(raw)]
+    except Exception:
+        pass
+
+    if load_der_pkcs7_certificates is not None:
+        try:
+            return list(load_der_pkcs7_certificates(raw))
+        except Exception:
+            pass
+
+    return []
+
+
+def _load_certificates_from_file(path: str | Path) -> list[x509.Certificate]:
+    try:
+        file_path = Path(path).expanduser()
+        if not file_path.exists():
+            logger.warning("CA file not found: {}", file_path)
+            return []
+        raw = file_path.read_bytes()
+    except Exception as exc:
+        logger.warning("Failed to read CA file {}: {}", path, exc)
+        return []
+
+    if b"-----BEGIN CERTIFICATE-----" in raw:
+        return _parse_pem_certificates(raw)
+    return _parse_der_or_pkcs7_certificates(raw)
+
+
+def _load_windows_store_certificates(store_name: str) -> list[x509.Certificate]:
+    if os.name != "nt" or not hasattr(ssl, "enum_certificates"):
+        return []
+
+    certs: list[x509.Certificate] = []
+    try:
+        entries = ssl.enum_certificates(store_name)
+    except Exception as exc:
+        logger.warning("Failed to enumerate Windows certificate store {}: {}", store_name, exc)
+        return certs
+
+    for cert_bytes, encoding_type, _trust in entries:
+        try:
+            if encoding_type == "x509_asn":
+                certs.append(x509.load_der_x509_certificate(cert_bytes))
+            elif encoding_type == "pkcs_7_asn" and load_der_pkcs7_certificates is not None:
+                certs.extend(load_der_pkcs7_certificates(cert_bytes))
+        except Exception as exc:
+            logger.debug(
+                "Skip invalid certificate from Windows store {} ({}): {}",
+                store_name,
+                encoding_type,
+                exc,
+            )
+    return certs
+
+
+def _append_unique_certificates(
+    certificates: Iterable[x509.Certificate],
+    blocks: list[bytes],
+    seen: set[str],
+) -> int:
+    added = 0
+    for cert in certificates:
+        try:
+            fingerprint = _sha256_fingerprint(cert)
+            if fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            blocks.append(cert.public_bytes(serialization.Encoding.PEM))
+            added += 1
+        except Exception as exc:
+            logger.debug("Skip certificate while building CA bundle: {}", exc)
+    return added
+
+
+def _resolve_custom_ca_path() -> str:
+    env_value = (
+        os.getenv("GROK2API_CUSTOM_CA_FILE")
+        or os.getenv("CUSTOM_CA_FILE")
+        or ""
+    )
+    value = env_value.strip()
+    if not value:
+        value = str(get_config("proxy.custom_ca_file", "") or "").strip()
+    return value
+
+
+def _use_system_ca() -> bool:
+    raw = os.getenv("GROK2API_USE_SYSTEM_CA") or os.getenv("USE_SYSTEM_CA")
+    if raw is not None:
+        return raw.strip().lower() in {"1", "true", "yes", "on", "y"}
+    default = os.name == "nt"
+    return bool(get_config("proxy.use_system_ca", default))
+
+
+def get_combined_ca_bundle_path() -> str:
+    """Return a generated CA bundle path under an ASCII-only runtime directory."""
+    global _BUNDLE_SIGNATURE, _BUNDLE_PATH
+
+    custom_ca_path = _resolve_custom_ca_path()
+    custom_ca_mtime = None
+    if custom_ca_path:
+        try:
+            custom_ca_mtime = Path(custom_ca_path).expanduser().stat().st_mtime_ns
+        except OSError:
+            custom_ca_mtime = None
+
+    signature = (
+        certifi.where(),
+        _use_system_ca(),
+        custom_ca_path,
+        custom_ca_mtime,
+        os.name,
+    )
+
+    with _BUNDLE_LOCK:
+        if _BUNDLE_SIGNATURE == signature and _BUNDLE_PATH and Path(_BUNDLE_PATH).exists():
+            return _BUNDLE_PATH
+
+        blocks: list[bytes] = []
+        seen: set[str] = set()
+
+        certifi_certs = _load_certificates_from_file(certifi.where())
+        certifi_count = _append_unique_certificates(certifi_certs, blocks, seen)
+
+        system_count = 0
+        if _use_system_ca():
+            for store_name in ("ROOT", "CA"):
+                system_count += _append_unique_certificates(
+                    _load_windows_store_certificates(store_name), blocks, seen
+                )
+
+        custom_count = 0
+        if custom_ca_path:
+            custom_count = _append_unique_certificates(
+                _load_certificates_from_file(custom_ca_path), blocks, seen
+            )
+            if custom_count == 0:
+                logger.warning("No usable certificates loaded from proxy.custom_ca_file={}", custom_ca_path)
+
+        output_path = _runtime_cert_dir() / "combined-ca.pem"
+        temp_path = output_path.with_suffix(".tmp")
+        temp_path.write_bytes(b"".join(blocks))
+        os.replace(temp_path, output_path)
+
+        _BUNDLE_SIGNATURE = signature
+        _BUNDLE_PATH = str(output_path)
+
+        logger.info(
+            "Prepared CA bundle: path={}, certifi={}, system={}, custom={}, total={}",
+            _BUNDLE_PATH,
+            certifi_count,
+            system_count,
+            custom_count,
+            len(seen),
+        )
+        return _BUNDLE_PATH
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """Create SSL context backed by the generated combined CA bundle."""
+    cafile = get_combined_ca_bundle_path()
+    return ssl.create_default_context(cafile=cafile)
+
+
+__all__ = ["get_combined_ca_bundle_path", "create_ssl_context"]

--- a/app/services/grok/services/image.py
+++ b/app/services/grok/services/image.py
@@ -68,6 +68,7 @@ class ImageGenerationService:
         stream: bool,
         enable_nsfw: Optional[bool] = None,
         chat_format: bool = False,
+        prefer_ws: bool = False,
     ) -> ImageGenerationResult:
         max_token_retries = int(get_config("retry.max_retry") or 3)
         tried_tokens: set[str] = set()
@@ -77,6 +78,32 @@ class ImageGenerationService:
         if enable_nsfw is None:
             enable_nsfw = bool(get_config("image.nsfw"))
         prefer_tags = {"nsfw"} if enable_nsfw else None
+
+        if prefer_ws:
+            if stream:
+                return await self._stream_ws(
+                    token_mgr=token_mgr,
+                    token=token,
+                    model_info=model_info,
+                    prompt=prompt,
+                    n=n,
+                    response_format=response_format,
+                    size=size,
+                    aspect_ratio=aspect_ratio,
+                    enable_nsfw=enable_nsfw,
+                    chat_format=chat_format,
+                )
+            return await self._collect_ws(
+                token_mgr=token_mgr,
+                token=token,
+                model_info=model_info,
+                tried_tokens=tried_tokens,
+                prompt=prompt,
+                n=n,
+                response_format=response_format,
+                aspect_ratio=aspect_ratio,
+                enable_nsfw=enable_nsfw,
+            )
 
         if stream:
 

--- a/app/services/grok/services/model.py
+++ b/app/services/grok/services/model.py
@@ -42,6 +42,9 @@ def _build_alias_model(alias_id: str, base: ModelInfo) -> ModelInfo:
     description = f"Alias of {base.model_id}"
     if base.description:
         description = f"{base.description} ({description})"
+    display_name = alias_id.upper()
+    if alias_id == "grok-imagine-1.0-edit-vision":
+        display_name = "Grok Image Edit Vision"
 
     return ModelInfo(
         model_id=alias_id,
@@ -49,7 +52,7 @@ def _build_alias_model(alias_id: str, base: ModelInfo) -> ModelInfo:
         model_mode=base.model_mode,
         tier=base.tier,
         cost=base.cost,
-        display_name=alias_id.upper(),
+        display_name=display_name,
         description=description,
         is_image=base.is_image,
         is_image_edit=base.is_image_edit,
@@ -246,6 +249,7 @@ class ModelService:
         "grok-code-fast-1": "grok-4.1-fast",
         "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta",
         "grok-4-20-beta-latest-non-reasoning": "grok-4.20-beta",
+        "grok-imagine-1.0-edit-vision": "grok-imagine-1.0-edit",
     }
 
     _base_map = {m.model_id: m for m in MODELS}

--- a/app/services/grok/services/model.py
+++ b/app/services/grok/services/model.py
@@ -38,6 +38,25 @@ class ModelInfo(BaseModel):
     is_video: bool = False
 
 
+def _build_alias_model(alias_id: str, base: ModelInfo) -> ModelInfo:
+    description = f"Alias of {base.model_id}"
+    if base.description:
+        description = f"{base.description} ({description})"
+
+    return ModelInfo(
+        model_id=alias_id,
+        grok_model=base.grok_model,
+        model_mode=base.model_mode,
+        tier=base.tier,
+        cost=base.cost,
+        display_name=alias_id.upper(),
+        description=description,
+        is_image=base.is_image,
+        is_image_edit=base.is_image_edit,
+        is_video=base.is_video,
+    )
+
+
 class ModelService:
     """模型管理服务"""
 
@@ -100,7 +119,7 @@ class ModelService:
         ModelInfo(
             model_id="grok-4-heavy",
             grok_model="grok-4",
-            model_mode="MODEL_MODE_HEAVY",
+            model_mode="MODEL_MODE_EXPERT",
             tier=Tier.SUPER,
             cost=Cost.HIGH,
             display_name="GROK-4-HEAVY",
@@ -111,7 +130,7 @@ class ModelService:
         ModelInfo(
             model_id="grok-4.1-mini",
             grok_model="grok-4-1-thinking-1129",
-            model_mode="MODEL_MODE_GROK_4_1_MINI_THINKING",
+            model_mode="MODEL_MODE_FAST",
             tier=Tier.BASIC,
             cost=Cost.LOW,
             display_name="GROK-4.1-MINI",
@@ -144,7 +163,7 @@ class ModelService:
         ModelInfo(
             model_id="grok-4.1-thinking",
             grok_model="grok-4-1-thinking-1129",
-            model_mode="MODEL_MODE_GROK_4_1_THINKING",
+            model_mode="MODEL_MODE_EXPERT",
             tier=Tier.BASIC,
             cost=Cost.HIGH,
             display_name="GROK-4.1-THINKING",
@@ -155,7 +174,7 @@ class ModelService:
         ModelInfo(
             model_id="grok-4.20-beta",
             grok_model="grok-420",
-            model_mode="MODEL_MODE_GROK_420",
+            model_mode="MODEL_MODE_FAST",
             tier=Tier.BASIC,
             cost=Cost.LOW,
             display_name="GROK-4.20-BETA",
@@ -213,7 +232,26 @@ class ModelService:
         ),
     ]
 
-    _map = {m.model_id: m for m in MODELS}
+    ALIASES = {
+        "grok-4-1-mini": "grok-4.1-mini",
+        "grok-4-1-fast": "grok-4.1-fast",
+        "grok-4-1-expert": "grok-4.1-expert",
+        "grok-4-1-thinking": "grok-4.1-thinking",
+        "grok-4-20-beta": "grok-4.20-beta",
+        "grok-4-fast": "grok-4.1-fast",
+        "grok-4-fast-reasoning": "grok-4.1-fast",
+        "grok-4-fast-non-reasoning": "grok-4.1-fast",
+        "grok-4-1-fast-reasoning": "grok-4.1-fast",
+        "grok-4-1-fast-non-reasoning": "grok-4.1-fast",
+        "grok-code-fast-1": "grok-4.1-fast",
+        "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta",
+        "grok-4-20-beta-latest-non-reasoning": "grok-4.20-beta",
+    }
+
+    _base_map = {m.model_id: m for m in MODELS}
+    _map = dict(_base_map)
+    for alias_id, canonical_id in ALIASES.items():
+        _map[alias_id] = _build_alias_model(alias_id, _base_map[canonical_id])
 
     @classmethod
     def get(cls, model_id: str) -> Optional[ModelInfo]:

--- a/app/services/grok/utils/process.py
+++ b/app/services/grok/utils/process.py
@@ -3,6 +3,7 @@
 """
 
 import asyncio
+import json
 import time
 from typing import Any, AsyncGenerator, Optional, AsyncIterable, List, TypeVar
 
@@ -50,6 +51,29 @@ def _collect_images(obj: Any) -> List[str]:
         seen.add(url)
         urls.append(url)
 
+    def collect_card_attachment(value: Any):
+        if not isinstance(value, dict):
+            return
+        image_chunk = value.get("image_chunk") or {}
+        if isinstance(image_chunk, dict):
+            image_url = image_chunk.get("imageUrl")
+            if isinstance(image_url, str):
+                add(image_url)
+
+        image = value.get("image") or {}
+        if isinstance(image, dict):
+            original = image.get("original")
+            if isinstance(original, str):
+                add(original)
+
+    def parse_card_json(raw: Any):
+        if not isinstance(raw, str) or not raw.strip():
+            return
+        try:
+            collect_card_attachment(json.loads(raw))
+        except Exception:
+            return
+
     def walk(value: Any):
         if isinstance(value, dict):
             for key, item in value.items():
@@ -60,6 +84,16 @@ def _collect_images(obj: Any) -> List[str]:
                                 add(url)
                     elif isinstance(item, str):
                         add(item)
+                    continue
+                if key == "cardAttachmentsJson" and isinstance(item, list):
+                    for raw in item:
+                        parse_card_json(raw)
+                    continue
+                if key == "cardAttachment" and isinstance(item, dict):
+                    parse_card_json(item.get("jsonData"))
+                    continue
+                if key in {"imageUrl", "original"} and isinstance(item, str):
+                    add(item)
                     continue
                 walk(item)
         elif isinstance(value, list):

--- a/app/services/reverse/accept_tos.py
+++ b/app/services/reverse/accept_tos.py
@@ -2,6 +2,7 @@
 Reverse interface: accept ToS (gRPC-Web).
 """
 
+from typing import Any
 from curl_cffi.requests import AsyncSession
 
 from app.core.logger import logger
@@ -14,6 +15,7 @@ from app.core.proxy_pool import (
 )
 from app.core.exceptions import UpstreamException
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 from app.services.reverse.utils.grpc import GrpcClient, GrpcStatus
 
@@ -115,6 +117,44 @@ class AcceptTosReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AcceptTosReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    wrapped = await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=ACCEPT_TOS_API,
+                        headers=headers,
+                        timeout=float(get_config("nsfw.timeout") or 60),
+                        logger_prefix="AcceptTosReverse: Request failed",
+                        expected_statuses=(200,),
+                        response_kind="binary",
+                        data=payload,
+                    )
+                    _, trailers = GrpcClient.parse_response(
+                        wrapped.content,
+                        content_type=wrapped.headers.get("content-type"),
+                        headers=wrapped.headers,
+                    )
+                    grpc_status = GrpcClient.get_status(trailers)
+                    if grpc_status.code not in (-1, 0):
+                        raise UpstreamException(
+                            message=f"AcceptTosReverse: gRPC failed, {grpc_status.code}",
+                            details={
+                                "status": grpc_status.http_equiv,
+                                "grpc_status": grpc_status.code,
+                                "grpc_message": grpc_status.message,
+                            },
+                        )
+                    return grpc_status
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"AcceptTosReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"AcceptTosReverse: Request failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/app_chat.py
+++ b/app/services/reverse/app_chat.py
@@ -4,16 +4,19 @@ Reverse interface: app chat conversations.
 
 import inspect
 import orjson
+import aiohttp
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 from curl_cffi.requests import AsyncSession
 
 from app.core.logger import logger
 from app.core.config import get_config
+from app.core.ssl_certs import create_ssl_context
 from app.core.proxy_pool import get_current_proxy_from, rotate_proxy, should_rotate_proxy
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.auth_probe import classify_probe, probe_rate_limits_status
 from app.services.reverse.utils.retry import extract_status_for_retry, retry_on_status
 
 CHAT_API = "https://grok.com/rest/app-chat/conversations/new"
@@ -171,6 +174,63 @@ class AppChatReverse:
         return payload
 
     @staticmethod
+    async def _aiohttp_fallback_request(
+        headers: Dict[str, str],
+        payload: Dict[str, Any],
+        timeout: float,
+    ):
+        """Fallback to aiohttp when curl-cffi is reset by the remote edge."""
+        client_timeout = aiohttp.ClientTimeout(total=timeout or 30)
+        session = aiohttp.ClientSession(timeout=client_timeout, trust_env=True)
+        try:
+            response = await session.post(
+                CHAT_API,
+                headers=headers,
+                data=orjson.dumps(payload),
+                ssl=create_ssl_context(),
+            )
+
+            if response.status != 200:
+                content = await response.text()
+                content_type = str(response.headers.get("Content-Type", ""))
+                server_header = str(response.headers.get("Server", ""))
+                is_token_expired, is_cloudflare = classify_probe(
+                    response.status,
+                    content_type,
+                    server_header,
+                    content,
+                )
+                response.close()
+                await session.close()
+                raise UpstreamException(
+                    message=f"AppChatReverse: Chat failed, {response.status}",
+                    details={
+                        "status": response.status,
+                        "body": content,
+                        "is_token_expired": is_token_expired,
+                        "is_cloudflare": is_cloudflare,
+                    },
+                    status_code=response.status,
+                )
+
+            async def stream_response():
+                try:
+                    while True:
+                        line = await response.content.readline()
+                        if not line:
+                            break
+                        yield line.decode("utf-8", errors="ignore").rstrip("\r\n")
+                finally:
+                    response.close()
+                    await session.close()
+
+            return stream_response()
+        except Exception:
+            if not session.closed:
+                await session.close()
+            raise
+
+    @staticmethod
     async def request(
         session: AsyncSession,
         token: str,
@@ -285,10 +345,8 @@ class AppChatReverse:
                     content_type = str(response.headers.get("content-type", ""))
 
                     logger.error(
-                        "AppChatReverse: Chat failed, %s, content_type=%s, body=%s",
-                        response.status_code,
-                        content_type,
-                        content[:500],
+                        f"AppChatReverse: Chat failed, status={response.status_code}, "
+                        f"content_type={content_type}, body={content[:500]}",
                         extra={"error_type": "UpstreamException"},
                     )
                     raise UpstreamException(
@@ -342,6 +400,51 @@ class AppChatReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AppChatReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await AppChatReverse._aiohttp_fallback_request(
+                        headers=headers,
+                        payload=payload,
+                        timeout=timeout,
+                    )
+                except UpstreamException as fallback_error:
+                    if fallback_error.status_code == 401:
+                        try:
+                            await TokenService.record_fail(
+                                token, 401, "app_chat_auth_failed", threshold=1
+                            )
+                        except Exception:
+                            pass
+                    raise fallback_error
+                except Exception as fallback_exc:
+                    logger.warning(
+                        "AppChatReverse: aiohttp fallback failed, {}",
+                        fallback_exc,
+                    )
+
+            probe = await probe_rate_limits_status(token)
+            if probe is not None and probe.status == 401:
+                try:
+                    await TokenService.record_fail(
+                        token, 401, "app_chat_auth_failed", threshold=1
+                    )
+                except Exception:
+                    pass
+                raise UpstreamException(
+                    message="AppChatReverse: Chat failed, 401",
+                    details={
+                        "status": 401,
+                        "body": probe.body,
+                        "is_token_expired": probe.is_token_expired,
+                        "is_cloudflare": probe.is_cloudflare,
+                        "error": str(e),
+                    },
+                    status_code=401,
+                )
+
             logger.error(
                 f"AppChatReverse: Chat failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/app_chat.py
+++ b/app/services/reverse/app_chat.py
@@ -345,8 +345,10 @@ class AppChatReverse:
                     content_type = str(response.headers.get("content-type", ""))
 
                     logger.error(
-                        f"AppChatReverse: Chat failed, status={response.status_code}, "
-                        f"content_type={content_type}, body={content[:500]}",
+                        "AppChatReverse: Chat failed, status={}, content_type={}, body={}",
+                        response.status_code,
+                        content_type,
+                        content[:500],
                         extra={"error_type": "UpstreamException"},
                     )
                     raise UpstreamException(

--- a/app/services/reverse/assets_delete.py
+++ b/app/services/reverse/assets_delete.py
@@ -16,6 +16,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 DELETE_API = "https://grok.com/rest/assets-metadata"
@@ -99,6 +100,27 @@ class AssetsDeleteReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.asset_proxy_url") and not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AssetsDeleteReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="DELETE",
+                        url=f"{DELETE_API}/{asset_id}",
+                        headers=headers,
+                        timeout=float(get_config("asset.delete_timeout") or 60),
+                        logger_prefix="AssetsDeleteReverse: Delete failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"AssetsDeleteReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"AssetsDeleteReverse: Delete failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/assets_download.py
+++ b/app/services/reverse/assets_download.py
@@ -19,6 +19,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 DOWNLOAD_API = "https://assets.grok.com"
@@ -140,6 +141,28 @@ class AssetsDownloadReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.asset_proxy_url") and not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AssetsDownloadReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="GET",
+                        url=url,
+                        headers=headers,
+                        timeout=float(get_config("asset.download_timeout") or 60),
+                        logger_prefix="AssetsDownloadReverse: Download failed",
+                        expected_statuses=(200,),
+                        response_kind="binary",
+                        allow_redirects=True,
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"AssetsDownloadReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"AssetsDownloadReverse: Download failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/assets_list.py
+++ b/app/services/reverse/assets_list.py
@@ -16,6 +16,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 LIST_API = "https://grok.com/rest/assets"
@@ -100,6 +101,28 @@ class AssetsListReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.asset_proxy_url") and not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AssetsListReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="GET",
+                        url=LIST_API,
+                        headers=headers,
+                        timeout=float(get_config("asset.list_timeout") or 60),
+                        logger_prefix="AssetsListReverse: List failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        params=params,
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"AssetsListReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"AssetsListReverse: List failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/assets_upload.py
+++ b/app/services/reverse/assets_upload.py
@@ -2,7 +2,6 @@
 Reverse interface: upload asset.
 """
 
-from typing import Any
 from curl_cffi.requests import AsyncSession
 
 from app.core.logger import logger
@@ -16,6 +15,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 UPLOAD_API = "https://grok.com/rest/app-chat/upload-file"
@@ -25,7 +25,7 @@ class AssetsUploadReverse:
     """/rest/app-chat/upload-file reverse interface."""
 
     @staticmethod
-    async def request(session: AsyncSession, token: str, fileName: str, fileMimeType: str, content: str) -> Any:
+    async def request(session: AsyncSession, token: str, fileName: str, fileMimeType: str, content: str):
         """Upload asset to Grok.
 
         Args:
@@ -107,6 +107,28 @@ class AssetsUploadReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.asset_proxy_url") and not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "AssetsUploadReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=UPLOAD_API,
+                        headers=headers,
+                        timeout=float(get_config("asset.upload_timeout") or 60),
+                        logger_prefix="AssetsUploadReverse: Upload failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        json_payload=payload,
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"AssetsUploadReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"AssetsUploadReverse: Upload failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/media_post.py
+++ b/app/services/reverse/media_post.py
@@ -17,6 +17,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 MEDIA_POST_API = "https://grok.com/rest/media/post/create"
@@ -117,6 +118,28 @@ class MediaPostReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "MediaPostReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=MEDIA_POST_API,
+                        headers=headers,
+                        timeout=float(get_config("video.timeout") or 60),
+                        logger_prefix="MediaPostReverse: Media post create failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        data=orjson.dumps(payload),
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"MediaPostReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"MediaPostReverse: Media post create failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/media_post_link.py
+++ b/app/services/reverse/media_post_link.py
@@ -17,6 +17,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 MEDIA_POST_LINK_API = "https://grok.com/rest/media/post/create-link"
@@ -104,6 +105,28 @@ class MediaPostLinkReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "MediaPostLinkReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=MEDIA_POST_LINK_API,
+                        headers=headers,
+                        timeout=float(get_config("video.timeout") or 60),
+                        logger_prefix="MediaPostLinkReverse: Media post create link failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        data=orjson.dumps(payload),
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"MediaPostLinkReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"MediaPostLinkReverse: Media post create link failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/nsfw_mgmt.py
+++ b/app/services/reverse/nsfw_mgmt.py
@@ -2,6 +2,7 @@
 Reverse interface: NSFW feature controls (gRPC-Web).
 """
 
+from typing import Any
 from curl_cffi.requests import AsyncSession
 
 from app.core.logger import logger
@@ -14,6 +15,7 @@ from app.core.proxy_pool import (
 )
 from app.core.exceptions import UpstreamException
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 from app.services.reverse.utils.grpc import GrpcClient, GrpcStatus
 
@@ -123,6 +125,44 @@ class NsfwMgmtReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "NsfwMgmtReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    wrapped = await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=NSFW_MGMT_API,
+                        headers=headers,
+                        timeout=float(get_config("nsfw.timeout") or 60),
+                        logger_prefix="NsfwMgmtReverse: Request failed",
+                        expected_statuses=(200,),
+                        response_kind="binary",
+                        data=payload,
+                    )
+                    _, trailers = GrpcClient.parse_response(
+                        wrapped.content,
+                        content_type=wrapped.headers.get("content-type"),
+                        headers=wrapped.headers,
+                    )
+                    grpc_status = GrpcClient.get_status(trailers)
+                    if grpc_status.code not in (-1, 0):
+                        raise UpstreamException(
+                            message=f"NsfwMgmtReverse: gRPC failed, {grpc_status.code}",
+                            details={
+                                "status": grpc_status.http_equiv,
+                                "grpc_status": grpc_status.code,
+                                "grpc_message": grpc_status.message,
+                            },
+                        )
+                    return grpc_status
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"NsfwMgmtReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"NsfwMgmtReverse: Request failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/rate_limits.py
+++ b/app/services/reverse/rate_limits.py
@@ -16,6 +16,10 @@ from app.core.proxy_pool import (
 )
 from app.core.exceptions import UpstreamException
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.auth_probe import (
+    ProbeJSONResponse,
+    probe_rate_limits_status,
+)
 from app.services.reverse.utils.retry import retry_on_status
 
 RATE_LIMITS_API = "https://grok.com/rest/rate-limits"
@@ -137,6 +141,32 @@ class RateLimitsReverse:
             # Handle other non-upstream exceptions
             import traceback
             error_details = traceback.format_exc()
+            probe = await probe_rate_limits_status(token)
+            if probe is not None:
+                if probe.status == 200:
+                    logger.warning(
+                        "RateLimitsReverse: curl-cffi failed but aiohttp probe succeeded; using fallback response"
+                    )
+                    return ProbeJSONResponse(probe)
+
+                logger.warning(
+                    "RateLimitsReverse: curl-cffi failed; fallback probe returned status={}, token_expired={}, cloudflare={}",
+                    probe.status,
+                    probe.is_token_expired,
+                    probe.is_cloudflare,
+                )
+                raise UpstreamException(
+                    message=f"RateLimitsReverse: Request failed, {probe.status}",
+                    details={
+                        "status": probe.status,
+                        "body": probe.body,
+                        "is_token_expired": probe.is_token_expired,
+                        "is_cloudflare": probe.is_cloudflare,
+                        "error": str(e),
+                    },
+                    status_code=probe.status,
+                )
+
             logger.error(
                 f"RateLimitsReverse: Unexpected error, {type(e).__name__}: {str(e)}\n{error_details}"
             )

--- a/app/services/reverse/set_birth.py
+++ b/app/services/reverse/set_birth.py
@@ -17,6 +17,7 @@ from app.core.proxy_pool import (
 )
 from app.core.exceptions import UpstreamException
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 SET_BIRTH_API = "https://grok.com/rest/auth/set-birth-date"
@@ -108,6 +109,28 @@ class SetBirthReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "SetBirthReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=SET_BIRTH_API,
+                        headers=headers,
+                        timeout=float(get_config("nsfw.timeout") or 60),
+                        logger_prefix="SetBirthReverse: Request failed",
+                        expected_statuses=(200, 204),
+                        response_kind="json",
+                        json_payload=payload,
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"SetBirthReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"SetBirthReverse: Request failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/utils/auth_probe.py
+++ b/app/services/reverse/utils/auth_probe.py
@@ -1,0 +1,124 @@
+"""
+Lightweight fallback probes for auth diagnosis when curl-cffi resets the connection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+import orjson
+
+from app.core.config import get_config
+from app.core.logger import logger
+from app.core.ssl_certs import create_ssl_context
+from app.services.reverse.utils.headers import build_headers
+
+RATE_LIMITS_API = "https://grok.com/rest/rate-limits"
+RATE_LIMITS_PAYLOAD = {
+    "requestKind": "DEFAULT",
+    "modelName": "grok-4-1-thinking-1129",
+}
+
+
+@dataclass
+class ProbeResult:
+    status: int
+    body: str
+    content_type: str
+    server_header: str
+    is_token_expired: bool
+    is_cloudflare: bool
+
+
+class ProbeJSONResponse:
+    """Small response adapter used when the fallback probe succeeds."""
+
+    def __init__(self, result: ProbeResult):
+        self.status_code = result.status
+        self.headers = {
+            "content-type": result.content_type,
+            "server": result.server_header,
+        }
+        self.text = result.body
+        self._result = result
+
+    def json(self) -> Any:
+        return orjson.loads(self.text) if self.text else {}
+
+
+def classify_probe(status: int, content_type: str, server_header: str, body: str) -> tuple[bool, bool]:
+    content_type_lower = (content_type or "").lower()
+    server_lower = (server_header or "").lower()
+    body_lower = (body or "").lower()
+
+    is_cloudflare = "challenge-platform" in body_lower
+    if "cloudflare" in server_lower and "application/json" not in content_type_lower:
+        is_cloudflare = True
+
+    # A direct 401 from Grok's authenticated rate-limit endpoint is a strong signal
+    # that the SSO session is no longer valid, even if the body is empty.
+    is_token_expired = status == 401
+    if is_token_expired:
+        is_cloudflare = False
+    if not is_token_expired and status == 401 and "application/json" in content_type_lower:
+        auth_error_keywords = [
+            "unauthorized",
+            "not logged in",
+            "unauthenticated",
+            "bad-credentials",
+        ]
+        is_token_expired = any(keyword in body_lower for keyword in auth_error_keywords)
+
+    return is_token_expired, is_cloudflare
+
+
+async def probe_rate_limits_status(token: str) -> ProbeResult | None:
+    """Probe the rate-limits endpoint with aiohttp to recover a usable status/body."""
+    if get_config("proxy.base_proxy_url"):
+        return None
+
+    headers = build_headers(
+        cookie_token=token,
+        content_type="application/json",
+        origin="https://grok.com",
+        referer="https://grok.com/",
+    )
+
+    timeout = float(get_config("usage.timeout") or 20)
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
+
+    try:
+        async with aiohttp.ClientSession(timeout=client_timeout, trust_env=True) as session:
+            async with session.post(
+                RATE_LIMITS_API,
+                headers=headers,
+                data=orjson.dumps(RATE_LIMITS_PAYLOAD),
+                ssl=create_ssl_context(),
+            ) as response:
+                body = await response.text()
+                content_type = response.headers.get("Content-Type", "")
+                server_header = response.headers.get("Server", "")
+                is_token_expired, is_cloudflare = classify_probe(
+                    response.status, content_type, server_header, body
+                )
+                return ProbeResult(
+                    status=response.status,
+                    body=body,
+                    content_type=content_type,
+                    server_header=server_header,
+                    is_token_expired=is_token_expired,
+                    is_cloudflare=is_cloudflare,
+                )
+    except Exception as exc:
+        logger.debug("probe_rate_limits_status failed: {}", exc)
+        return None
+
+
+__all__ = [
+    "ProbeJSONResponse",
+    "ProbeResult",
+    "classify_probe",
+    "probe_rate_limits_status",
+]

--- a/app/services/reverse/utils/headers.py
+++ b/app/services/reverse/utils/headers.py
@@ -57,6 +57,18 @@ def _sanitize_header_value(
     return normalized
 
 
+def _strip_cookie_fields(cookie_header: str, field_names: tuple[str, ...]) -> str:
+    """Remove duplicate cookie fields so appended values stay deterministic."""
+    value = cookie_header
+    for field_name in field_names:
+        value = re.sub(
+            rf"(^|;\s*){re.escape(field_name)}=[^;]*",
+            "",
+            value,
+        )
+    return value.strip(" ;")
+
+
 def build_sso_cookie(sso_token: str) -> str:
     """
     Build SSO Cookie string.
@@ -67,19 +79,32 @@ def build_sso_cookie(sso_token: str) -> str:
     Returns:
         str: The SSO Cookie string.
     """
+    raw_cookie = _sanitize_header_value(
+        get_config("proxy.raw_cookie") or "",
+        field_name="proxy.raw_cookie",
+    )
+    if raw_cookie:
+        return raw_cookie
+
     # Format
     sso_token = sso_token[4:] if sso_token.startswith("sso=") else sso_token
     sso_token = _sanitize_header_value(
         sso_token, field_name="sso_token", remove_all_spaces=True
     )
+    sso_rw_token = _sanitize_header_value(
+        get_config("proxy.sso_rw") or sso_token,
+        field_name="proxy.sso_rw",
+        remove_all_spaces=True,
+    )
 
     # SSO Cookie
-    cookie = f"sso={sso_token}; sso-rw={sso_token}"
+    cookie = f"sso={sso_token}; sso-rw={sso_rw_token}"
 
     # CF Cookies
     cf_cookies = _sanitize_header_value(
         get_config("proxy.cf_cookies") or "", field_name="proxy.cf_cookies"
     )
+    cf_cookies = _strip_cookie_fields(cf_cookies, ("sso", "sso-rw", "cf_clearance"))
     cf_clearance = _sanitize_header_value(
         get_config("proxy.cf_clearance") or "",
         field_name="proxy.cf_clearance",

--- a/app/services/reverse/utils/http_fallback.py
+++ b/app/services/reverse/utils/http_fallback.py
@@ -1,0 +1,86 @@
+"""
+Shared aiohttp fallback helpers for reverse HTTP interfaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Optional
+
+import aiohttp
+import orjson
+
+from app.core.exceptions import UpstreamException
+from app.core.ssl_certs import create_ssl_context
+
+
+class AiohttpJSONResponse:
+    def __init__(self, body: str, headers: Mapping[str, str]):
+        self._body = body
+        self.headers = headers
+
+    def json(self):
+        return orjson.loads(self._body) if self._body else {}
+
+
+class AiohttpBinaryResponse:
+    def __init__(self, body: bytes, headers: Mapping[str, str]):
+        self.content = body
+        self.headers = headers
+
+    async def aiter_content(self, chunk_size: int = 65536):
+        for i in range(0, len(self.content), chunk_size):
+            yield self.content[i : i + chunk_size]
+
+
+async def request_with_aiohttp_fallback(
+    *,
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    timeout: float,
+    logger_prefix: str,
+    expected_statuses: Iterable[int],
+    response_kind: str,
+    params: Optional[Mapping[str, Any]] = None,
+    data: Any = None,
+    json_payload: Any = None,
+    allow_redirects: bool = False,
+):
+    client_timeout = aiohttp.ClientTimeout(total=float(timeout or 60))
+    async with aiohttp.ClientSession(timeout=client_timeout, trust_env=True) as session:
+        async with session.request(
+            method.upper(),
+            url,
+            headers=headers,
+            params=params,
+            data=data,
+            json=json_payload,
+            ssl=create_ssl_context(),
+            allow_redirects=allow_redirects,
+        ) as response:
+            if response_kind == "binary":
+                body = await response.read()
+                error_body = body.decode("utf-8", errors="ignore")
+            else:
+                body = await response.text()
+                error_body = body
+
+            if response.status not in set(expected_statuses):
+                raise UpstreamException(
+                    message=f"{logger_prefix}: Request failed, {response.status}",
+                    details={"status": response.status, "body": error_body},
+                    status_code=response.status,
+                )
+
+            if response_kind == "binary":
+                return AiohttpBinaryResponse(body=body, headers=response.headers)
+            if response_kind == "json":
+                return AiohttpJSONResponse(body=body, headers=response.headers)
+            raise ValueError(f"Unsupported response_kind: {response_kind}")
+
+
+__all__ = [
+    "AiohttpBinaryResponse",
+    "AiohttpJSONResponse",
+    "request_with_aiohttp_fallback",
+]

--- a/app/services/reverse/utils/session.py
+++ b/app/services/reverse/utils/session.py
@@ -10,6 +10,7 @@ from curl_cffi.const import CurlOpt
 
 from app.core.config import get_config
 from app.core.logger import logger
+from app.core.ssl_certs import get_combined_ca_bundle_path
 
 
 def _should_skip_proxy_ssl() -> bool:
@@ -47,11 +48,14 @@ class ResettableSession:
 
     def _create_session(self) -> AsyncSession:
         kwargs = dict(self._session_kwargs)
+        opts = dict(kwargs.get("curl_options", {}))
+        ca_bundle = get_combined_ca_bundle_path()
+        opts[CurlOpt.CAINFO] = ca_bundle
+        opts[CurlOpt.PROXY_CAINFO] = ca_bundle
         if self._skip_proxy_ssl:
-            opts = kwargs.get("curl_options", {})
             opts[CurlOpt.PROXY_SSL_VERIFYPEER] = 0
             opts[CurlOpt.PROXY_SSL_VERIFYHOST] = 0
-            kwargs["curl_options"] = opts
+        kwargs["curl_options"] = opts
         return AsyncSession(**kwargs)
 
     async def _maybe_reset(self) -> None:

--- a/app/services/reverse/utils/websocket.py
+++ b/app/services/reverse/utils/websocket.py
@@ -3,21 +3,22 @@ WebSocket helpers for reverse interfaces.
 """
 
 import ssl
-import certifi
 import aiohttp
+import orjson
+import websockets
 from aiohttp_socks import ProxyConnector
-from typing import Mapping, Optional, Any
+from dataclasses import dataclass
+from typing import Mapping, Optional, Any, Awaitable, Callable
 from urllib.parse import urlparse
 
 from app.core.logger import logger
 from app.core.config import get_config
 from app.core.proxy_pool import get_current_proxy_from, rotate_proxy
+from app.core.ssl_certs import create_ssl_context
 
 
 def _default_ssl_context() -> ssl.SSLContext:
-    context = ssl.create_default_context()
-    context.load_verify_locations(certifi.where())
-    return context
+    return create_ssl_context()
 
 
 def _normalize_socks_proxy(proxy_url: str) -> tuple[str, Optional[bool]]:
@@ -72,20 +73,59 @@ def resolve_proxy(proxy_url: Optional[str] = None, ssl_context: ssl.SSLContext =
 class WebSocketConnection:
     """WebSocket connection wrapper."""
 
-    def __init__(self, session: aiohttp.ClientSession, ws: aiohttp.ClientWebSocketResponse) -> None:
+    def __init__(self, session: Optional[aiohttp.ClientSession], ws: Any) -> None:
         self.session = session
         self.ws = ws
 
     async def close(self) -> None:
         if not self.ws.closed:
             await self.ws.close()
-        await self.session.close()
+        if self.session is not None:
+            await self.session.close()
 
     async def __aenter__(self) -> aiohttp.ClientWebSocketResponse:
         return self.ws
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         await self.close()
+
+
+@dataclass
+class _CompatWSMessage:
+    type: aiohttp.WSMsgType
+    data: Any
+
+
+class _WebsocketsAdapter:
+    """Adapter exposing a minimal aiohttp-style WebSocket API."""
+
+    def __init__(self, ws: Any):
+        self._ws = ws
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def send_json(self, data: Any) -> None:
+        await self._ws.send(orjson.dumps(data).decode())
+
+    async def receive(self) -> _CompatWSMessage:
+        try:
+            data = await self._ws.recv()
+        except websockets.ConnectionClosed as exc:
+            self._closed = True
+            return _CompatWSMessage(aiohttp.WSMsgType.CLOSED, exc)
+        except Exception as exc:
+            return _CompatWSMessage(aiohttp.WSMsgType.ERROR, exc)
+
+        if isinstance(data, bytes):
+            return _CompatWSMessage(aiohttp.WSMsgType.BINARY, data)
+        return _CompatWSMessage(aiohttp.WSMsgType.TEXT, data)
+
+    async def close(self) -> None:
+        self._closed = True
+        await self._ws.close()
 
 
 class WebSocketClient:
@@ -167,11 +207,30 @@ class WebSocketClient:
                         proxy=resolved_proxy,
                         ssl=self._ssl_context,
                         **extra_kwargs,
-                    )
+                        )
                 return WebSocketConnection(session, ws)
             except Exception as exc:
                 last_error = exc
                 await session.close()
+                if not proxy_url:
+                    try:
+                        origin = None
+                        extra_headers = dict(headers or {})
+                        if "Origin" in extra_headers:
+                            origin = extra_headers.pop("Origin")
+                        logger.warning(
+                            "WebSocket connect failed via aiohttp; retrying with websockets fallback"
+                        )
+                        ws = await websockets.connect(
+                            url,
+                            additional_headers=extra_headers,
+                            origin=origin,
+                            open_timeout=total_timeout,
+                            ssl=self._ssl_context,
+                        )
+                        return WebSocketConnection(None, _WebsocketsAdapter(ws))
+                    except Exception as fallback_exc:
+                        last_error = fallback_exc
                 if self._proxy_override or not active_proxy_key or attempt >= max_retry:
                     raise
                 rotate_proxy(active_proxy_key)

--- a/app/services/reverse/video_upscale.py
+++ b/app/services/reverse/video_upscale.py
@@ -17,6 +17,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 
 VIDEO_UPSCALE_API = "https://grok.com/rest/media/video/upscale"
@@ -106,6 +107,28 @@ class VideoUpscaleReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "VideoUpscaleReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=VIDEO_UPSCALE_API,
+                        headers=headers,
+                        timeout=float(get_config("video.timeout") or 60),
+                        logger_prefix="VideoUpscaleReverse: Upscale failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        data=orjson.dumps(payload),
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"VideoUpscaleReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"VideoUpscaleReverse: Upscale failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/ws_livekit.py
+++ b/app/services/reverse/ws_livekit.py
@@ -18,6 +18,7 @@ from app.core.proxy_pool import (
 from app.core.exceptions import UpstreamException
 from app.services.token.service import TokenService
 from app.services.reverse.utils.headers import build_headers, build_ws_headers
+from app.services.reverse.utils.http_fallback import request_with_aiohttp_fallback
 from app.services.reverse.utils.retry import retry_on_status
 from app.services.reverse.utils.websocket import WebSocketClient, WebSocketConnection
 
@@ -128,6 +129,28 @@ class LivekitTokenReverse:
                 raise
 
             # Handle other non-upstream exceptions
+            if not get_config("proxy.base_proxy_url"):
+                try:
+                    logger.warning(
+                        "LivekitTokenReverse: curl-cffi failed; retrying with aiohttp fallback"
+                    )
+                    return await request_with_aiohttp_fallback(
+                        method="POST",
+                        url=LIVEKIT_TOKEN_API,
+                        headers=headers,
+                        timeout=float(get_config("voice.timeout") or 120),
+                        logger_prefix="LivekitTokenReverse: Request failed",
+                        expected_statuses=(200,),
+                        response_kind="json",
+                        data=orjson.dumps(payload),
+                    )
+                except UpstreamException:
+                    raise
+                except Exception as fallback_exc:
+                    logger.warning(
+                        f"LivekitTokenReverse: aiohttp fallback failed, {fallback_exc}"
+                    )
+
             logger.error(
                 f"LivekitTokenReverse: Request failed, {str(e)}",
                 extra={"error_type": type(e).__name__},

--- a/app/services/reverse/ws_livekit.py
+++ b/app/services/reverse/ws_livekit.py
@@ -95,7 +95,9 @@ class LivekitTokenReverse:
                 if response.status_code != 200:
                     body = response.text[:200]
                     logger.error(
-                        f"LivekitTokenReverse: Request failed, {response.status_code}, body={body}"
+                        "LivekitTokenReverse: Request failed, {}, body={}",
+                        response.status_code,
+                        body,
                     )
                     raise UpstreamException(
                         message=f"LivekitTokenReverse: Request failed, {response.status_code}",

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -37,9 +37,15 @@ base_proxy_url = ""
 # 资源代理地址（代理静态资源如图片/视频）
 asset_proxy_url = ""
 # 完整 CF Cookies（自动刷新写入）
+raw_cookie = ""
+sso_rw = ""
 cf_cookies = ""
 # 跳过代理 SSL 证书验证（代理使用自签名证书时启用）
 skip_proxy_ssl_verify = false
+# 是否将 Windows 系统证书合并进运行时 CA Bundle（Windows 推荐开启）
+use_system_ca = true
+# 额外自定义根证书文件（PEM/DER/CER/P7B），用于公司代理/安全软件签发证书
+custom_ca_file = ""
 # 是否启用 CF 自动刷新
 enabled = false
 # FlareSolverr 服务地址（通过环境变量 FLARESOLVERR_URL 自动设置）
@@ -53,7 +59,7 @@ cf_clearance = ""
 # curl_cffi 浏览器指纹
 browser = "chrome136"
 # User-Agent 字符串
-user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
 
 
 # ==================== 重试策略 ====================

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -163,6 +163,8 @@ blocked_parallel_enabled = true
 n = 1
 # 图片尺寸：1280x720 / 720x1280 / 1792x1024 / 1024x1792 / 1024x1024
 size = "1024x1024"
+# 是否显式开启 NSFW（默认继承 [image].nsfw）
+nsfw = true
 # 响应格式：url / b64_json / base64
 response_format = "url"
 

--- a/launch-grok2api.ps1
+++ b/launch-grok2api.ps1
@@ -1,0 +1,135 @@
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+function Import-SimpleDotEnv {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path -Encoding UTF8) {
+        $line = $rawLine.Trim()
+        if (-not $line -or $line.StartsWith('#')) {
+            continue
+        }
+
+        $index = $line.IndexOf('=')
+        if ($index -lt 1) {
+            continue
+        }
+
+        $key = $line.Substring(0, $index).Trim()
+        $value = $line.Substring($index + 1).Trim()
+
+        if ($value.Length -ge 2) {
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+        }
+
+        if (-not (Test-Path -LiteralPath "Env:$key")) {
+            Set-Item -LiteralPath "Env:$key" -Value $value
+        }
+    }
+}
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ''
+    )
+
+    $item = Get-Item -LiteralPath "Env:$Name" -ErrorAction SilentlyContinue
+    if ($null -eq $item -or [string]::IsNullOrWhiteSpace($item.Value)) {
+        return $Default
+    }
+    return [string]$item.Value
+}
+
+function Get-EnvIntValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [int]$Default
+    )
+
+    $raw = Get-EnvValue -Name $Name -Default ''
+    if (-not $raw) {
+        return $Default
+    }
+
+    $parsed = 0
+    if ([int]::TryParse($raw, [ref]$parsed)) {
+        return $parsed
+    }
+
+    return $Default
+}
+
+function Test-Health {
+    param([Parameter(Mandatory = $true)][string]$Url)
+
+    try {
+        $null = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+$ProjectRoot = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+Set-Location -LiteralPath $ProjectRoot
+Import-SimpleDotEnv -Path (Join-Path $ProjectRoot '.env')
+
+$port = Get-EnvIntValue -Name 'SERVER_PORT' -Default 8000
+$listenHost = Get-EnvValue -Name 'SERVER_HOST' -Default '127.0.0.1'
+$browserHost = switch ($listenHost.ToLowerInvariant()) {
+    '0.0.0.0' { '127.0.0.1' }
+    '::' { '127.0.0.1' }
+    'localhost' { '127.0.0.1' }
+    default { $listenHost }
+}
+
+$healthUrl = "http://127.0.0.1:$port/health"
+$adminUrl = "http://${browserHost}:$port/admin/login"
+$startScript = Join-Path $ProjectRoot 'start-grok2api.ps1'
+
+Write-Host 'Checking Grok2API service...' -ForegroundColor Cyan
+if (Test-Health -Url $healthUrl) {
+    Write-Host 'Service is already running. Opening admin page...' -ForegroundColor Green
+    Start-Process $adminUrl | Out-Null
+    exit 0
+}
+
+Write-Host 'Starting Grok2API in a new PowerShell window...' -ForegroundColor Cyan
+Start-Process powershell -WorkingDirectory $ProjectRoot -ArgumentList @(
+    '-ExecutionPolicy', 'Bypass',
+    '-NoProfile',
+    '-File', $startScript
+) | Out-Null
+
+$ready = $false
+for ($i = 0; $i -lt 30; $i++) {
+    Start-Sleep -Seconds 1
+    if (Test-Health -Url $healthUrl) {
+        $ready = $true
+        break
+    }
+}
+
+if ($ready) {
+    Write-Host 'Service started successfully. Opening admin page...' -ForegroundColor Green
+    Start-Process $adminUrl | Out-Null
+    exit 0
+}
+
+Write-Host ''
+Write-Host 'Startup timed out.' -ForegroundColor Yellow
+Write-Host 'Please check the newly opened PowerShell window for details.' -ForegroundColor Yellow
+Write-Host "You can also visit: $adminUrl" -ForegroundColor Yellow
+exit 1

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,7 @@ curl http://localhost:8000/v1/chat/completions \
 | └─`n` | integer | 生成数量 | `1` ~ `10` |
 | └─`size` | string | 图片尺寸 | `1280x720`, `720x1280`, `1792x1024`, `1024x1792`, `1024x1024` |
 | └─`response_format` | string | 响应格式 | `url`, `b64_json`, `base64` |
+| └─`nsfw` | boolean | 显式开启 NSFW | `true`, `false` |
 
 **消息格式 (messages)**：
 
@@ -281,6 +282,7 @@ curl http://localhost:8000/v1/images/generations \
 | `size` | string | 图片尺寸 | `1280x720`, `720x1280`, `1792x1024`, `1024x1792`, `1024x1024` |
 | `quality` | string | 图片质量 | - (暂不支持) |
 | `response_format` | string | 响应格式 | `url`, `b64_json`, `base64` |
+| `nsfw` | boolean | 显式开启 NSFW | `true`, `false` |
 | `style` | string | 风格 | - (暂不支持) |
 
 **注意事项**：

--- a/start-grok2api.ps1
+++ b/start-grok2api.ps1
@@ -1,0 +1,191 @@
+param(
+    [string]$ListenHost,
+    [int]$Port,
+    [int]$Workers,
+    [string]$CustomCaFile,
+    [switch]$NoSystemCa,
+    [switch]$SkipPortCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+function Import-SimpleDotEnv {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    foreach ($rawLine in Get-Content -LiteralPath $Path -Encoding UTF8) {
+        $line = $rawLine.Trim()
+        if (-not $line -or $line.StartsWith('#')) {
+            continue
+        }
+
+        $index = $line.IndexOf('=')
+        if ($index -lt 1) {
+            continue
+        }
+
+        $key = $line.Substring(0, $index).Trim()
+        $value = $line.Substring($index + 1).Trim()
+
+        if ($value.Length -ge 2) {
+            if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+                $value = $value.Substring(1, $value.Length - 2)
+            }
+        }
+
+        if (-not (Test-Path -LiteralPath "Env:$key")) {
+            Set-Item -LiteralPath "Env:$key" -Value $value
+        }
+    }
+}
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ''
+    )
+
+    $item = Get-Item -LiteralPath "Env:$Name" -ErrorAction SilentlyContinue
+    if ($null -eq $item -or [string]::IsNullOrWhiteSpace($item.Value)) {
+        return $Default
+    }
+    return [string]$item.Value
+}
+
+function Get-EnvIntValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [int]$Default
+    )
+
+    $raw = Get-EnvValue -Name $Name -Default ''
+    if (-not $raw) {
+        return $Default
+    }
+
+    $parsed = 0
+    if ([int]::TryParse($raw, [ref]$parsed)) {
+        return $parsed
+    }
+
+    return $Default
+}
+
+function Get-PortListeners {
+    param([Parameter(Mandatory = $true)][int]$LocalPort)
+
+    $items = New-Object System.Collections.Generic.List[object]
+
+    try {
+        $connections = Get-NetTCPConnection -State Listen -LocalPort $LocalPort -ErrorAction Stop
+        foreach ($connection in $connections) {
+            $process = Get-Process -Id $connection.OwningProcess -ErrorAction SilentlyContinue
+            $items.Add([PSCustomObject]@{
+                Address = $connection.LocalAddress
+                Port = $LocalPort
+                PID = $connection.OwningProcess
+                ProcessName = if ($process) { $process.ProcessName } else { '' }
+            })
+        }
+        return $items
+    }
+    catch {
+        foreach ($entry in (netstat -ano | Select-String 'LISTENING')) {
+            $text = (($entry.Line -replace '\s+', ' ').Trim())
+            $parts = $text -split ' '
+            if ($parts.Count -lt 5) {
+                continue
+            }
+
+            $local = $parts[1]
+            $processId = $parts[-1]
+            if ($local -match ':(\d+)$' -and [int]$Matches[1] -eq $LocalPort) {
+                $process = Get-Process -Id ([int]$processId) -ErrorAction SilentlyContinue
+                $items.Add([PSCustomObject]@{
+                    Address = $local
+                    Port = $LocalPort
+                    PID = [int]$processId
+                    ProcessName = if ($process) { $process.ProcessName } else { '' }
+                })
+            }
+        }
+        return $items
+    }
+}
+
+$ProjectRoot = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
+Set-Location -LiteralPath $ProjectRoot
+
+Import-SimpleDotEnv -Path (Join-Path $ProjectRoot '.env')
+
+$GranianPath = Join-Path $ProjectRoot '.venv\Scripts\granian.exe'
+if (-not (Test-Path -LiteralPath $GranianPath)) {
+    throw "Granian not found: $GranianPath. Run dependency install first."
+}
+
+if (-not $PSBoundParameters.ContainsKey('ListenHost')) {
+    $ListenHost = Get-EnvValue -Name 'SERVER_HOST' -Default '127.0.0.1'
+}
+if (-not $PSBoundParameters.ContainsKey('Port')) {
+    $Port = Get-EnvIntValue -Name 'SERVER_PORT' -Default 8000
+}
+if (-not $PSBoundParameters.ContainsKey('Workers')) {
+    $Workers = Get-EnvIntValue -Name 'SERVER_WORKERS' -Default 1
+}
+
+$env:PYTHONUTF8 = '1'
+$env:PYTHONIOENCODING = 'utf-8'
+
+if ($NoSystemCa.IsPresent) {
+    $env:GROK2API_USE_SYSTEM_CA = 'false'
+}
+elseif (-not (Test-Path -LiteralPath 'Env:GROK2API_USE_SYSTEM_CA')) {
+    $env:GROK2API_USE_SYSTEM_CA = 'true'
+}
+
+if ($PSBoundParameters.ContainsKey('CustomCaFile')) {
+    $resolvedCa = (Resolve-Path -LiteralPath $CustomCaFile).Path
+    $env:GROK2API_CUSTOM_CA_FILE = $resolvedCa
+}
+elseif (Test-Path -LiteralPath 'Env:GROK2API_CUSTOM_CA_FILE') {
+    $resolvedCa = (Resolve-Path -LiteralPath $env:GROK2API_CUSTOM_CA_FILE).Path
+    $env:GROK2API_CUSTOM_CA_FILE = $resolvedCa
+}
+else {
+    Remove-Item -LiteralPath 'Env:GROK2API_CUSTOM_CA_FILE' -ErrorAction SilentlyContinue
+}
+
+if (-not $SkipPortCheck.IsPresent) {
+    $listeners = @(Get-PortListeners -LocalPort $Port)
+    if ($listeners.Count -gt 0) {
+        Write-Host "Port $Port is already in use:" -ForegroundColor Yellow
+        $listeners | Format-Table -AutoSize | Out-String | Write-Host
+        throw "Stop the process using port $Port, or pass -Port with another value."
+    }
+}
+
+Write-Host '========================================' -ForegroundColor Cyan
+Write-Host 'Grok2API startup settings' -ForegroundColor Cyan
+Write-Host '========================================' -ForegroundColor Cyan
+Write-Host "Project root : $ProjectRoot"
+Write-Host "Listen host  : $ListenHost"
+Write-Host "Listen port  : $Port"
+Write-Host "Workers      : $Workers"
+Write-Host "Use system CA: $($env:GROK2API_USE_SYSTEM_CA)"
+if ([string]::IsNullOrWhiteSpace($env:GROK2API_CUSTOM_CA_FILE)) {
+    $customCaDisplay = '(not set)'
+}
+else {
+    $customCaDisplay = $env:GROK2API_CUSTOM_CA_FILE
+}
+Write-Host "Custom CA    : $customCaDisplay"
+Write-Host '========================================' -ForegroundColor Cyan
+
+& $GranianPath --interface asgi --host $ListenHost --port $Port --workers $Workers main:app
+exit $LASTEXITCODE

--- a/start-with-system-ca.cmd
+++ b/start-with-system-ca.cmd
@@ -1,0 +1,6 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+powershell -ExecutionPolicy Bypass -NoProfile -File "%~dp0start-grok2api.ps1" %*
+set "EXIT_CODE=%ERRORLEVEL%"
+endlocal & exit /b %EXIT_CODE%

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.core import auth
+
+
+class AuthTokenTests(unittest.IsolatedAsyncioTestCase):
+    async def test_verify_api_key_rejects_unicode_token_without_typeerror(self):
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer",
+            credentials="测试令牌",
+        )
+
+        with patch.object(auth, "get_config", return_value="202020hgx"):
+            with self.assertRaises(HTTPException) as ctx:
+                await auth.verify_api_key(credentials)
+
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, "Invalid authentication token")
+
+    async def test_verify_api_key_accepts_unicode_token_when_config_matches(self):
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer",
+            credentials="测试令牌",
+        )
+
+        with patch.object(auth, "get_config", return_value="测试令牌"):
+            token = await auth.verify_api_key(credentials)
+
+        self.assertEqual(token, "测试令牌")
+
+    async def test_verify_function_key_accepts_unicode_token_when_enabled(self):
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer",
+            credentials="功能密钥",
+        )
+
+        def fake_get_config(key, default=None):
+            values = {
+                "app.function_key": "功能密钥",
+                "app.function_enabled": True,
+            }
+            return values.get(key, default)
+
+        with patch.object(auth, "get_config", side_effect=fake_get_config):
+            token = await auth.verify_function_key(credentials)
+
+        self.assertEqual(token, "功能密钥")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auth_probe.py
+++ b/tests/test_auth_probe.py
@@ -1,0 +1,31 @@
+import unittest
+
+from app.services.reverse.utils.auth_probe import classify_probe
+
+
+class AuthProbeTests(unittest.TestCase):
+    def test_classify_probe_marks_empty_401_as_expired_token(self):
+        is_token_expired, is_cloudflare = classify_probe(
+            401,
+            "text/plain",
+            "cloudflare",
+            "",
+        )
+
+        self.assertTrue(is_token_expired)
+        self.assertFalse(is_cloudflare)
+
+    def test_classify_probe_marks_challenge_as_cloudflare(self):
+        is_token_expired, is_cloudflare = classify_probe(
+            403,
+            "text/html",
+            "cloudflare",
+            "<html>challenge-platform</html>",
+        )
+
+        self.assertFalse(is_token_expired)
+        self.assertTrue(is_cloudflare)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_image_models.py
+++ b/tests/test_image_models.py
@@ -1,0 +1,21 @@
+import unittest
+
+from app.api.v1.image import ImageGenerationRequest, validate_generation_request
+
+
+class ImageModelTests(unittest.TestCase):
+    def test_fast_image_model_is_allowed(self):
+        request = ImageGenerationRequest(
+            prompt="A red square",
+            model="grok-imagine-1.0-fast",
+            n=1,
+            size="1024x1024",
+            response_format="b64_json",
+            stream=False,
+        )
+
+        validate_generation_request(request)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -1,0 +1,52 @@
+import unittest
+
+from app.services.grok.services.model import ModelService
+
+
+class ModelAliasTests(unittest.TestCase):
+    def test_canonical_models_use_working_upstream_pairs(self):
+        cases = {
+            "grok-4-heavy": ("grok-4", "MODEL_MODE_EXPERT"),
+            "grok-4.1-mini": ("grok-4-1-thinking-1129", "MODEL_MODE_FAST"),
+            "grok-4.1-thinking": ("grok-4-1-thinking-1129", "MODEL_MODE_EXPERT"),
+            "grok-4.20-beta": ("grok-420", "MODEL_MODE_FAST"),
+        }
+
+        for model_id, (grok_model, model_mode) in cases.items():
+            with self.subTest(model_id=model_id):
+                info = ModelService.get(model_id)
+                self.assertIsNotNone(info)
+                self.assertEqual(info.grok_model, grok_model)
+                self.assertEqual(info.model_mode, model_mode)
+
+    def test_aliases_resolve_to_same_grok_target(self):
+        cases = {
+            "grok-4-fast": "grok-4.1-fast",
+            "grok-code-fast-1": "grok-4.1-fast",
+            "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta",
+            "grok-4-20-beta-latest-non-reasoning": "grok-4.20-beta",
+        }
+
+        for alias_id, canonical_id in cases.items():
+            with self.subTest(alias_id=alias_id):
+                alias = ModelService.get(alias_id)
+                canonical = ModelService.get(canonical_id)
+
+                self.assertIsNotNone(alias)
+                self.assertIsNotNone(canonical)
+                self.assertEqual(alias.grok_model, canonical.grok_model)
+                self.assertEqual(alias.model_mode, canonical.model_mode)
+                self.assertEqual(alias.tier, canonical.tier)
+                self.assertEqual(alias.cost, canonical.cost)
+
+    def test_models_list_includes_aliases(self):
+        model_ids = {model.model_id for model in ModelService.list()}
+
+        self.assertIn("grok-4-fast", model_ids)
+        self.assertIn("grok-code-fast-1", model_ids)
+        self.assertIn("grok-4.20-beta-latest-non-reasoning", model_ids)
+        self.assertIn("grok-4-20-beta-latest-non-reasoning", model_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_process_images.py
+++ b/tests/test_process_images.py
@@ -1,0 +1,20 @@
+import unittest
+
+from app.services.grok.utils.process import _collect_images
+
+
+class ProcessImageTests(unittest.TestCase):
+    def test_collect_images_reads_card_attachments_json(self):
+        payload = {
+            "cardAttachmentsJson": [
+                '{"id":"abc","image_chunk":{"imageUrl":"users/demo/generated/test/image.jpg"}}'
+            ]
+        }
+
+        images = _collect_images(payload)
+
+        self.assertEqual(images, ["users/demo/generated/test/image.jpg"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

This PR improves Grok2API transport resilience in environments where `curl_cffi`, `aiohttp`, and WebSocket clients do not fail in the same way, while restoring compatibility for several published Grok model and media paths that were no longer reliably usable.

## What changed

### Transport resilience
- add a shared HTTP fallback helper that retries failed reverse requests with `aiohttp`
- add a shared WebSocket fallback path that retries failed `aiohttp.ws_connect` calls with `websockets`
- apply the fallback pattern across reverse interfaces used by chat, assets, livekit, media post flows, gRPC-web flows, and related utility endpoints
- add runtime CA bundle generation under an ASCII-safe path and merge Windows system roots to reduce TLS/path issues on Windows
- add Windows startup helpers for launching the service and admin UI more reliably

### Auth and config hardening
- make API key comparison Unicode-safe
- sanitize and support additional cookie-related proxy fields
- expose config for system CA/custom CA and raw cookie overrides

### Model and media compatibility
- update broken upstream model mappings for:
  - `grok-4-heavy`
  - `grok-4.1-mini`
  - `grok-4.1-thinking`
  - `grok-4.20-beta`
- add common alias model IDs for OpenAI-compatible clients
- allow `grok-imagine-1.0-fast` in image generation validation
- extend image URL extraction to parse generated-image card attachments from app-chat responses

## Why

In this environment, multiple reverse paths were failing due to transport-specific behavior:
- some HTTPS calls failed with `curl_cffi` but succeeded with `aiohttp`
- some WebSocket connections failed with `aiohttp` but succeeded with `websockets`

Using transport fallbacks makes the reverse layer much more resilient without changing the public API.

Separately, several published Grok model names no longer mapped to working upstream combinations. This PR keeps the public model names stable while routing them to upstream pairs that still work.

## Validation

Verified locally:
- chat models:
  - `grok-3`
  - `grok-3-mini`
  - `grok-3-thinking`
  - `grok-4`
  - `grok-4-thinking`
  - `grok-4-heavy`
  - `grok-4.1-mini`
  - `grok-4.1-fast`
  - `grok-4.1-expert`
  - `grok-4.1-thinking`
  - `grok-4.20-beta`
- image/video models:
  - `grok-imagine-1.0`
  - `grok-imagine-1.0-fast`
  - `grok-imagine-1.0-edit`
  - `grok-imagine-1.0-video`

Regression checks:
- unit tests pass
- `python -m compileall app/services/reverse` passes

## Scope notes

This PR intentionally keeps the upstreamable parts of the work:
- shared HTTP fallback (`curl_cffi` -> `aiohttp`)
- shared WebSocket fallback (`aiohttp` -> `websockets`)
- Windows CA/runtime-path hardening
- model/media compatibility fixes needed for current upstream behavior

Local-language launcher wrappers were intentionally left out of the PR to keep the scope generic.
