### PR TITLE
fix: prevent false unsaved changes and default config flash on config…

### DIFF
--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -648,7 +648,7 @@ function applyConfigI18n() {
   SCHEMA = buildSchema();
   if (!_configLoaded) return;
   renderAll();
-  _refreshDirtyState();
+  _refreshDirtyState({ autoNormalizeSelects: false });
 }
 
 // ── API ────────────────────────────────────────────────────────────────────
@@ -908,7 +908,7 @@ function _refreshRow(section, key) {
   if (row) row.classList.toggle('modified', _fullPath(section, key) in _dirty);
 }
 
-function _refreshDirtyState() {
+function _refreshDirtyState({ autoNormalizeSelects = true } = {}) {
   const n = Object.keys(_dirty).length;
   document.getElementById('btn-save').disabled  = n === 0;
   document.getElementById('btn-reset').disabled = n === 0;
@@ -943,7 +943,7 @@ function _refreshDirtyState() {
       const isDisabled = _evalDisabledWhen(o.dataset.disabledWhen);
       o.disabled = isDisabled;
       o.title = isDisabled ? (o.dataset.disabledTip || '') : '';
-      if (isDisabled && o.selected) anyChanged = true;
+      if (autoNormalizeSelects && isDisabled && o.selected) anyChanged = true;
     });
     // If the currently selected option became disabled, switch to first enabled
     if (anyChanged) {
@@ -972,7 +972,7 @@ async function load() {
     _configLoaded = true;
     if (!SCHEMA.length) SCHEMA = buildSchema();
     renderAll();
-    _refreshDirtyState();
+    _refreshDirtyState({ autoNormalizeSelects: false });
   } catch (e) {
     showToast(tr('config.loadFailed', { message: e.message }, `配置加载失败: ${e.message}`), 'error');
   }
@@ -995,7 +995,7 @@ async function doSave() {
     _dirty = {};
     // Re-render to clear modified state
     renderAll();
-    _refreshDirtyState();
+    _refreshDirtyState({ autoNormalizeSelects: false });
     showToast(tr('config.saveSuccess', null, '更改已保存'), 'success');
   } catch (e) {
     showToast(tr('config.saveFailed', { message: e.message }, `保存更改失败: ${e.message}`), 'error');
@@ -1007,7 +1007,7 @@ function doReset() {
   if (!Object.keys(_dirty).length) return;
   _dirty = {};
   renderAll();
-  _refreshDirtyState();
+  _refreshDirtyState({ autoNormalizeSelects: false });
   showToast(tr('config.resetSuccess', null, '未保存的更改已撤销'), 'info');
 }
 

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -602,6 +602,7 @@ let SCHEMA = [];
 let _cfg = {};        // loaded config (nested)
 let _dirty = {};      // { "section.key": newValue }
 let _activeTab = SCHEMA_DEF[0].id;
+let _configLoaded = false;
 
 function tr(key, params, fallback) {
   const value = t(key, params);
@@ -645,6 +646,7 @@ function buildSchema() {
 function applyConfigI18n() {
   document.title = tr('config.pageTitle', null, 'Grok2API - 配置管理');
   SCHEMA = buildSchema();
+  if (!_configLoaded) return;
   renderAll();
   _refreshDirtyState();
 }
@@ -966,6 +968,8 @@ function _refreshDirtyState() {
 async function load() {
   try {
     _cfg = await _api('GET', '/config');
+    _dirty = {};
+    _configLoaded = true;
     if (!SCHEMA.length) SCHEMA = buildSchema();
     renderAll();
     _refreshDirtyState();
@@ -1011,8 +1015,6 @@ function doReset() {
 (async () => {
   try {
     SCHEMA = buildSchema();
-    renderAll();
-    _refreshDirtyState();
 
     waitI18n().then(() => {
       applyConfigI18n();


### PR DESCRIPTION
# Fix false "unsaved changes" warning on admin config page


## Summary

Fix: Added a _configLoaded guard flag that prevents rendering and dirty-state updates until the actual config is loaded. Reset _dirty and set the flag to true only after the server responds. Skip i18n-driven re-renders if config is not yet loaded. Removed the pre-load render from the bootstrap sequence.

## Changes:

- [config.html]
  - Added `let _configLoaded` = false state flag
  - Wrapped logic in `applyConfigI18n()` with `if (!_configLoaded) return`
  - Reset `_dirty = {} `and set `_configLoaded = true `
  - Removed `renderAll() `+ `_refreshDirtyState()` from startup sequence
## Testing
- Locally navigate between admin pages (Account → Config → Cache → Config)
- Verify no false "unsaved changes" alert appears on entry
- Verify config values load without any default-value flash
- Edit a config field, save, then navigate away—confirm no false unsaved warning