### PR TITLE
feat: add LOG_FILE_ENABLED configuration for local file logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@
 # ==================== 基础运行 ====================
 TZ=Asia/Shanghai
 LOG_LEVEL=INFO
+# 写入本地文件日志
+LOG_FILE_ENABLED=true
 
 # 账号目录增量同步间隔（秒）
 ACCOUNT_SYNC_INTERVAL=30

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ docker compose up -d
 | :-- | :-- | :-- |
 | `TZ` | 时区 | `Asia/Shanghai` |
 | `LOG_LEVEL` | 日志级别 | `INFO` |
+| `LOG_FILE_ENABLED` | 写入本地文件日志 | `true` |
 | `ACCOUNT_SYNC_INTERVAL` | 账号目录增量同步间隔（秒） | `30` |
 | `SERVER_HOST` | 服务监听地址 | `0.0.0.0` |
 | `SERVER_PORT` | 服务监听端口 | `8000` |

--- a/app/platform/logging/logger.py
+++ b/app/platform/logging/logger.py
@@ -13,6 +13,13 @@ logger = _loguru_logger
 _configured = False
 
 
+def _get_env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def setup_logging(
     *,
     level: str = "INFO",
@@ -70,10 +77,11 @@ def reload_logging(
 ) -> None:
     """Re-configure logging from runtime values (called after config loads)."""
     level = os.getenv("LOG_LEVEL", default_level)
+    file_logging = _get_env_bool("LOG_FILE_ENABLED", True)
     setup_logging(
         level=level,
         json_console=json_console,
-        file_logging=True,
+        file_logging=file_logging,
         max_files=max_files,
     )
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -167,6 +167,7 @@ docker compose up -d
 | :-- | :-- | :-- |
 | `TZ` | Time zone | `Asia/Shanghai` |
 | `LOG_LEVEL` | Log level | `INFO` |
+| `LOG_FILE_ENABLED` | Write local log files | `true` |
 | `ACCOUNT_SYNC_INTERVAL` | Account directory incremental sync interval in seconds | `30` |
 | `SERVER_HOST` | Service bind address | `0.0.0.0` |
 | `SERVER_PORT` | Service port | `8000` |


### PR DESCRIPTION
## Summary

- 新增 `LOG_FILE_ENABLED` 环境变量，用于控制是否写入本地文件日志。
- 保持控制台日志输出不变，仅控制 `logs/` 下的文件日志 sink 是否启用。
- 同步更新 `.env.example`、README 和英文文档，补充该配置项说明。

## Testing

- 使用 `uv run python -c 'import os, tempfile; from pathlib import Path; from app.platform.logging.logger import reload_logging; td = Path(tempfile.mkdtemp()); os.chdir(td); os.environ["LOG_FILE_ENABLED"] = "false"; reload_logging(); print((td / "logs").exists())'` 验证关闭后不会创建 `logs/`。
- 使用 `uv run python -c 'import os, tempfile; from pathlib import Path; from app.platform.logging.logger import reload_logging; td = Path(tempfile.mkdtemp()); os.chdir(td); os.environ["LOG_FILE_ENABLED"] = "true"; reload_logging(); print((td / "logs").exists())'` 验证开启后仍会创建 `logs/`。
- 文档改动已与默认值保持一致。

## Related

- N/A
