### PR TITLE
fix: enhance feedback handling in asset upload process

### DIFF
--- a/app/dataplane/reverse/transport/asset_upload.py
+++ b/app/dataplane/reverse/transport/asset_upload.py
@@ -20,6 +20,7 @@ from app.dataplane.proxy.adapters.headers import build_sso_cookie
 from app.dataplane.proxy.adapters.headers import build_http_headers
 from app.dataplane.proxy.adapters.session import ResettableSession, build_session_kwargs
 from app.dataplane.reverse.protocol.xai_assets import resolve_asset_reference
+from app.control.proxy.feedback import build_feedback
 from app.control.proxy.models import ProxyFeedback, ProxyFeedbackKind
 
 _UPLOAD_URL = "https://grok.com/rest/app-chat/upload-file"
@@ -143,13 +144,10 @@ async def _upload_file_inner(
                 "asset upload request failed: status={} body={}",
                 response.status_code, body_text,
             )
+            is_cloudflare = "just a moment" in body_text.lower()
             await proxy.feedback(
                 lease,
-                ProxyFeedback(
-                    kind        = ProxyFeedbackKind.UPSTREAM_5XX if response.status_code >= 500
-                                  else ProxyFeedbackKind.FORBIDDEN,
-                    status_code = response.status_code,
-                ),
+                build_feedback(response.status_code, is_cloudflare=is_cloudflare),
             )
             raise UpstreamError(
                 f"Asset upload returned {response.status_code}",

--- a/app/products/web/router.py
+++ b/app/products/web/router.py
@@ -32,6 +32,11 @@ def _serve_html(path: str):
     return serve_static_html(_DIR / path)
 
 
+@router.get("/", include_in_schema=False)
+async def root():
+    return RedirectResponse("/admin")
+
+
 # --- Admin pages ---
 @router.get("/admin", include_in_schema=False)
 async def admin_root():


### PR DESCRIPTION
## Summary

- 修正图片上传链路在遇到 Cloudflare 403 挑战页时的代理反馈分类。
- 之前 `upload-file` 返回挑战页时会被当成普通 `forbidden`，不会触发当前 clearance bundle 失效与刷新，容易反复复用失效的 clearance。
- 现在会按 `challenge` 处理，便于 FlareSolverr clearance 在上传失败后正确失效并重新获取。

## Testing

- 使用 `uv run python -c 'from app.control.proxy.feedback import build_feedback; print(build_feedback(403, is_cloudflare=True).kind); print(build_feedback(403, is_cloudflare=False).kind)'` 验证 403 反馈分类结果。
- 使用 `uv run python -c 'import app.dataplane.reverse.transport.asset_upload as m; print("import-ok")'` 验证上传模块可正常导入。
- 未完成完整的图生视频端到端上传测试。

## Related

- Fixed: #432 