### PR TITLE
refactor: improve type hinting in ClearanceMode parse method

### DIFF
--- a/app/control/proxy/models.py
+++ b/app/control/proxy/models.py
@@ -1,7 +1,7 @@
 """Control-plane proxy domain models."""
 
 from enum import IntEnum, StrEnum
-from typing import Any
+from typing import Any, Self
 
 from pydantic import BaseModel, Field
 
@@ -29,7 +29,7 @@ class ClearanceMode(StrEnum):
     FLARESOLVERR = "flaresolverr" # maintained by FlareSolverr
 
     @classmethod
-    def parse(cls, value: str | "ClearanceMode") -> "ClearanceMode":
+    def parse(cls, value: str | Self) -> Self:
         if isinstance(value, cls):
             return value
         normalized = str(value or "").strip().lower()


### PR DESCRIPTION
## Summary

- Corrected the syntax of the `ClearanceMode.parse` type annotation to prevent Python 3.13 from directly throwing an error during the module import phase.

## Testing

- Use `uv run python -c 'import app.main; print("import-ok")'` to verify that the application's main module can be imported normally and no longer fails to start due to type annotation issues.

## Related

- #423 