### PR TITLE
fix: Update invalid credentials checks and error status handling

### DIFF
--- a/app/dataplane/reverse/protocol/xai_usage.py
+++ b/app/dataplane/reverse/protocol/xai_usage.py
@@ -196,6 +196,7 @@ def is_invalid_credentials_body(body: str) -> bool:
     text = str(body or "").lower()
     return (
         "invalid-credentials" in text
+        or "bad-credentials" in text
         or "failed to look up session id" in text
         or "blocked-user" in text
         or "email-domain-rejected" in text
@@ -210,7 +211,7 @@ def is_invalid_credentials_error(exc: BaseException) -> bool:
     """Return whether *exc* indicates the account is invalid or blocked."""
     if not isinstance(exc, UpstreamError):
         return False
-    if exc.status not in (400, 403):
+    if exc.status not in (400, 401, 403):
         return False
     return is_invalid_credentials_body(str(exc.details.get("body", "") or ""))
 


### PR DESCRIPTION
## Summary

- Expand invalid-credentials detection in `app/dataplane/reverse/protocol/xai_usage.py` to treat `"bad-credentials"` as an invalid account signal in addition to the existing blocked / revoked / expired markers.
- Update `is_invalid_credentials_error` so `401` responses are handled the same as `400` and `403` when the upstream body indicates credential failure.
- This keeps account invalidation logic aligned with newer upstream error payloads, so bad tokens are classified as account problems instead of being misread as proxy or transport failures.

## Testing

- `uv run python -c 'from app.dataplane.reverse.protocol.xai_usage import is_invalid_credentials_body; assert is_invalid_credentials_body("bad-credentials"); print("bad-credentials detection ok")'`
  - 输出：`bad-credentials detection ok`
- `uv run python -c 'from app.dataplane.reverse.protocol.xai_usage import is_invalid_credentials_error; from app.platform.errors import UpstreamError; exc = UpstreamError("upstream", status=401, body="bad-credentials"); assert is_invalid_credentials_error(exc); print("401 invalid credentials detection ok")'`
  - 输出：`401 invalid credentials detection ok`

## Related

- #452 