### PR TITLE
fix: share SQL engine during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ docker compose up -d
 | `ACCOUNT_REDIS_URL` | `redis` 模式 Redis DSN | `""` |
 | `ACCOUNT_MYSQL_URL` | `mysql` 模式 SQLAlchemy DSN | `""` |
 | `ACCOUNT_POSTGRESQL_URL` | `postgresql` 模式 SQLAlchemy DSN | `""` |
+| `ACCOUNT_SQL_POOL_SIZE` | SQL 连接池核心连接数 | `5` |
+| `ACCOUNT_SQL_MAX_OVERFLOW` | SQL 连接池最大溢出连接数 | `10` |
+| `ACCOUNT_SQL_POOL_TIMEOUT` | 等待连接池空闲连接的超时时间（秒） | `30` |
+| `ACCOUNT_SQL_POOL_RECYCLE` | 连接最大复用时间（秒），超时后自动重连 | `1800` |
 
 ### 系统配置项
 

--- a/app/control/account/backends/factory.py
+++ b/app/control/account/backends/factory.py
@@ -132,7 +132,7 @@ def _make_sql(dialect: str) -> AccountRepository:
     else:
         url    = _get_env("ACCOUNT_POSTGRESQL_URL")
         engine = create_pgsql_engine(url)
-    return SqlAccountRepository(engine, dialect=dialect)
+    return SqlAccountRepository(engine, dialect=dialect, dispose_engine=False)
 
 
 __all__ = ["create_repository", "describe_repository_target", "get_repository_backend"]

--- a/app/control/account/backends/sql.py
+++ b/app/control/account/backends/sql.py
@@ -5,7 +5,9 @@ only the DDL fragments and upsert syntax differ.
 """
 
 import json
+import os
 import ssl
+from threading import Lock
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
@@ -135,6 +137,10 @@ _MYSQL_SSL_MODE_ALIASES: dict[str, str] = {
     "verify_identity": "verify_identity",
 }
 
+_ENGINE_CACHE_LOCK = Lock()
+_ENGINE_CACHE: dict[tuple[str, str], AsyncEngine] = {}
+_ENGINE_KEYS_BY_ID: dict[int, set[tuple[str, str]]] = {}
+
 
 def _normalize_sql_url(dialect: str, url: str) -> str:
     """Rewrite SQL URLs to the async SQLAlchemy dialect form."""
@@ -155,6 +161,16 @@ def _normalize_sql_url(dialect: str, url: str) -> str:
     if url.startswith("pgsql://"):
         return f"postgresql+asyncpg://{url[len('pgsql://') :]}"
     return url
+
+
+def _get_env_int(name: str, default: int, *, minimum: int = 0) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return default
 
 
 def _normalize_ssl_mode(dialect: str, raw_mode: str) -> str:
@@ -334,6 +350,43 @@ def _prepare_sql_url_and_connect_args(
     return cleaned_url, _build_sql_connect_args(dialect, ssl_options)
 
 
+def _sql_engine_kwargs(connect_args: dict[str, Any] | None) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "pool_size": _get_env_int("ACCOUNT_SQL_POOL_SIZE", 1, minimum=1),
+        "max_overflow": _get_env_int("ACCOUNT_SQL_MAX_OVERFLOW", 0, minimum=0),
+        "pool_timeout": _get_env_int("ACCOUNT_SQL_POOL_TIMEOUT", 30, minimum=1),
+        "pool_recycle": _get_env_int("ACCOUNT_SQL_POOL_RECYCLE", 1800, minimum=0),
+        "pool_pre_ping": True,
+        "pool_use_lifo": True,
+    }
+    if connect_args:
+        kwargs["connect_args"] = connect_args
+    return kwargs
+
+
+def _get_or_create_engine(
+    cache_key: tuple[str, str],
+    normalized_url: str,
+    connect_args: dict[str, Any] | None,
+) -> AsyncEngine:
+    with _ENGINE_CACHE_LOCK:
+        engine = _ENGINE_CACHE.get(cache_key)
+        if engine is not None:
+            return engine
+
+        engine = create_async_engine(normalized_url, **_sql_engine_kwargs(connect_args))
+        _ENGINE_CACHE[cache_key] = engine
+        _ENGINE_KEYS_BY_ID.setdefault(id(engine), set()).add(cache_key)
+        return engine
+
+
+def _evict_cached_engine(engine: AsyncEngine) -> None:
+    with _ENGINE_CACHE_LOCK:
+        for key in _ENGINE_KEYS_BY_ID.pop(id(engine), set()):
+            if _ENGINE_CACHE.get(key) is engine:
+                _ENGINE_CACHE.pop(key, None)
+
+
 def _row_to_record(row: Any) -> AccountRecord:
     d = dict(row._mapping)
     d["tags"]  = json.loads(d.get("tags")  or "[]")
@@ -352,10 +405,17 @@ def _row_to_record(row: Any) -> AccountRecord:
 class SqlAccountRepository:
     """Async SQLAlchemy-based repository for MySQL / PostgreSQL."""
 
-    def __init__(self, engine: AsyncEngine, *, dialect: str = "mysql") -> None:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        dialect: str = "mysql",
+        dispose_engine: bool = True,
+    ) -> None:
         self._engine  = engine
         self._dialect = dialect   # "mysql" | "postgresql"
         self._session = async_sessionmaker(engine, expire_on_commit=False)
+        self._dispose_engine = dispose_engine
 
     # ------------------------------------------------------------------
     # Revision helpers (run inside a transaction)
@@ -680,31 +740,23 @@ class SqlAccountRepository:
 
     async def close(self) -> None:
         """Dispose the SQLAlchemy connection pool."""
-        await self._engine.dispose()
+        if self._dispose_engine:
+            _evict_cached_engine(self._engine)
+            await self._engine.dispose()
 
 
 def create_mysql_engine(url: str) -> AsyncEngine:
     """Create an async SQLAlchemy engine for MySQL."""
-    normalized_url, connect_args = _prepare_sql_url_and_connect_args("mysql", url)
-    return create_async_engine(
-        normalized_url,
-        pool_size=10,
-        max_overflow=20,
-        pool_pre_ping=True,
-        **({"connect_args": connect_args} if connect_args else {}),
-    )
+    raw_url = (url or "").strip()
+    normalized_url, connect_args = _prepare_sql_url_and_connect_args("mysql", raw_url)
+    return _get_or_create_engine(("mysql", raw_url), normalized_url, connect_args)
 
 
 def create_pgsql_engine(url: str) -> AsyncEngine:
     """Create an async SQLAlchemy engine for PostgreSQL."""
-    normalized_url, connect_args = _prepare_sql_url_and_connect_args("postgresql", url)
-    return create_async_engine(
-        normalized_url,
-        pool_size=10,
-        max_overflow=20,
-        pool_pre_ping=True,
-        **({"connect_args": connect_args} if connect_args else {}),
-    )
+    raw_url = (url or "").strip()
+    normalized_url, connect_args = _prepare_sql_url_and_connect_args("postgresql", raw_url)
+    return _get_or_create_engine(("postgresql", raw_url), normalized_url, connect_args)
 
 
 __all__ = ["SqlAccountRepository", "create_mysql_engine", "create_pgsql_engine"]

--- a/app/control/account/backends/sql.py
+++ b/app/control/account/backends/sql.py
@@ -138,8 +138,8 @@ _MYSQL_SSL_MODE_ALIASES: dict[str, str] = {
 }
 
 _ENGINE_CACHE_LOCK = Lock()
-_ENGINE_CACHE: dict[tuple[str, str], AsyncEngine] = {}
-_ENGINE_KEYS_BY_ID: dict[int, set[tuple[str, str]]] = {}
+_ENGINE_CACHE: dict[tuple[str, str, str], AsyncEngine] = {}
+_ENGINE_KEYS_BY_ID: dict[int, set[tuple[str, str, str]]] = {}
 
 
 def _normalize_sql_url(dialect: str, url: str) -> str:
@@ -352,8 +352,8 @@ def _prepare_sql_url_and_connect_args(
 
 def _sql_engine_kwargs(connect_args: dict[str, Any] | None) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
-        "pool_size": _get_env_int("ACCOUNT_SQL_POOL_SIZE", 1, minimum=1),
-        "max_overflow": _get_env_int("ACCOUNT_SQL_MAX_OVERFLOW", 0, minimum=0),
+        "pool_size": _get_env_int("ACCOUNT_SQL_POOL_SIZE", 5, minimum=1),
+        "max_overflow": _get_env_int("ACCOUNT_SQL_MAX_OVERFLOW", 10, minimum=0),
         "pool_timeout": _get_env_int("ACCOUNT_SQL_POOL_TIMEOUT", 30, minimum=1),
         "pool_recycle": _get_env_int("ACCOUNT_SQL_POOL_RECYCLE", 1800, minimum=0),
         "pool_pre_ping": True,
@@ -365,7 +365,7 @@ def _sql_engine_kwargs(connect_args: dict[str, Any] | None) -> dict[str, Any]:
 
 
 def _get_or_create_engine(
-    cache_key: tuple[str, str],
+    cache_key: tuple[str, str, str],
     normalized_url: str,
     connect_args: dict[str, Any] | None,
 ) -> AsyncEngine:
@@ -745,18 +745,22 @@ class SqlAccountRepository:
             await self._engine.dispose()
 
 
+def _engine_cache_key(dialect: str, normalized_url: str, connect_args: dict[str, Any] | None) -> tuple[str, str, str]:
+    """Build a stable cache key from the normalized URL and connect args."""
+    args_key = str(sorted(connect_args.items(), key=lambda kv: kv[0])) if connect_args else ""
+    return (dialect, normalized_url, args_key)
+
+
 def create_mysql_engine(url: str) -> AsyncEngine:
     """Create an async SQLAlchemy engine for MySQL."""
-    raw_url = (url or "").strip()
-    normalized_url, connect_args = _prepare_sql_url_and_connect_args("mysql", raw_url)
-    return _get_or_create_engine(("mysql", raw_url), normalized_url, connect_args)
+    normalized_url, connect_args = _prepare_sql_url_and_connect_args("mysql", (url or "").strip())
+    return _get_or_create_engine(_engine_cache_key("mysql", normalized_url, connect_args), normalized_url, connect_args)
 
 
 def create_pgsql_engine(url: str) -> AsyncEngine:
     """Create an async SQLAlchemy engine for PostgreSQL."""
-    raw_url = (url or "").strip()
-    normalized_url, connect_args = _prepare_sql_url_and_connect_args("postgresql", raw_url)
-    return _get_or_create_engine(("postgresql", raw_url), normalized_url, connect_args)
+    normalized_url, connect_args = _prepare_sql_url_and_connect_args("postgresql", (url or "").strip())
+    return _get_or_create_engine(_engine_cache_key("postgresql", normalized_url, connect_args), normalized_url, connect_args)
 
 
 __all__ = ["SqlAccountRepository", "create_mysql_engine", "create_pgsql_engine"]

--- a/app/platform/config/backends/factory.py
+++ b/app/platform/config/backends/factory.py
@@ -73,7 +73,7 @@ def _make_sql(dialect: str) -> ConfigBackend:
             raise ValueError("PostgreSQL config backend requires ACCOUNT_POSTGRESQL_URL")
         engine = create_pgsql_engine(url)
 
-    return SqlConfigBackend(engine, dialect=dialect)
+    return SqlConfigBackend(engine, dialect=dialect, dispose_engine=False)
 
 
 __all__ = ["create_config_backend", "get_config_backend_name"]

--- a/app/platform/config/backends/sql.py
+++ b/app/platform/config/backends/sql.py
@@ -29,10 +29,17 @@ class SqlConfigBackend(ConfigBackend):
     Version token is stored as the integer value of the ``__version__`` row.
     """
 
-    def __init__(self, engine: AsyncEngine, *, dialect: str = "postgresql") -> None:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        dialect: str = "postgresql",
+        dispose_engine: bool = True,
+    ) -> None:
         self._engine  = engine
         self._dialect = dialect  # "mysql" | "postgresql"
         self._ready   = False
+        self._dispose_engine = dispose_engine
 
     async def _ensure_table(self) -> None:
         if self._ready:
@@ -117,4 +124,5 @@ class SqlConfigBackend(ConfigBackend):
             )
 
     async def close(self) -> None:
-        await self._engine.dispose()
+        if self._dispose_engine:
+            await self._engine.dispose()

--- a/app/platform/config/backends/sql.py
+++ b/app/platform/config/backends/sql.py
@@ -125,4 +125,6 @@ class SqlConfigBackend(ConfigBackend):
 
     async def close(self) -> None:
         if self._dispose_engine:
+            from app.control.account.backends.sql import _evict_cached_engine
+            _evict_cached_engine(self._engine)
             await self._engine.dispose()

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -179,6 +179,10 @@ docker compose up -d
 | `ACCOUNT_REDIS_URL` | Redis DSN for `redis` mode | `""` |
 | `ACCOUNT_MYSQL_URL` | SQLAlchemy DSN for `mysql` mode | `""` |
 | `ACCOUNT_POSTGRESQL_URL` | SQLAlchemy DSN for `postgresql` mode | `""` |
+| `ACCOUNT_SQL_POOL_SIZE` | Core connection pool size for SQL backends | `5` |
+| `ACCOUNT_SQL_MAX_OVERFLOW` | Maximum overflow connections above pool size | `10` |
+| `ACCOUNT_SQL_POOL_TIMEOUT` | Seconds to wait for a free connection from the pool | `30` |
+| `ACCOUNT_SQL_POOL_RECYCLE` | Max connection lifetime in seconds before reconnect | `1800` |
 
 ### System Configuration Groups
 

--- a/tests/test_sql_engine_factory.py
+++ b/tests/test_sql_engine_factory.py
@@ -1,0 +1,115 @@
+import asyncio
+import os
+import ssl
+import unittest
+from unittest.mock import patch
+
+from app.control.account.backends import sql as sql_backend
+from app.platform.config.backends.sql import SqlConfigBackend
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self.dispose_calls = 0
+
+    async def dispose(self) -> None:
+        self.dispose_calls += 1
+
+
+class SqlEngineFactoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        sql_backend._ENGINE_CACHE.clear()
+        sql_backend._ENGINE_KEYS_BY_ID.clear()
+
+    def tearDown(self) -> None:
+        sql_backend._ENGINE_CACHE.clear()
+        sql_backend._ENGINE_KEYS_BY_ID.clear()
+
+    def test_create_pgsql_engine_normalizes_ssl_and_pool_settings(self) -> None:
+        sentinel = object()
+        with patch.dict(
+            os.environ,
+            {
+                "ACCOUNT_SQL_POOL_SIZE": "2",
+                "ACCOUNT_SQL_MAX_OVERFLOW": "1",
+                "ACCOUNT_SQL_POOL_TIMEOUT": "15",
+                "ACCOUNT_SQL_POOL_RECYCLE": "600",
+            },
+            clear=False,
+        ):
+            with patch.object(sql_backend, "create_async_engine", return_value=sentinel) as create_engine:
+                engine = sql_backend.create_pgsql_engine(
+                    "postgres://user:pass@example.com:5432/defaultdb?sslmode=require&application_name=grok2api"
+                )
+
+        self.assertIs(engine, sentinel)
+        create_engine.assert_called_once()
+        args, kwargs = create_engine.call_args
+        self.assertEqual(
+            args[0],
+            "postgresql+asyncpg://user:pass@example.com:5432/defaultdb?application_name=grok2api",
+        )
+        self.assertEqual(kwargs["connect_args"], {"ssl": "require"})
+        self.assertEqual(kwargs["pool_size"], 2)
+        self.assertEqual(kwargs["max_overflow"], 1)
+        self.assertEqual(kwargs["pool_timeout"], 15)
+        self.assertEqual(kwargs["pool_recycle"], 600)
+        self.assertTrue(kwargs["pool_pre_ping"])
+        self.assertTrue(kwargs["pool_use_lifo"])
+
+    def test_create_mysql_engine_moves_ssl_mode_to_ssl_context(self) -> None:
+        sentinel = object()
+        with patch.object(sql_backend, "create_async_engine", return_value=sentinel) as create_engine:
+            engine = sql_backend.create_mysql_engine(
+                "mysql://user:pass@example.com:3306/defaultdb?ssl-mode=REQUIRED&charset=utf8mb4"
+            )
+
+        self.assertIs(engine, sentinel)
+        create_engine.assert_called_once()
+        args, kwargs = create_engine.call_args
+        self.assertEqual(
+            args[0],
+            "mysql+aiomysql://user:pass@example.com:3306/defaultdb?charset=utf8mb4",
+        )
+        self.assertIsInstance(kwargs["connect_args"]["ssl"], ssl.SSLContext)
+        self.assertFalse(kwargs["connect_args"]["ssl"].check_hostname)
+        self.assertEqual(kwargs["connect_args"]["ssl"].verify_mode, ssl.CERT_NONE)
+
+    def test_create_pgsql_engine_reuses_shared_engine_for_same_url(self) -> None:
+        sentinel = object()
+        with patch.object(sql_backend, "create_async_engine", return_value=sentinel) as create_engine:
+            engine_a = sql_backend.create_pgsql_engine(
+                "postgres://user:pass@example.com:5432/defaultdb?sslmode=require"
+            )
+            engine_b = sql_backend.create_pgsql_engine(
+                "postgres://user:pass@example.com:5432/defaultdb?sslmode=require"
+            )
+
+        self.assertIs(engine_a, engine_b)
+        create_engine.assert_called_once()
+
+    def test_repository_close_disposes_and_evicts_cached_engine(self) -> None:
+        engine = _DummyEngine()
+        with patch.object(sql_backend, "create_async_engine", return_value=engine):
+            shared = sql_backend.create_pgsql_engine(
+                "postgres://user:pass@example.com:5432/defaultdb?sslmode=require"
+            )
+
+        repo = sql_backend.SqlAccountRepository(shared, dialect="postgresql", dispose_engine=True)
+        asyncio.run(repo.close())
+
+        self.assertEqual(engine.dispose_calls, 1)
+        self.assertEqual(sql_backend._ENGINE_CACHE, {})
+        self.assertEqual(sql_backend._ENGINE_KEYS_BY_ID, {})
+
+    def test_sql_config_backend_can_skip_disposing_shared_engine(self) -> None:
+        engine = _DummyEngine()
+        backend = SqlConfigBackend(engine, dialect="postgresql", dispose_engine=False)
+
+        asyncio.run(backend.close())
+
+        self.assertEqual(engine.dispose_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- share the SQLAlchemy async engine between config and account startup when they use the same SQL DSN
- reduce default SQL pool pressure for small PostgreSQL plans by using conservative pool defaults
- add regression tests for SSL normalization, shared-engine reuse, and dispose ownership

## Testing
- uv run ruff check app/control/account/backends/sql.py app/platform/config/backends/sql.py app/platform/config/backends/factory.py tests/test_sql_engine_factory.py
- uv run python -m unittest tests.test_sql_engine_factory
- deployed and tested successfully on Render
