### PR TITLE
feat: 新增 auto/fast/expert/heavy 简洁模型，优先使用高等级号池

### DIFF
--- a/app/control/model/registry.py
+++ b/app/control/model/registry.py
@@ -24,7 +24,13 @@ MODELS: tuple[ModelSpec, ...] = (
     ModelSpec("grok-4.20-0309-heavy",                   ModeId.AUTO,   Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Heavy"),
     ModelSpec("grok-4.20-0309-reasoning-heavy",         ModeId.EXPERT, Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning Heavy"),
     ModelSpec("grok-4.20-multi-agent-0309",             ModeId.HEAVY,  Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Multi-Agent 0309"),
-    
+
+    # --- 硬优先级反向选池 (heavy → super → basic) ---
+    ModelSpec("grok-4.20-fast",                        ModeId.FAST,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Fast",          prefer_best=True),
+    ModelSpec("grok-4.20-auto",                        ModeId.AUTO,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Auto",          prefer_best=True),
+    ModelSpec("grok-4.20-expert",                      ModeId.EXPERT, Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Expert",        prefer_best=True),
+    ModelSpec("grok-4.20-heavy",                       ModeId.HEAVY,  Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Heavy",         prefer_best=True),
+
     # === Image ==============================================================
 
     # Basic+

--- a/app/control/model/spec.py
+++ b/app/control/model/spec.py
@@ -9,12 +9,17 @@ from .enums import Capability, ModeId, Tier
 class ModelSpec:
     """Immutable descriptor for one model variant.
 
-    ``model_name`` is the public-facing identifier used in API requests.
-    ``mode_id``    is the upstream ``modeId`` value (auto / fast / expert).
-    ``tier``       determines which account pool is used (basic / super).
-    ``capability`` is a bitmask of supported operations.
-    ``enabled``    gates whether the model appears in ``/v1/models``.
+    ``model_name``  is the public-facing identifier used in API requests.
+    ``mode_id``     is the upstream ``modeId`` value (auto / fast / expert).
+    ``tier``        determines which account pool is used (basic / super).
+                    When ``prefer_best`` is True, ``tier`` only affects
+                    ``pool_name()``/``pool_id()``; the actual selection order
+                    is reversed (heavy → super → basic).
+    ``capability``  is a bitmask of supported operations.
+    ``enabled``     gates whether the model appears in ``/v1/models``.
     ``public_name`` is the human-readable display name.
+    ``prefer_best`` when True, reverses pool priority to try higher-tier
+                    pools first (hard priority, not soft preference).
     """
 
     model_name:  str
@@ -23,6 +28,7 @@ class ModelSpec:
     capability:  Capability
     enabled:     bool
     public_name: str
+    prefer_best: bool = False
 
     # --- convenience predicates ---
 
@@ -42,14 +48,27 @@ class ModelSpec:
         """Return the integer PoolId for the dataplane account table."""
         return int(self.tier)
 
+    # 返回按优先级排序的候选池 ID
     def pool_candidates(self) -> tuple[int, ...]:
         """Return pool IDs to try in priority order.
 
-        A higher-tier account can always serve a lower-tier model:
+        When ``prefer_best`` is True the order is reversed so that the
+        highest-tier pool is attempted first (hard priority — the first
+        pool with any available account wins; lower pools are only reached
+        when all accounts in higher pools are exhausted).
+
+        Default (prefer_best=False):
           BASIC tier  → try basic first, then super, then heavy
           SUPER tier  → try super first, then heavy
           HEAVY tier  → heavy only
+
+        Reversed (prefer_best=True):
+          non-HEAVY   → try heavy first, then super, then basic
+          HEAVY tier  → heavy only
         """
+        if self.prefer_best:
+            if self.tier == Tier.HEAVY:  return (2,)       # heavy only
+            return (2, 1, 0)                                # heavy, super, basic
         if self.tier == Tier.BASIC:  return (0, 1, 2)   # basic, super, heavy
         if self.tier == Tier.SUPER:  return (1, 2)       # super, heavy
         return (2,)                                       # heavy only


### PR DESCRIPTION
## Summary

新增 `prefer_best` 标志位和 4 个 prefer-best 聊天模型，反转账号池选择顺序（heavy → super → basic），让请求优先消耗高等级账号。

## 设计动机

1. 现有模型列表带版本后缀（如 `0309`），数量多且命名相似，选起来费劲。干脆对应 Grok 官网四个档位（auto/fast/expert/heavy）各出一个简洁别名，一眼就知道选哪个。
2. auto/fast/expert 这三个模式在 basic、super、heavy 三个等级的号池里都有，也就是说不管你用哪个等级的账号都能跑这三个模式。既然如此，大部分用户肯定想优先用到最强的那个——所以反转选池顺序，heavy 先上，用完再降级到 super、basic，高级账号不白放着。
3. 完全向后兼容：原有 15 个模型 `prefer_best` 默认 `False`，选池逻辑不变，零影响。

## 选池对比

| Tier | 默认模型 `prefer_best=False` | Prefer-Best 模型 `prefer_best=True` |
|------|------------------------------|--------------------------------------|
| BASIC | basic → super → heavy | **heavy → super → basic** |
| SUPER | super → heavy | **heavy → super → basic** |
| HEAVY | heavy only | heavy only（无变化） |

## 新增模型

| 模型名 | modeId | 选池顺序 | 说明 |
|--------|--------|----------|------|
| `grok-4.20-fast` | FAST | heavy → super → basic | 快速对话，优先高级池 |
| `grok-4.20-auto` | AUTO | heavy → super → basic | 自动模式，优先高级池 |
| `grok-4.20-expert` | EXPERT | heavy → super → basic | 专家推理，优先高级池 |
| `grok-4.20-heavy` | HEAVY | heavy only | Heavy 独占 |

- 无版本后缀，作为 "latest" 别名使用
- 原有 15 个模型行为完全不变（`prefer_best` 默认 `False`）

## 变更文件

| 文件 | 变更 |
|------|------|
| `app/control/model/spec.py` | 新增 `prefer_best` 字段 + 反向 `pool_candidates()` 逻辑 |
| `app/control/model/registry.py` | 注册 4 个 prefer-best 模型 |

## Test Plan

- [x] 分别调用 `grok-4.20-auto`/`grok-4.20-fast`/`grok-4.20-expert`，验证选池顺序为 heavy → super → basic
- [x] 调用 `grok-4.20-heavy`，验证只走 heavy only 号池
- [x] 调用原有模型（如 `grok-4.20-0309`），验证选池行为不变
- [x] heavy 池账号全部耗尽时，prefer-best 模型降级到 super → basic
- [x] 三个池全部耗尽时，返回正常的无可用账号错误（不死循环）
