### PR TITLE
chore: update configuration paths to use DATA_DIR and LOG_DIR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # 用法：
 # 1. 复制为 .env 后按需修改
 # 2. 启动期 / 部署期变量放这里
-# 3. 常规运行时配置优先改 data/config.toml
+# 3. 常规运行时配置优先改 ${DATA_DIR}/config.toml
 
 
 # ==================== 基础运行 ====================
@@ -28,9 +28,6 @@ HOST_PORT=8000
 # 可选：local | redis | mysql | postgresql
 ACCOUNT_STORAGE=local
 
-# local: SQLite 文件路径
-ACCOUNT_LOCAL_PATH=data/accounts.db
-
 # redis: Redis DSN（ACCOUNT_STORAGE=redis 时必填）
 # ACCOUNT_REDIS_URL=redis://:password@host:6379/0
 
@@ -41,7 +38,6 @@ ACCOUNT_LOCAL_PATH=data/accounts.db
 # ACCOUNT_POSTGRESQL_URL=postgresql+asyncpg://user:password@127.0.0.1:5432/grok2api
 
 
-# ==================== 可选：初始化脚本目录 ====================
-# 仅 scripts/init_storage.sh 使用；不影响应用内配置路径解析
+# ==================== 可选：本地数据 / 日志目录 ====================
 DATA_DIR=./data
 LOG_DIR=./logs

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ docker compose up -d
 
 ### Vercel
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,ACCOUNT_STORAGE,ACCOUNT_LOCAL_PATH,CONFIG_LOCAL_PATH,ACCOUNT_REDIS_URL,ACCOUNT_MYSQL_URL,ACCOUNT_POSTGRESQL_URL)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,DATA_DIR,LOG_DIR,ACCOUNT_STORAGE,ACCOUNT_REDIS_URL,ACCOUNT_MYSQL_URL,ACCOUNT_POSTGRESQL_URL)
 
 ### Render
 
@@ -157,7 +157,7 @@ docker compose up -d
 | 位置 | 用途 | 生效时机 |
 | :-- | :-- | :-- |
 | `.env` | 启动前配置 | 服务启动时 |
-| `data/config.toml` | 运行时配置 | 保存后即时生效 |
+| `${DATA_DIR}/config.toml` | 运行时配置 | 保存后即时生效 |
 | `config.defaults.toml` | 默认模板 | 首次初始化时 |
 
 
@@ -174,8 +174,9 @@ docker compose up -d
 | `SERVER_PORT` | 服务监听端口 | `8000` |
 | `SERVER_WORKERS` | Granian worker 数量 | `1` |
 | `HOST_PORT` | Docker Compose 宿主机映射端口 | `8000` |
+| `DATA_DIR` | 本地数据目录 | `./data` |
+| `LOG_DIR` | 本地日志目录 | `./logs` |
 | `ACCOUNT_STORAGE` | 账号存储后端 | `local` |
-| `ACCOUNT_LOCAL_PATH` | `local` 模式 SQLite 路径 | `data/accounts.db` |
 | `ACCOUNT_REDIS_URL` | `redis` 模式 Redis DSN | `""` |
 | `ACCOUNT_MYSQL_URL` | `mysql` 模式 SQLAlchemy DSN | `""` |
 | `ACCOUNT_POSTGRESQL_URL` | `postgresql` 模式 SQLAlchemy DSN | `""` |

--- a/app/control/account/backends/factory.py
+++ b/app/control/account/backends/factory.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+from app.platform.paths import data_path
 from ..repository import AccountRepository
 
-_DEFAULT_LOCAL_PATH = "data/accounts.db"
 _SUPPORTED_BACKENDS = {"local", "redis", "mysql", "postgresql"}
 
 
@@ -79,7 +79,7 @@ def _get_required_env(name: str) -> str:
 
 
 def _resolve_local_db_path() -> Path:
-    path_str = _get_env("ACCOUNT_LOCAL_PATH", _DEFAULT_LOCAL_PATH)
+    path_str = _get_env("ACCOUNT_LOCAL_PATH", str(data_path("accounts.db")))
     db_path = Path(path_str)
     if not db_path.is_absolute():
         db_path = Path(__file__).resolve().parents[4] / db_path

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.platform.logging.logger import logger, setup_logging, reload_logging
 from app.platform.config.snapshot import config as _config
 from app.platform.errors import AppError
 from app.platform.meta import get_project_version
+from app.platform.paths import data_path
 
 
 load_dotenv()
@@ -37,7 +38,7 @@ load_dotenv()
 # Scheduler leader-election via advisory file lock
 # ---------------------------------------------------------------------------
 
-_LOCK_FILE = Path(__file__).resolve().parent.parent / "data" / ".scheduler.lock"
+_LOCK_FILE = data_path(".scheduler.lock")
 _lock_fd: int | None = None
 
 

--- a/app/platform/config/backends/factory.py
+++ b/app/platform/config/backends/factory.py
@@ -3,9 +3,8 @@
 import os
 from pathlib import Path
 
+from app.platform.paths import data_path
 from .base import ConfigBackend
-
-_DEFAULT_USER_PATH = "data/config.toml"
 
 
 def get_config_backend_name() -> str:
@@ -16,7 +15,7 @@ def get_config_backend_name() -> str:
 def create_config_backend() -> ConfigBackend:
     """Instantiate the config backend that matches the account storage backend.
 
-    ``ACCOUNT_STORAGE=local``       → TOML file (data/config.toml)
+    ``ACCOUNT_STORAGE=local``       → TOML file (``${DATA_DIR}/config.toml``)
     ``ACCOUNT_STORAGE=redis``       → Redis  (ACCOUNT_REDIS_URL)
     ``ACCOUNT_STORAGE=mysql``       → MySQL  (ACCOUNT_MYSQL_URL)
     ``ACCOUNT_STORAGE=postgresql``  → PostgreSQL (ACCOUNT_POSTGRESQL_URL)
@@ -38,7 +37,7 @@ def create_config_backend() -> ConfigBackend:
 def _make_toml() -> ConfigBackend:
     from .toml import TomlConfigBackend
 
-    path_str = os.getenv("CONFIG_LOCAL_PATH", _DEFAULT_USER_PATH).strip()
+    path_str = os.getenv("CONFIG_LOCAL_PATH", str(data_path("config.toml"))).strip()
     path = Path(path_str)
     if not path.is_absolute():
         path = Path(__file__).resolve().parents[5] / path

--- a/app/platform/logging/logger.py
+++ b/app/platform/logging/logger.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from loguru import logger as _loguru_logger
 
+from app.platform.paths import log_dir as get_log_dir
+
 # Re-export as the canonical logger so imports stay uniform.
 logger = _loguru_logger
 
@@ -52,7 +54,7 @@ def setup_logging(
     )
 
     if file_logging:
-        _dir = log_dir or (Path.cwd() / "logs")
+        _dir = log_dir or get_log_dir()
         _dir.mkdir(parents=True, exist_ok=True)
         logger.add(
             str(_dir / "app_{time:YYYY-MM-DD}.log"),

--- a/app/platform/paths.py
+++ b/app/platform/paths.py
@@ -1,0 +1,34 @@
+"""Shared runtime paths derived from environment variables."""
+
+import os
+from pathlib import Path
+
+
+_ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def _resolve_env_path(name: str, default: str) -> Path:
+    raw = os.getenv(name, default).strip() or default
+    path = Path(raw)
+    if not path.is_absolute():
+        path = _ROOT_DIR / path
+    return path
+
+
+def data_dir() -> Path:
+    return _resolve_env_path("DATA_DIR", "data")
+
+
+def log_dir() -> Path:
+    return _resolve_env_path("LOG_DIR", "logs")
+
+
+def data_path(*parts: str) -> Path:
+    return data_dir().joinpath(*parts)
+
+
+def log_path(*parts: str) -> Path:
+    return log_dir().joinpath(*parts)
+
+
+__all__ = ["data_dir", "log_dir", "data_path", "log_path"]

--- a/app/platform/startup/migration.py
+++ b/app/platform/startup/migration.py
@@ -2,21 +2,21 @@
 
 Config migration
 ----------------
-local   : seeds data/config.toml from config.defaults.toml if the file
-          does not exist yet — gives users an editable copy on first run.
-redis / sql : if the backend is empty (version == 0) AND data/config.toml
-          exists, migrates the user overrides into the DB backend.
-          If data/config.toml does not exist either, nothing is written
-          (defaults are always loaded from config.defaults.toml at runtime).
+local   : seeds ``${DATA_DIR}/config.toml`` from ``config.defaults.toml`` if
+          the file does not exist yet — gives users an editable copy on first run.
+redis / sql : if the backend is empty (version == 0) AND
+          ``${DATA_DIR}/config.toml`` exists, migrates the user overrides into
+          the DB backend. If it does not exist either, nothing is written
+          (defaults are always loaded from ``config.defaults.toml`` at runtime).
 
 Account migration
 -----------------
 Runs only when ACCOUNT_STORAGE != "local".
-If data/accounts.db (the previous local SQLite store) exists AND the
+If ``${DATA_DIR}/accounts.db`` (the previous local SQLite store) exists AND the
 target backend is empty (revision == 0), all accounts are copied into the
 new backend — preserving pool, status, quota, usage stats, and timestamps.
 After a successful migration the SQLite file is renamed to
-data/accounts.db.migrated so the same migration is never re-run.
+``${DATA_DIR}/accounts.db.migrated`` so the same migration is never re-run.
 """
 
 from __future__ import annotations
@@ -28,15 +28,16 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from app.platform.paths import data_path
+
 if TYPE_CHECKING:
     from app.control.account.repository import AccountRepository
     from app.platform.config.backends.base import ConfigBackend
 
 _BASE_DIR     = Path(__file__).resolve().parents[3]
-_DATA_DIR     = _BASE_DIR / "data"
 _DEFAULTS_PATH = _BASE_DIR / "config.defaults.toml"
-_USER_CFG_PATH = _DATA_DIR / "config.toml"
-_LOCAL_DB_PATH = _DATA_DIR / "accounts.db"
+_USER_CFG_PATH = data_path("config.toml")
+_LOCAL_DB_PATH = data_path("accounts.db")
 _BATCH         = 500  # accounts per upsert/patch batch
 
 
@@ -64,10 +65,10 @@ async def _migrate_config(backend: "ConfigBackend") -> None:
     backend_name = get_config_backend_name()
 
     if backend_name == "local":
-        # Seed data/config.toml from defaults so users have an editable file.
+        # Seed ${DATA_DIR}/config.toml from defaults so users have an editable file.
         if not _USER_CFG_PATH.exists() and _DEFAULTS_PATH.exists():
             await asyncio.to_thread(shutil.copy2, _DEFAULTS_PATH, _USER_CFG_PATH)
-            logger.info("config: seeded data/config.toml from config.defaults.toml")
+            logger.info("config: seeded {} from config.defaults.toml", _USER_CFG_PATH)
         return
 
     # DB / Redis backends — migrate only if backend is empty.
@@ -79,7 +80,8 @@ async def _migrate_config(backend: "ConfigBackend") -> None:
         if user_data:
             await backend.apply_patch(user_data)
             logger.info(
-                "config: migrated data/config.toml → {} backend ({} keys)",
+                "config: migrated {} -> {} backend ({} keys)",
+                _USER_CFG_PATH,
                 backend_name,
                 _count_keys(user_data),
             )

--- a/app/platform/storage/media_paths.py
+++ b/app/platform/storage/media_paths.py
@@ -2,21 +2,25 @@
 
 from pathlib import Path
 
-_FILES_DIR = Path("data/files")
-_IMAGE_DIR = _FILES_DIR / "images"
-_VIDEO_DIR = _FILES_DIR / "videos"
+from app.platform.paths import data_path
+
+
+def _files_dir() -> Path:
+    return data_path("files")
 
 
 def image_files_dir() -> Path:
     """Return the local image storage directory."""
-    _IMAGE_DIR.mkdir(parents=True, exist_ok=True)
-    return _IMAGE_DIR
+    path = _files_dir() / "images"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def video_files_dir() -> Path:
     """Return the local video storage directory."""
-    _VIDEO_DIR.mkdir(parents=True, exist_ok=True)
-    return _VIDEO_DIR
+    path = _files_dir() / "videos"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 __all__ = ["image_files_dir", "video_files_dir"]

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -95,7 +95,7 @@ async def _download_image_bytes(token: str, url: str) -> tuple[bytes, str]:
 
 
 def _save_image(raw: bytes, mime: str, image_id: str) -> str:
-    """Save raw bytes to data/files/images/, return the file ID."""
+    """Save raw bytes to ``${DATA_DIR}/files/images`` and return the file ID."""
     img_dir = image_files_dir()
     ext = ".png" if "png" in mime else ".jpg"
     path = img_dir / f"{image_id}{ext}"

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -110,7 +110,7 @@ docker compose up -d
 
 ### Vercel
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,ACCOUNT_STORAGE,ACCOUNT_LOCAL_PATH,CONFIG_LOCAL_PATH,ACCOUNT_REDIS_URL,ACCOUNT_MYSQL_URL,ACCOUNT_POSTGRESQL_URL)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/chenyme/grok2api&env=LOG_LEVEL,LOG_FILE_ENABLED,DATA_DIR,LOG_DIR,ACCOUNT_STORAGE,ACCOUNT_REDIS_URL,ACCOUNT_MYSQL_URL,ACCOUNT_POSTGRESQL_URL)
 
 ### Render
 
@@ -156,7 +156,7 @@ docker compose up -d
 | Location | Purpose | Effective Time |
 | :-- | :-- | :-- |
 | `.env` | Pre-start configuration | At service startup |
-| `data/config.toml` | Runtime configuration | Effective immediately after save |
+| `${DATA_DIR}/config.toml` | Runtime configuration | Effective immediately after save |
 | `config.defaults.toml` | Default template | On first initialization |
 
 
@@ -173,8 +173,9 @@ docker compose up -d
 | `SERVER_PORT` | Service port | `8000` |
 | `SERVER_WORKERS` | Granian worker count | `1` |
 | `HOST_PORT` | Docker Compose published host port | `8000` |
+| `DATA_DIR` | Local data directory | `./data` |
+| `LOG_DIR` | Local log directory | `./logs` |
 | `ACCOUNT_STORAGE` | Account storage backend | `local` |
-| `ACCOUNT_LOCAL_PATH` | SQLite path for `local` mode | `data/accounts.db` |
 | `ACCOUNT_REDIS_URL` | Redis DSN for `redis` mode | `""` |
 | `ACCOUNT_MYSQL_URL` | SQLAlchemy DSN for `mysql` mode | `""` |
 | `ACCOUNT_POSTGRESQL_URL` | SQLAlchemy DSN for `postgresql` mode | `""` |

--- a/vercel.json
+++ b/vercel.json
@@ -4,9 +4,9 @@
   "env": {
     "LOG_LEVEL": "INFO",
     "LOG_FILE_ENABLED": "false",
+    "DATA_DIR": "/tmp/data",
+    "LOG_DIR": "/tmp/logs",
     "ACCOUNT_STORAGE": "local",
-    "ACCOUNT_LOCAL_PATH": "/tmp/data/accounts.db",
-    "CONFIG_LOCAL_PATH": "/tmp/data/config.toml",
     "ACCOUNT_REDIS_URL": "redis://localhost:6379/0",
     "ACCOUNT_MYSQL_URL": "",
     "ACCOUNT_POSTGRESQL_URL": ""


### PR DESCRIPTION
## Summary

- 统一运行时本地路径策略，改为由 `DATA_DIR` 和 `LOG_DIR` 统一派生。
- 账号本地库、运行时配置文件、图片/视频本地缓存、调度锁文件和启动迁移路径都自动跟随 `DATA_DIR`，避免不同模块各自写死 `data/`。
- 本地文件日志目录跟随 `LOG_DIR`，并同步更新 `.env.example`、README、英文文档和 Vercel 一键部署默认配置。

## Testing

- 使用 `uv run python -c 'import app.main; print("import-ok")'` 验证应用入口可正常导入。
- 使用临时 `DATA_DIR` 验证 `accounts.db`、图片缓存目录、视频缓存目录和调度锁路径都会随 `DATA_DIR` 变化。
- 使用临时 `LOG_DIR` 验证本地日志目录会随 `LOG_DIR` 变化。
- 检查 Vercel 配置与 README，确认一键部署默认使用 `DATA_DIR=/tmp/data`、`LOG_DIR=/tmp/logs`。

## Related

- NOT
