### PR TITLE
feat: Enhance proxy clearance management with scheduler and warm-up functionality

### DIFF
--- a/app/control/proxy/__init__.py
+++ b/app/control/proxy/__init__.py
@@ -32,6 +32,9 @@ class ProxyDirectory:
         self._resource_nodes: list[EgressNode]          = []  # for media downloads
         self._bundles:        dict[str, ClearanceBundle] = {}
         self._lock            = asyncio.Lock()
+        # Single-flight guard: at most one FlareSolverr call per affinity key.
+        # Other coroutines wait on the Event until the active refresh completes.
+        self._refresh_events: dict[str, asyncio.Event]  = {}
         self._manual          = ManualClearanceProvider()
         self._flare           = FlareSolverrClearanceProvider()
         self._egress_mode:    EgressMode    = EgressMode.DIRECT
@@ -151,24 +154,77 @@ class ProxyDirectory:
         if self._clearance_mode == ClearanceMode.NONE:
             return None
 
-        async with self._lock:
-            existing = self._bundles.get(affinity_key)
-            if existing and existing.state.value == 0:   # VALID
-                return existing
+        # Single-flight: only one coroutine fetches clearance per affinity key.
+        # Concurrent callers wait on the Event and retry once it fires.
+        while True:
+            async with self._lock:
+                bundle = self._bundles.get(affinity_key)
+                if bundle and bundle.state.value == 0:   # VALID
+                    return bundle
+                event = self._refresh_events.get(affinity_key)
+                if event is None:
+                    # This coroutine wins the right to refresh.
+                    event = asyncio.Event()
+                    self._refresh_events[affinity_key] = event
+                    break
+            # Another coroutine is already refreshing — wait for it, then retry.
+            await event.wait()
 
-        if self._clearance_mode == ClearanceMode.MANUAL:
-            bundle = self._manual.build_bundle(affinity_key=affinity_key)
-        else:
-            bundle = await self._flare.refresh_bundle(
-                affinity_key = affinity_key,
+        try:
+            if self._clearance_mode == ClearanceMode.MANUAL:
+                bundle = self._manual.build_bundle(affinity_key=affinity_key)
+            else:
+                bundle = await self._flare.refresh_bundle(
+                    affinity_key = affinity_key,
+                    proxy_url    = proxy_url,
+                )
+            if bundle:
+                async with self._lock:
+                    self._bundles[affinity_key] = bundle
+            return bundle
+        finally:
+            async with self._lock:
+                self._refresh_events.pop(affinity_key, None)
+            event.set()  # Wake all waiters so they retry with the new bundle.
+
+    # ------------------------------------------------------------------
+    # Clearance lifecycle helpers (used by ProxyClearanceScheduler)
+    # ------------------------------------------------------------------
+
+    async def invalidate_clearance(self) -> None:
+        """Mark all cached clearance bundles as invalid.
+
+        The next ``acquire()`` call for each affinity key will trigger a fresh
+        FlareSolverr fetch (serialised by the single-flight guard).
+        """
+        from .models import ClearanceBundleState
+        async with self._lock:
+            self._bundles = {
+                k: b.model_copy(update={"state": ClearanceBundleState.INVALID})
+                for k, b in self._bundles.items()
+            }
+        logger.debug("clearance bundles invalidated: count={}", len(self._bundles))
+
+    async def warm_up(self) -> None:
+        """Pre-fetch clearance bundles for all configured affinity keys.
+
+        Called once at startup and after each scheduled invalidation so that
+        the first real request does not have to wait for FlareSolverr.
+        """
+        if self._clearance_mode == ClearanceMode.NONE:
+            return
+        async with self._lock:
+            nodes = list(self._nodes)
+        affinity_keys = (
+            [(n.proxy_url or "direct", n.proxy_url or "") for n in nodes]
+            if nodes
+            else [("direct", "")]
+        )
+        for affinity, proxy_url in affinity_keys:
+            await self._get_or_build_bundle(
+                affinity_key = affinity,
                 proxy_url    = proxy_url,
             )
-
-        if bundle:
-            async with self._lock:
-                self._bundles[affinity_key] = bundle
-
-        return bundle
 
     # ------------------------------------------------------------------
     # Properties

--- a/app/control/proxy/scheduler.py
+++ b/app/control/proxy/scheduler.py
@@ -33,6 +33,8 @@ class ProxyClearanceScheduler:
         logger.info("proxy clearance scheduler stopped")
 
     async def _loop(self) -> None:
+        # Warm up immediately on start so the first request doesn't block.
+        await self._warm_up()
         while self._running:
             try:
                 interval = self._get_interval()
@@ -50,10 +52,19 @@ class ProxyClearanceScheduler:
                 )
                 await asyncio.sleep(60)
 
-    async def _refresh(self) -> None:
-        """Reload proxy configuration (which triggers bundle refresh)."""
+    async def _warm_up(self) -> None:
+        """Pre-fetch clearance bundles without invalidating existing ones."""
         try:
-            await self._directory.load()
+            await self._directory.warm_up()
+            logger.debug("proxy clearance warm-up completed")
+        except Exception as exc:
+            logger.warning("proxy clearance warm-up failed: error={}", exc)
+
+    async def _refresh(self) -> None:
+        """Invalidate cached clearance bundles and pre-fetch fresh ones."""
+        try:
+            await self._directory.invalidate_clearance()
+            await self._directory.warm_up()
             logger.debug("proxy clearance refresh completed")
         except Exception as exc:
             logger.warning("proxy clearance refresh failed: error={}", exc)

--- a/app/main.py
+++ b/app/main.py
@@ -205,10 +205,14 @@ async def lifespan(app: FastAPI):
             _SYNC_IDLE_INTERVAL,
         )
 
-    # 5. Initialise proxy directory.
+    # 5. Initialise proxy directory and start clearance refresh scheduler.
     from app.control.proxy import get_proxy_directory
+    from app.control.proxy.scheduler import ProxyClearanceScheduler
 
-    await get_proxy_directory()
+    proxy_dir = await get_proxy_directory()
+    proxy_scheduler = ProxyClearanceScheduler(proxy_dir)
+    if is_leader:
+        proxy_scheduler.start()
 
     logger.info("application startup completed")
     yield
@@ -225,6 +229,7 @@ async def lifespan(app: FastAPI):
 
     if is_leader:
         scheduler.stop()
+        proxy_scheduler.stop()
         _release_scheduler_lock()
 
     set_refresh_service(None)


### PR DESCRIPTION
## Summary

- Add a single-flight guard for proxy clearance refreshes so only one coroutine calls FlareSolverr per affinity key while concurrent requests wait for the same result.
- Add explicit clearance lifecycle helpers to invalidate and warm up cached bundles, and update the proxy clearance scheduler to prewarm on startup and refresh by invalidating then rebuilding bundles.
- Start the proxy clearance scheduler during app startup on the leader worker so FlareSolverr-managed clearance stays fresh in the background and the first real request is less likely to block on clearance generation.

## Testing

- `uv run python -c 'from app.control.proxy import ProxyDirectory; from app.control.proxy.scheduler import ProxyClearanceScheduler; d = ProxyDirectory(); s = ProxyClearanceScheduler(d); print("proxy scheduler import ok")'`
- `uv run python -c 'from app.main import create_app; app = create_app(); print(app.title)'`

## Related

- #448 
