### PR TITLE
fix: clearance mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@
 <br>
 
 Grok2API 是一个基于 **FastAPI** 构建的 Grok 网关，支持将 Grok Web 能力以 OpenAI 兼容 API 的方式转换。核心特性：
-- OpenAI 兼容接口：`/v1/chat/completions`、`/v1/responses`、`/v1/images/generations`、`/v1/images/edits`、`/v1/videos`
-- 支持流式与非流式对话、显式思考输出、函数工具结构透传
+- OpenAI 兼容接口：`/v1/models`、`/v1/chat/completions`、`/v1/responses`、`/v1/images/generations`、`/v1/images/edits`、`/v1/videos`、`/v1/videos/{video_id}`、`/v1/videos/{video_id}/content`
+- Anthropic 兼容接口：`/v1/messages`
+- 支持流式与非流式对话、显式思考输出、函数工具结构透传，以及统一的 token / usage 统计
 - 支持多账号池、层级选号、失败反馈、额度同步与自动维护
 - 支持本地缓存图片、视频与本地代理链接返回
 - 支持文生图、图像编辑、文生视频、图生视频
@@ -30,28 +31,32 @@ flowchart LR
     Client["Clients\nOpenAI SDK / curl / Browser"] --> API["FastAPI App"]
 
     subgraph Products["Products"]
+        direction TB
         OpenAI["OpenAI APIs\n/v1/*"]
         Anthropic["Anthropic APIs\n/v1/messages"]
         Web["Web Products\n/admin /webui/*"]
     end
 
     subgraph Control["Control"]
+        direction TB
         Models["Model Registry"]
         Accounts["Account Services"]
         Proxies["Proxy Services"]
     end
 
     subgraph Dataplane["Dataplane"]
+        direction TB
+        Reverse["Reverse Protocol + Transport"]
         AccountDP["AccountDirectory"]
         ProxyDP["Proxy Runtime"]
-        Reverse["Reverse Protocol + Transport"]
     end
 
     subgraph Platform["Platform"]
-        Config["Config Snapshot"]
-        Auth["Auth"]
+        direction TB
         Tokens["Token Estimation"]
         Storage["Storage"]
+        Config["Config Snapshot"]
+        Auth["Auth"]
         Log["Logging"]
     end
 

--- a/app/control/proxy/__init__.py
+++ b/app/control/proxy/__init__.py
@@ -45,7 +45,7 @@ class ProxyDirectory:
         """Load proxy configuration from the current config snapshot."""
         cfg = get_config()
         self._egress_mode    = EgressMode(cfg.get_str("proxy.egress.mode", "direct"))
-        self._clearance_mode = ClearanceMode(cfg.get_str("proxy.clearance.mode", "none"))
+        self._clearance_mode = ClearanceMode.parse(cfg.get_str("proxy.clearance.mode", "none"))
 
         nodes: list[EgressNode]          = []
         resource_nodes: list[EgressNode] = []

--- a/app/control/proxy/models.py
+++ b/app/control/proxy/models.py
@@ -24,9 +24,18 @@ class EgressMode(StrEnum):
 
 
 class ClearanceMode(StrEnum):
-    NONE    = "none"     # no CF clearance required
-    MANUAL  = "manual"   # operator-supplied cf_cookies
-    MANAGED = "managed"  # maintained by FlareSolverr
+    NONE         = "none"         # no CF clearance required
+    MANUAL       = "manual"       # operator-supplied cf_cookies
+    FLARESOLVERR = "flaresolverr" # maintained by FlareSolverr
+
+    @classmethod
+    def parse(cls, value: str | "ClearanceMode") -> "ClearanceMode":
+        if isinstance(value, cls):
+            return value
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            return cls.NONE
+        return cls(normalized)
 
 
 class EgressNodeState(IntEnum):

--- a/app/control/proxy/providers/flaresolverr.py
+++ b/app/control/proxy/providers/flaresolverr.py
@@ -37,8 +37,8 @@ class FlareSolverrClearanceProvider:
         proxy_url:    str,
     ) -> ClearanceBundle | None:
         cfg = get_config()
-        mode = cfg.get_str("proxy.clearance.mode", "none")
-        if mode != ClearanceMode.MANAGED:
+        mode = ClearanceMode.parse(cfg.get_str("proxy.clearance.mode", "none"))
+        if mode != ClearanceMode.FLARESOLVERR:
             return None
         fs_url      = cfg.get_str("proxy.clearance.flaresolverr_url", "")
         timeout_sec = cfg.get_int("proxy.clearance.timeout_sec", 60)
@@ -58,7 +58,7 @@ class FlareSolverrClearanceProvider:
             return None
 
         return ClearanceBundle(
-            bundle_id    = f"managed:{affinity_key}",
+            bundle_id    = f"flaresolverr:{affinity_key}",
             cf_cookies   = result.get("cookies", ""),
             user_agent   = result.get("user_agent", ""),
             affinity_key = affinity_key,

--- a/app/control/proxy/providers/manual.py
+++ b/app/control/proxy/providers/manual.py
@@ -9,7 +9,7 @@ class ManualClearanceProvider:
 
     def build_bundle(self, *, affinity_key: str) -> ClearanceBundle | None:
         cfg = get_config()
-        mode = cfg.get_str("proxy.clearance.mode", "none")
+        mode = ClearanceMode.parse(cfg.get_str("proxy.clearance.mode", "none"))
         if mode != ClearanceMode.MANUAL:
             return None
         return ClearanceBundle(

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -4,7 +4,7 @@
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.119%2B-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![Version](https://img.shields.io/badge/version-2.0.0.rc0-111827)](../pyproject.toml)
 [![License](https://img.shields.io/badge/license-MIT-16a34a)](../LICENSE)
-[![中文](https://img.shields.io/badge/中文-2563EB?logo=bookstack&logoColor=white)](../REAMDE.md)
+[![中文](https://img.shields.io/badge/中文-2563EB?logo=bookstack&logoColor=white)](../README.md)
 [![Project%20Docs](https://img.shields.io/badge/Project%20Docs-0F766E?logo=readthedocs&logoColor=white)](https://blog.cheny.me/blog/posts/grok2api)
 
 > [!NOTE]
@@ -13,8 +13,9 @@
 <br>
 
 Grok2API is a **FastAPI**-based Grok gateway that exposes Grok Web capabilities through OpenAI-compatible APIs. Core features:
-- OpenAI-compatible endpoints: `/v1/chat/completions`, `/v1/responses`, `/v1/images/generations`, `/v1/images/edits`, `/v1/videos`
-- Streaming and non-streaming chat, explicit reasoning output, and function-tool structure passthrough
+- OpenAI-compatible endpoints: `/v1/models`, `/v1/chat/completions`, `/v1/responses`, `/v1/images/generations`, `/v1/images/edits`, `/v1/videos`, `/v1/videos/{video_id}`, `/v1/videos/{video_id}/content`
+- Anthropic-compatible endpoint: `/v1/messages`
+- Streaming and non-streaming chat, explicit reasoning output, function-tool structure passthrough, and unified token / usage accounting
 - Multi-account pools, tier-aware selection, failure feedback, quota synchronization, and automatic maintenance
 - Local image/video caching and locally proxied media URLs
 - Text-to-image, image editing, text-to-video, and image-to-video support
@@ -29,28 +30,32 @@ flowchart LR
     Client["Clients\nOpenAI SDK / curl / Browser"] --> API["FastAPI App"]
 
     subgraph Products["Products"]
+        direction TB
         OpenAI["OpenAI APIs\n/v1/*"]
         Anthropic["Anthropic APIs\n/v1/messages"]
         Web["Web Products\n/admin /webui/*"]
     end
 
     subgraph Control["Control"]
+        direction TB
         Models["Model Registry"]
         Accounts["Account Services"]
         Proxies["Proxy Services"]
     end
 
     subgraph Dataplane["Dataplane"]
+        direction TB
+        Reverse["Reverse Protocol + Transport"]
         AccountDP["AccountDirectory"]
         ProxyDP["Proxy Runtime"]
-        Reverse["Reverse Protocol + Transport"]
     end
 
     subgraph Platform["Platform"]
-        Config["Config Snapshot"]
-        Auth["Auth"]
+        direction TB
         Tokens["Token Estimation"]
         Storage["Storage"]
+        Config["Config Snapshot"]
+        Auth["Auth"]
         Log["Logging"]
     end
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grok2api"
-version = "2.0.0.rc0"
+version = "2.0.1"
 description = "Grok2API rebuilt with FastAPI, fully aligned with the latest web call format. Supports streaming and non-streaming chat, image generation/editing, deep thinking, token pool concurrency, and automatic load balancing."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "grok2api"
-version = "2.0.0rc0"
+version = "2.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Fix `proxy.clearance.mode` handling so the current `flaresolverr` value matches the backend enum and provider flow.
- Prevent startup failure when users save the FlareSolverr option in WebUI and then rebuild/restart with Docker Compose.
- Update the Chinese and English README files to reflect the current API surface and feature set, including Anthropic-compatible messaging and token estimation support.

## Testing

- Verified the reported failure path by checking the startup stack trace and matching it against the proxy clearance mode loading flow.
- Confirmed this change aligns config parsing, mode selection, and provider handling around `flaresolverr`.

## Related

- Fixes #423 
