### PR TITLE
chore: add python-dotenv dependency and update imports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -27,6 +28,9 @@ from app.platform.logging.logger import logger, setup_logging, reload_logging
 from app.platform.config.snapshot import config as _config
 from app.platform.errors import AppError
 from app.platform.meta import get_project_version
+
+
+load_dotenv()
 
 
 # ---------------------------------------------------------------------------
@@ -54,7 +58,7 @@ def _try_acquire_scheduler_lock() -> bool:
     except BlockingIOError:
         # Another worker already holds the lock.
         return False
-    except (OSError, AttributeError):
+    except (ImportError, OSError, AttributeError):
         # fcntl unavailable (Windows) or unexpected FS error — treat as leader.
         return True
 
@@ -67,7 +71,7 @@ def _release_scheduler_lock() -> None:
         import fcntl
         fcntl.flock(_lock_fd, fcntl.LOCK_UN)
         os.close(_lock_fd)
-    except OSError:
+    except (ImportError, OSError):
         pass
     _lock_fd = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "loguru>=0.7.3",
     "orjson>=3.11.4",
     "pydantic>=2.12.3",
+    "python-dotenv>=1.1.1",
     "python-multipart>=0.0.21",
     "redis>=6.4.0",
     "sqlalchemy>=2.0.46",

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,7 @@ dependencies = [
     { name = "loguru" },
     { name = "orjson" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "redis" },
     { name = "sqlalchemy" },
@@ -567,6 +568,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "orjson", specifier = ">=3.11.4" },
     { name = "pydantic", specifier = ">=2.12.3" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "python-multipart", specifier = ">=0.0.21" },
     { name = "redis", specifier = ">=6.4.0" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
@@ -902,6 +904,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f5/ae/1fe3fcd9f959efa0ebe200b8de88b5a5ce3e767e38c7ac32fb179f16a388/pymysql-1.1.2.tar.gz", hash = "sha256:4961d3e165614ae65014e361811a724e2044ad3ea3739de9903ae7c21f539f03", size = 48258, upload-time = "2025-08-24T12:55:55.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/4c/ad33b92b9864cbde84f259d5df035a6447f91891f5be77788e2a3892bce3/pymysql-1.1.2-py3-none-any.whl", hash = "sha256:e6b1d89711dd51f8f74b1631fe08f039e7d76cf67a42a323d3178f0f25762ed9", size = 45300, upload-time = "2025-08-24T12:55:53.394Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `python-dotenv` and load `.env` at application startup so local development reads startup environment variables as documented.
- Fix Windows startup compatibility in the scheduler lock path by handling missing `fcntl` as a supported fallback instead of crashing during lifespan startup.

## Testing

- Ran `uv sync` to install and lock the new dependency.
- Ran `uv run python -c 'import app.main; print("import-ok")'' to verify the application entrypoint still imports successfully.
- Ran `env -u ACCOUNT_STORAGE -u ACCOUNT_LOCAL_PATH uv run python -c 'import os; import app.main; print(os.getenv("ACCOUNT_STORAGE")); print(os.getenv("ACCOUNT_LOCAL_PATH"))'` to confirm `.env` values ​​are loaded at startup.
- Ran `uv run python -c 'import builtins; import app.main as m; orig = builtins.__import__; builtins.__import__ = lambda name, *a, **k: (_ for _ in ()).throw(ModuleNotFoundError("No module named fcntl")) if name == "fcntl" else orig(name, *a, **k); print(m._try_acquire_scheduler_lock()); m._release_scheduler_lock(); builtins.__import__ = orig'` to verify the Windows-style `fcntl` fallback no longer crashes.

## Related

- Addresses local `.env` loading not taking effect in development mode
- Addresses Windows startup failure caused by missing `fcntl`
- fixed：#428