### PR TITLE
feat: reduce webui/admin rerenders and cache header metadata

### DIFF
--- a/app/statics/admin/account.html
+++ b/app/statics/admin/account.html
@@ -1062,6 +1062,15 @@ const refreshingTokens = new Set();
 let _cb = null;
 let _editingToken = '';
 let _filterMenuBound = false;
+let _tokenViewVersion = 0;
+let _tokenViewCacheKey = '';
+let _tokenViewCache = null;
+
+function invalidateTokenView() {
+  _tokenViewVersion += 1;
+  _tokenViewCacheKey = '';
+  _tokenViewCache = null;
+}
 
 function tr(key, params, fallback) {
   const value = t(key, params);
@@ -1132,12 +1141,91 @@ async function load() {
       ? data.tokens
       : Object.entries(data.tokens || {}).flatMap(([pool, items]) =>
           Array.isArray(items) ? items.map(t => ({ ...t, pool: t.pool || pool })) : []);
+    invalidateTokenView();
     render();
   } catch (e) { showToast(`${tr('account.loadFailed', null, '加载失败')}: ${e.message}`, 'error'); }
 }
 
 // ── Render ─────────────────────────────────────────────────────────────────
-function render() { renderStats(); renderFilters(); renderTable(); }
+function render() {
+  const view = getTokenView();
+  renderStats(view);
+  renderFilters(view);
+  renderTable(view);
+}
+
+function getTokenView() {
+  const cacheKey = `${_tokenViewVersion}|${curStatus}|${curNsfw}|${curPool}`;
+  if (_tokenViewCache && _tokenViewCacheKey === cacheKey) return _tokenViewCache;
+
+  const stats = { active: 0, cooling: 0, invalid: 0, disabled: 0, calls: 0, qa: 0, qf: 0, qe: 0, qh: 0 };
+  const statusCounts = { all: 0, active: 0, cooling: 0, invalid: 0, disabled: 0 };
+  const nsfwCounts = { all: 0, enabled: 0, disabled: 0 };
+  const poolCounts = new Map([['all', 0]]);
+  const poolsSet = new Set(['basic', 'super', 'heavy']);
+  const filteredItems = [];
+
+  for (const token of allTokens) {
+    const pool = token.pool || 'basic';
+    const quota = token.quota || {};
+    const nsfwEnabled = (token.tags || []).includes('nsfw');
+    const invalid = isInvalidStatus(token.status);
+    const disabled = isDisabledStatus(token.status);
+    const matchesPool = curPool === 'all' || pool === curPool;
+    const matchesStatus = curStatus === 'all'
+      || (curStatus === 'invalid' ? invalid : curStatus === 'disabled' ? disabled : token.status === curStatus);
+    const matchesNsfw = curNsfw === 'all' || (curNsfw === 'enabled' ? nsfwEnabled : !nsfwEnabled);
+
+    poolsSet.add(pool);
+    stats.calls += (token.use_count || 0) + (token.fail_count || 0);
+    stats.qa += quota.auto?.remaining || 0;
+    stats.qf += quota.fast?.remaining || 0;
+    stats.qe += quota.expert?.remaining || 0;
+    stats.qh += quota.heavy?.remaining || 0;
+
+    if (token.status === 'active') stats.active += 1;
+    if (token.status === 'cooling') stats.cooling += 1;
+    if (invalid) stats.invalid += 1;
+    if (disabled) stats.disabled += 1;
+
+    if (matchesPool && matchesNsfw) {
+      statusCounts.all += 1;
+      if (token.status === 'active') statusCounts.active += 1;
+      if (token.status === 'cooling') statusCounts.cooling += 1;
+      if (invalid) statusCounts.invalid += 1;
+      if (disabled) statusCounts.disabled += 1;
+    }
+
+    if (matchesPool && matchesStatus) {
+      nsfwCounts.all += 1;
+      if (nsfwEnabled) nsfwCounts.enabled += 1;
+      else nsfwCounts.disabled += 1;
+    }
+
+    if (matchesStatus && matchesNsfw) {
+      poolCounts.set('all', poolCounts.get('all') + 1);
+      poolCounts.set(pool, (poolCounts.get(pool) || 0) + 1);
+    }
+
+    if (matchesPool && matchesStatus && matchesNsfw) filteredItems.push(token);
+  }
+
+  if (curPool !== 'all' && !poolsSet.has(curPool)) {
+    curPool = 'all';
+    return getTokenView();
+  }
+
+  _tokenViewCacheKey = `${_tokenViewVersion}|${curStatus}|${curNsfw}|${curPool}`;
+  _tokenViewCache = {
+    stats,
+    statusCounts,
+    nsfwCounts,
+    poolCounts,
+    pools: Array.from(poolsSet),
+    filteredItems,
+  };
+  return _tokenViewCache;
+}
 
 function poolLabel(pool) {
   return tr(`account.pool.${pool}`, null, pool);
@@ -1151,33 +1239,21 @@ function isInvalidStatus(status) {
   return !['active', 'cooling', 'disabled'].includes(status);
 }
 
-function renderStats() {
-  const active  = allTokens.filter(t => t.status === 'active').length;
-  const cooling = allTokens.filter(t => t.status === 'cooling').length;
-  const invalid = allTokens.filter(t => isInvalidStatus(t.status)).length;
-  const disabled = allTokens.filter(t => isDisabledStatus(t.status)).length;
-  let calls = 0, qa = 0, qf = 0, qe = 0, qh = 0;
-  for (const t of allTokens) {
-    const q = t.quota || {};
-    calls += (t.use_count || 0) + (t.fail_count || 0);
-    qa += q.auto?.remaining   || 0;
-    qf += q.fast?.remaining   || 0;
-    qe += q.expert?.remaining || 0;
-    qh += q.heavy?.remaining  || 0;
-  }
+function renderStats(view = getTokenView()) {
+  const { stats } = view;
   $('s-total',   allTokens.length);
-  $('s-active',  active);
-  $('s-cooling', cooling);
-  $('s-invalid', invalid);
-  $('s-disabled', disabled);
-  $('s-calls', fmt(calls));
-  $('s-qa', fmt(qa)); $('s-qf', fmt(qf)); $('s-qe', fmt(qe)); $('s-qh', fmt(qh));
+  $('s-active',  stats.active);
+  $('s-cooling', stats.cooling);
+  $('s-invalid', stats.invalid);
+  $('s-disabled', stats.disabled);
+  $('s-calls', fmt(stats.calls));
+  $('s-qa', fmt(stats.qa)); $('s-qf', fmt(stats.qf)); $('s-qe', fmt(stats.qe)); $('s-qh', fmt(stats.qh));
 }
 
-function renderFilters() {
-  renderStatusFilters();
-  renderNsfwFilters();
-  renderPoolFilters();
+function renderFilters(view = getTokenView()) {
+  renderStatusFilters(view);
+  renderNsfwFilters(view);
+  renderPoolFilters(view);
   syncFilterTrigger();
 }
 
@@ -1221,35 +1297,30 @@ function syncFilterTrigger() {
   trigger.classList.toggle('is-active', active);
 }
 
-function renderStatusFilters() {
-  const scope = applyNsfwFilter(applyPoolFilter(allTokens, curPool), curNsfw);
-  setFilterCount('fc-status-all', scope.length);
-  setFilterCount('fc-status-active', scope.filter(t => t.status === 'active').length);
-  setFilterCount('fc-status-cooling', scope.filter(t => t.status === 'cooling').length);
-  setFilterCount('fc-status-invalid', scope.filter(t => isInvalidStatus(t.status)).length);
-  setFilterCount('fc-status-disabled', scope.filter(t => isDisabledStatus(t.status)).length);
+function renderStatusFilters(view = getTokenView()) {
+  setFilterCount('fc-status-all', view.statusCounts.all);
+  setFilterCount('fc-status-active', view.statusCounts.active);
+  setFilterCount('fc-status-cooling', view.statusCounts.cooling);
+  setFilterCount('fc-status-invalid', view.statusCounts.invalid);
+  setFilterCount('fc-status-disabled', view.statusCounts.disabled);
   document.querySelectorAll('[data-status]').forEach(el => el.classList.toggle('active', el.dataset.status === curStatus));
 }
 
-function renderNsfwFilters() {
-  const scope = applyStatusFilter(applyPoolFilter(allTokens, curPool), curStatus);
-  const enabled = scope.filter(t => (t.tags || []).includes('nsfw')).length;
-  setFilterCount('fc-nsfw-all', scope.length);
-  setFilterCount('fc-nsfw-enabled', enabled);
-  setFilterCount('fc-nsfw-disabled', scope.length - enabled);
+function renderNsfwFilters(view = getTokenView()) {
+  setFilterCount('fc-nsfw-all', view.nsfwCounts.all);
+  setFilterCount('fc-nsfw-enabled', view.nsfwCounts.enabled);
+  setFilterCount('fc-nsfw-disabled', view.nsfwCounts.disabled);
   document.querySelectorAll('[data-nsfw]').forEach(el => el.classList.toggle('active', el.dataset.nsfw === curNsfw));
 }
 
-function renderPoolFilters() {
+function renderPoolFilters(view = getTokenView()) {
   const wrap = document.getElementById('pool-filter-chips');
   if (!wrap) return;
-  const pools = [...new Set(['basic', 'super', 'heavy', ...allTokens.map(t => t.pool || 'basic')])];
-  if (curPool !== 'all' && !pools.includes(curPool)) curPool = 'all';
-  const scope = applyNsfwFilter(applyStatusFilter(allTokens, curStatus), curNsfw);
+  const pools = view.pools;
   wrap.innerHTML = [
-    `<button type="button" class="filter-chip${curPool === 'all' ? ' active' : ''}" data-pool="all" onclick="switchPool('all')"><span>${tr('account.filterTypeAll', null, '全部')}</span><span class="filter-chip-count">${scope.length}</span></button>`,
+    `<button type="button" class="filter-chip${curPool === 'all' ? ' active' : ''}" data-pool="all" onclick="switchPool('all')"><span>${tr('account.filterTypeAll', null, '全部')}</span><span class="filter-chip-count">${view.poolCounts.get('all') || 0}</span></button>`,
     ...pools.map(pool => {
-      const count = scope.filter(t => (t.pool || 'basic') === pool).length;
+      const count = view.poolCounts.get(pool) || 0;
       return `<button type="button" class="filter-chip${curPool === pool ? ' active' : ''}" data-pool="${xe(pool)}" onclick="switchPool('${xe(pool)}')"><span>${xe(poolLabel(pool))}</span><span class="filter-chip-count">${count}</span></button>`;
     }),
   ].join('');
@@ -1279,7 +1350,7 @@ function applyNsfwFilter(items, mode = curNsfw) {
 }
 
 function filtered() {
-  return applyNsfwFilter(applyStatusFilter(applyPoolFilter(allTokens, curPool), curStatus), curNsfw);
+  return getTokenView().filteredItems;
 }
 
 function preserveScroll(fn) {
@@ -1288,8 +1359,9 @@ function preserveScroll(fn) {
   requestAnimationFrame(() => window.scrollTo({ top: y, behavior: 'auto' }));
 }
 
-function renderTable() {
-  const items = filtered(), total = items.length;
+function renderTable(view = getTokenView()) {
+  const items = view.filteredItems;
+  const total = items.length;
   const pages = Math.max(1, Math.ceil(total / pageSize));
   if (curPage > pages) curPage = pages;
   const slice = items.slice((curPage - 1) * pageSize, curPage * pageSize);
@@ -1400,7 +1472,10 @@ function switchPool(pool) {
   });
 }
 function prevPage() { if (curPage > 1) { curPage--; renderTable(); } }
-function nextPage() { const pages = Math.max(1, Math.ceil(filtered().length / pageSize)); if (curPage < pages) { curPage++; renderTable(); } }
+function nextPage() {
+  const pages = Math.max(1, Math.ceil(getTokenView().filteredItems.length / pageSize));
+  if (curPage < pages) { curPage++; renderTable(); }
+}
 function changePageSize(v) {
   const next = Number(v);
   pageSize = PAGE_SIZE_OPTIONS.includes(next) ? next : 50;
@@ -1410,13 +1485,13 @@ function changePageSize(v) {
 }
 
 function toggleAll(checked) {
-  filtered().slice((curPage-1)*pageSize, curPage*pageSize).forEach(t => checked ? sel.add(t.token) : sel.delete(t.token));
+  getTokenView().filteredItems.slice((curPage-1)*pageSize, curPage*pageSize).forEach(t => checked ? sel.add(t.token) : sel.delete(t.token));
   document.querySelectorAll('.row-cb').forEach(el => el.checked = checked);
   updateBatchBtns();
 }
 function toggleRow(el) {
   el.checked ? sel.add(el.dataset.token) : sel.delete(el.dataset.token);
-  const page = filtered().slice((curPage-1)*pageSize, curPage*pageSize);
+  const page = getTokenView().filteredItems.slice((curPage-1)*pageSize, curPage*pageSize);
   const cbAll = document.getElementById('cb-all');
   cbAll.checked = page.every(t => sel.has(t.token));
   cbAll.indeterminate = !cbAll.checked && sel.size > 0;

--- a/app/statics/admin/cache.html
+++ b/app/statics/admin/cache.html
@@ -433,6 +433,12 @@ const _assetSel = new Set();
 let _assetTaskId = null;
 let _assetEs = null;
 let _assetLoaded = false;
+let _localViewVersion = 0;
+let _localViewCacheVersion = -1;
+let _localViewCache = null;
+let _assetViewVersion = 0;
+let _assetViewCacheVersion = -1;
+let _assetViewCache = null;
 
 function tr(key, params, fallback) {
   const value = t(key, params);
@@ -454,6 +460,88 @@ function getTypeNoun(type = _type) {
 function loadSavedPageSize() {
   const raw = Number(localStorage.getItem(PAGE_SIZE_KEY));
   return PAGE_SIZE_OPTIONS.includes(raw) ? raw : 100;
+}
+
+function invalidateLocalView() {
+  _localViewVersion += 1;
+}
+
+function invalidateAssetView() {
+  _assetViewVersion += 1;
+
+function getLocalView() {
+  if (_localViewCache && _localViewCacheVersion === _localViewVersion) return _localViewCache;
+
+  const selectedNames = [];
+  for (const item of _localItems) {
+    if (_localSel.has(item.name)) selectedNames.push(item.name);
+  }
+  const selectedCount = selectedNames.length;
+
+  _localViewCacheVersion = _localViewVersion;
+  _localViewCache = {
+    items: _localItems,
+    selectedNames,
+    totalItems: _localItems.length,
+    selectedCount,
+    hasSelection: selectedCount > 0,
+    allSelected: _localItems.length > 0 && selectedCount === _localItems.length,
+    someSelected: selectedCount > 0 && selectedCount < _localItems.length,
+  };
+  return _localViewCache;
+}
+
+function getAssetView() {
+  if (_assetViewCache && _assetViewCacheVersion === _assetViewVersion) return _assetViewCache;
+
+  const rows = [];
+  const clearableTokens = [];
+  const selectedClearableTokens = [];
+  let countedAssets = 0;
+  let selectedCount = 0;
+
+  for (const row of _assetData) {
+    const masked = row.masked || _maskToken(row.token || '');
+    const count = row.count || 0;
+    const hasItems = count > 0;
+    const isSelected = _assetSel.has(row.token);
+    const assets = Array.isArray(row.assets) ? row.assets : [];
+
+    countedAssets += count;
+    if (isSelected) selectedCount += 1;
+    if (hasItems) clearableTokens.push(row.token);
+    if (isSelected && hasItems) selectedClearableTokens.push(row.token);
+
+    rows.push({
+      row,
+      masked,
+      assets,
+      hasItems,
+      isOpen: !!_expanded[masked],
+      isSelected,
+    });
+  }
+
+  const totalRows = rows.length;
+  const selectedClearableCount = selectedClearableTokens.length;
+
+  _assetViewCacheVersion = _assetViewVersion;
+  _assetViewCache = {
+    loaded: _assetLoaded,
+    rows,
+    totalRows,
+    totalAccounts: totalRows,
+    totalAssets: _assetTotal || countedAssets,
+    selectedCount,
+    hasSelection: selectedCount > 0,
+    allSelected: totalRows > 0 && selectedCount === totalRows,
+    someSelected: selectedCount > 0 && selectedCount < totalRows,
+    clearableTokens,
+    hasClearable: clearableTokens.length > 0,
+    selectedClearableTokens,
+    selectedClearableCount,
+  };
+  return _assetViewCache;
 }
 
 function setLoadAssetsButton(labelKey, fallback, spinning = false) {
@@ -485,19 +573,18 @@ function applyToolbarI18n() {
   });
 }
 
-function updateAssetSummary() {
-  if (!_assetLoaded) {
+function updateAssetSummary(view = getAssetView()) {
+  if (!view.loaded) {
     document.getElementById('asset-summary').textContent = tr('cache.assetSummaryIdle', null, '点击右侧获取在线资产');
-    document.getElementById('btn-clear-all-assets').style.display = 'none';
+    updateAssetBatchButtons(view);
     return;
   }
-  const totalAssets = _assetTotal || _assetData.reduce((sum, row) => sum + (row.count || 0), 0);
   document.getElementById('asset-summary').textContent = tr(
     'cache.assetSummary',
-    { accounts: _assetData.length, files: totalAssets },
-    `共 ${_assetData.length} 个账户 · ${totalAssets} 个文件`
+    { accounts: view.totalAccounts, files: view.totalAssets },
+    `共 ${view.totalAccounts} 个账户 · ${view.totalAssets} 个文件`
   );
-  document.getElementById('btn-clear-all-assets').style.display = _assetData.some((row) => row.count > 0) ? '' : 'none';
+  updateAssetBatchButtons(view);
 }
 
 function applyCacheI18n() {
@@ -510,10 +597,10 @@ function applyCacheI18n() {
   applyToolbarI18n();
   setLoadAssetsButton('cache.loadAssets', '加载资产列表');
   _renderPagi();
-  if (_assetData.length) {
+  if (_assetLoaded) {
     _renderAssets();
-    updateAssetSummary();
   }
+  updateAssetSummary();
 }
 
 async function _api(method, path, body) {
@@ -549,8 +636,9 @@ async function loadList() {
     const d = await _api('GET', `/cache/list?type=${_type}&page=${_page}&page_size=${_pageSize}`);
     _total = d.total ?? 0;
     _localItems = d.items || [];
+    invalidateLocalView();
     _reconcileLocalSelection();
-    _renderTable(_localItems);
+    _renderTable();
     _renderPagi();
     updateLocalBatchButtons();
   } catch (e) {
@@ -558,9 +646,10 @@ async function loadList() {
   }
 }
 
-function _renderTable(items) {
+function _renderTable(view = getLocalView()) {
   const tbody = document.getElementById('cache-tbody');
-  syncLocalSelectAll();
+  const items = view.items;
+  syncLocalSelectAll(view);
   if (!items.length) {
     tbody.innerHTML = `<tr><td colspan="5" class="table-empty">${_esc(tr('cache.emptyLocal', null, '暂无缓存文件'))}</td></tr>`;
     return;
@@ -583,7 +672,7 @@ function _renderTable(items) {
       <td>${_fmtTime(f.modified_at)}</td>
       <td><div class="row-actions"><button class="row-action" onclick="viewFile('${_esc(f.name)}')" title="${_esc(tr('cache.actionView', null, '查看'))}" aria-label="${_esc(tr('cache.actionView', null, '查看'))}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z"/><circle cx="12" cy="12" r="3"/></svg></button><button class="row-action row-action-danger" onclick="deleteFile('${_esc(f.name)}')" title="${_esc(tr('cache.actionDelete', null, '删除'))}" aria-label="${_esc(tr('cache.actionDelete', null, '删除'))}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M5 7h14"/><path d="M9 7V4h6v3"/><path d="M8 10v7"/><path d="M12 10v7"/><path d="M16 10v7"/><path d="M7 7l1 13h8l1-13"/></svg></button></div></td>
     </tr>`).join('');
-  syncLocalSelectAll();
+  syncLocalSelectAll(view);
 }
 
 function _renderPagi() {
@@ -689,6 +778,7 @@ async function loadAssets() {
     _assetData = d.tokens || [];
     _assetTotal = d.total_assets ?? _assetData.reduce((sum, row) => sum + (row.count || 0), 0);
     _expanded = {};
+    invalidateAssetView();
     _reconcileAssetSelection();
     _renderAssets();
     updateAssetSummary();
@@ -698,6 +788,7 @@ async function loadAssets() {
     _assetTotal = 0;
     _expanded = {};
     _assetSel.clear();
+    invalidateAssetView();
     _renderAssets();
     updateAssetSummary();
     showToast(tr('cache.loadFailed', { message: e.message }, `加载失败: ${e.message}`), 'error');
@@ -707,14 +798,14 @@ async function loadAssets() {
   }
 }
 
-function _renderAssets() {
+function _renderAssets(view = getAssetView()) {
   const tbody = document.getElementById('assets-tbody');
-  syncAssetSelectAll();
-  if (!_assetLoaded) {
+  syncAssetSelectAll(view);
+  if (!view.loaded) {
     tbody.innerHTML = `<tr><td colspan="5" class="table-empty">${_esc(tr('cache.emptyAssetsIdle', null, '点击右上角获取在线资产列表'))}</td></tr>`;
     return;
   }
-  if (!_assetData.length) {
+  if (!view.totalRows) {
     tbody.innerHTML = `<tr><td colspan="5" class="table-empty">${_esc(tr('cache.emptyAccounts', null, '暂无账户数据'))}</td></tr>`;
     return;
   }
@@ -726,14 +817,12 @@ function _renderAssets() {
   const naLabel = tr('cache.na', null, '—');
 
   const rows = [];
-  for (const row of _assetData) {
-    const isOpen = !!_expanded[row.masked];
-    const hasItems = row.count > 0;
+  for (const { row, masked, assets, hasItems, isOpen, isSelected } of view.rows) {
     rows.push(`
       <tr>
-        <td><input type="checkbox" class="cb asset-row-cb" data-token="${_esc(row.token)}" ${_assetSel.has(row.token) ? 'checked' : ''} onchange="toggleAssetRow(this)"></td>
+        <td><input type="checkbox" class="cb asset-row-cb" data-token="${_esc(row.token)}" ${isSelected ? 'checked' : ''} onchange="toggleAssetRow(this)"></td>
         <td style="padding:10px 8px 10px 14px">
-          ${hasItems ? `<button class="expand-btn${isOpen ? ' open' : ''}" onclick="toggleExpand('${_esc(row.masked)}')" title="${_esc(isOpen ? collapseLabel : expandLabel)}">
+          ${hasItems ? `<button class="expand-btn${isOpen ? ' open' : ''}" onclick="toggleExpand('${_esc(masked)}')" title="${_esc(isOpen ? collapseLabel : expandLabel)}">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="9 18 15 12 9 6"/></svg>
           </button>` : '<span style="width:22px;display:inline-block"></span>'}
         </td>
@@ -742,7 +831,7 @@ function _renderAssets() {
             <span class="row-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M7 10V8a5 5 0 0 1 10 0v2"/><rect x="4" y="10" width="16" height="10" rx="2"/><circle cx="12" cy="15" r="1"/></svg>
             </span>
-            <span class="row-value">${_esc(row.masked)}</span>
+            <span class="row-value">${_esc(masked)}</span>
           </div>
           ${row.error ? `<span class="asset-err" title="${_esc(row.error)}">⚠ ${_esc(row.error)}</span>` : ''}
         </td>
@@ -750,12 +839,12 @@ function _renderAssets() {
           <span class="asset-count-badge${hasItems ? ' has-items' : ''}">${row.count}</span>
         </td>
         <td>
-          ${hasItems ? `<div class="row-actions"><button class="row-action row-action-danger" onclick="clearTokenAssets('${_esc(row.token)}','${_esc(row.masked)}')" title="${_esc(clearLabel)}" aria-label="${_esc(clearLabel)}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M5 7h14"/><path d="M9 7V4h6v3"/><path d="M8 10v7"/><path d="M12 10v7"/><path d="M16 10v7"/><path d="M7 7l1 13h8l1-13"/></svg></button></div>` : ''}
+          ${hasItems ? `<div class="row-actions"><button class="row-action row-action-danger" onclick="clearTokenAssets('${_esc(row.token)}','${_esc(masked)}')" title="${_esc(clearLabel)}" aria-label="${_esc(clearLabel)}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M5 7h14"/><path d="M9 7V4h6v3"/><path d="M8 10v7"/><path d="M12 10v7"/><path d="M16 10v7"/><path d="M7 7l1 13h8l1-13"/></svg></button></div>` : ''}
         </td>
       </tr>`);
 
     if (isOpen && hasItems) {
-      for (const asset of row.assets) {
+      for (const asset of assets) {
         rows.push(`
           <tr class="sub-row">
             <td></td>
@@ -771,19 +860,20 @@ function _renderAssets() {
             </td>
             <td style="color:#aaa;font-size:11px">${asset.size ? _fmtBytes(asset.size) : _esc(naLabel)}</td>
             <td>
-              <div class="row-actions"><button class="row-action row-action-danger" onclick="deleteAssetItem('${_esc(row.token)}','${_esc(row.masked)}','${_esc(asset.id)}')" title="${_esc(deleteLabel)}" aria-label="${_esc(deleteLabel)}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M5 7h14"/><path d="M9 7V4h6v3"/><path d="M8 10v7"/><path d="M12 10v7"/><path d="M16 10v7"/><path d="M7 7l1 13h8l1-13"/></svg></button></div>
+              <div class="row-actions"><button class="row-action row-action-danger" onclick="deleteAssetItem('${_esc(row.token)}','${_esc(masked)}','${_esc(asset.id)}')" title="${_esc(deleteLabel)}" aria-label="${_esc(deleteLabel)}"><svg viewBox="0 0 24 24" stroke-width="1.8"><path d="M5 7h14"/><path d="M9 7V4h6v3"/><path d="M8 10v7"/><path d="M12 10v7"/><path d="M16 10v7"/><path d="M7 7l1 13h8l1-13"/></svg></button></div>
             </td>
           </tr>`);
       }
     }
   }
   tbody.innerHTML = rows.join('');
-  syncAssetSelectAll();
-  updateAssetBatchButtons();
+  syncAssetSelectAll(view);
+  updateAssetBatchButtons(view);
 }
 
 function toggleExpand(masked) {
   _expanded[masked] = !_expanded[masked];
+  invalidateAssetView();
   _renderAssets();
 }
 
@@ -808,6 +898,7 @@ async function deleteAssetItem(token, masked, assetId) {
       row.count = row.assets.length;
     }
     _assetTotal = _assetData.reduce((sum, item) => sum + (item.count || 0), 0);
+    invalidateAssetView();
     _renderAssets();
     updateAssetSummary();
   } catch (e) {
@@ -817,29 +908,35 @@ async function deleteAssetItem(token, masked, assetId) {
 
 function _reconcileLocalSelection() {
   const names = new Set(_localItems.map((item) => item.name));
+  let changed = false;
   [..._localSel].forEach((name) => {
-    if (!names.has(name)) _localSel.delete(name);
+    if (!names.has(name)) {
+      _localSel.delete(name);
+      changed = true;
+    }
   });
+  if (changed) invalidateLocalView();
 }
 
-function syncLocalSelectAll() {
+function syncLocalSelectAll(view = getLocalView()) {
   const cbAll = document.getElementById('cb-local-all');
   if (!cbAll) return;
-  if (!_localItems.length) {
+  if (!view.totalItems) {
     cbAll.checked = false;
     cbAll.indeterminate = false;
     return;
   }
-  const selected = _localItems.filter((item) => _localSel.has(item.name)).length;
-  cbAll.checked = selected === _localItems.length;
-  cbAll.indeterminate = selected > 0 && selected < _localItems.length;
+  cbAll.checked = view.allSelected;
+  cbAll.indeterminate = view.someSelected;
 }
 
 function toggleAllLocal(checked) {
-  _localItems.forEach((item) => {
+  const view = getLocalView();
+  view.items.forEach((item) => {
     if (checked) _localSel.add(item.name);
     else _localSel.delete(item.name);
   });
+  invalidateLocalView();
   document.querySelectorAll('.local-row-cb').forEach((el) => { el.checked = checked; });
   syncLocalSelectAll();
   updateLocalBatchButtons();
@@ -850,12 +947,14 @@ function toggleLocalRow(el) {
   if (!name) return;
   if (el.checked) _localSel.add(name);
   else _localSel.delete(name);
+  invalidateLocalView();
   syncLocalSelectAll();
   updateLocalBatchButtons();
 }
 
 function clearLocalSelection(render = true) {
   _localSel.clear();
+  invalidateLocalView();
   syncLocalSelectAll();
   updateLocalBatchButtons();
   if (render) {
@@ -863,8 +962,8 @@ function clearLocalSelection(render = true) {
   }
 }
 
-function updateLocalBatchButtons() {
-  const show = _localSel.size > 0;
+function updateLocalBatchButtons(view = getLocalView()) {
+  const show = view.hasSelection;
   const btnDelete = document.getElementById('btn-local-delete-selected');
   const btnClear = document.getElementById('btn-clear');
   if (btnDelete) btnDelete.style.display = show ? '' : 'none';
@@ -872,7 +971,7 @@ function updateLocalBatchButtons() {
 }
 
 async function deleteSelectedLocal() {
-  const names = _localItems.filter((item) => _localSel.has(item.name)).map((item) => item.name);
+  const names = getLocalView().selectedNames;
   if (!names.length) return;
   if (!confirm(tr('cache.deleteSelectedConfirm', { n: names.length }, `确定要删除选中的 ${names.length} 个文件吗？`))) return;
   try {
@@ -889,29 +988,35 @@ async function deleteSelectedLocal() {
 
 function _reconcileAssetSelection() {
   const tokens = new Set(_assetData.map((row) => row.token));
+  let changed = false;
   [..._assetSel].forEach((token) => {
-    if (!tokens.has(token)) _assetSel.delete(token);
+    if (!tokens.has(token)) {
+      _assetSel.delete(token);
+      changed = true;
+    }
   });
+  if (changed) invalidateAssetView();
 }
 
-function syncAssetSelectAll() {
+function syncAssetSelectAll(view = getAssetView()) {
   const cbAll = document.getElementById('cb-asset-all');
   if (!cbAll) return;
-  if (!_assetData.length) {
+  if (!view.totalRows) {
     cbAll.checked = false;
     cbAll.indeterminate = false;
     return;
   }
-  const selected = _assetData.filter((row) => _assetSel.has(row.token)).length;
-  cbAll.checked = selected === _assetData.length;
-  cbAll.indeterminate = selected > 0 && selected < _assetData.length;
+  cbAll.checked = view.allSelected;
+  cbAll.indeterminate = view.someSelected;
 }
 
 function toggleAllAssets(checked) {
-  _assetData.forEach((row) => {
+  const view = getAssetView();
+  view.rows.forEach(({ row }) => {
     if (checked) _assetSel.add(row.token);
     else _assetSel.delete(row.token);
   });
+  invalidateAssetView();
   document.querySelectorAll('.asset-row-cb').forEach((el) => { el.checked = checked; });
   syncAssetSelectAll();
   updateAssetBatchButtons();
@@ -922,12 +1027,14 @@ function toggleAssetRow(el) {
   if (!token) return;
   if (el.checked) _assetSel.add(token);
   else _assetSel.delete(token);
+  invalidateAssetView();
   syncAssetSelectAll();
   updateAssetBatchButtons();
 }
 
 function clearAssetSelection(render = true) {
   _assetSel.clear();
+  invalidateAssetView();
   syncAssetSelectAll();
   updateAssetBatchButtons();
   if (render) {
@@ -935,29 +1042,27 @@ function clearAssetSelection(render = true) {
   }
 }
 
-function updateAssetBatchButtons() {
-  const selected = _assetData.filter((row) => _assetSel.has(row.token) && row.count > 0).length;
+function updateAssetBatchButtons(view = getAssetView()) {
   const btnClearAll = document.getElementById('btn-clear-all-assets');
   const btnClearSelected = document.getElementById('btn-clear-selected-assets');
-  const showSelection = _assetSel.size > 0;
-  if (btnClearSelected) btnClearSelected.style.display = selected > 0 ? '' : 'none';
-  if (btnClearAll) btnClearAll.style.display = !showSelection && _assetData.some((row) => row.count > 0) ? '' : 'none';
+  if (btnClearSelected) btnClearSelected.style.display = view.selectedClearableCount > 0 ? '' : 'none';
+  if (btnClearAll) btnClearAll.style.display = !view.hasSelection && view.hasClearable ? '' : 'none';
 }
 
 async function clearSelectedAssets() {
-  const tokens = _assetData.filter((row) => _assetSel.has(row.token) && row.count > 0).map((row) => row.token);
+  const tokens = getAssetView().selectedClearableTokens;
   if (!tokens.length) return;
   await runAssetClear(tokens);
 }
 
 async function clearAllAssets() {
-  const tokens = _assetData.filter((row) => row.count > 0).map((row) => row.token);
+  const tokens = getAssetView().clearableTokens;
   if (!tokens.length) return;
   await runAssetClear(tokens);
 }
 
 async function runAssetClear(tokens) {
-  const allTokens = _assetData.filter((row) => row.count > 0).map((row) => row.token);
+  const allTokens = getAssetView().clearableTokens;
   const isAll = tokens.length === allTokens.length;
   if (isAll) {
     if (!confirm(tr('cache.clearAllConfirm', { n: tokens.length }, `确定要清理全部 ${tokens.length} 个账户的在线资产吗？此操作不可撤销。`))) return;

--- a/app/statics/admin/cache.html
+++ b/app/statics/admin/cache.html
@@ -468,6 +468,7 @@ function invalidateLocalView() {
 
 function invalidateAssetView() {
   _assetViewVersion += 1;
+}
 
 function getLocalView() {
   if (_localViewCache && _localViewCacheVersion === _localViewVersion) return _localViewCache;

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -632,6 +632,14 @@ let _cfg = {};        // loaded config (nested)
 let _dirty = {};      // { "section.key": newValue }
 let _activeTab = SCHEMA_DEF[0].id;
 let _configLoaded = false;
+let _rowRefs = new Map();
+let _tabButtons = new Map();
+let _tabDirtyCounts = new Map();
+let _tabFieldIndex = new Map();
+let _conditionalRows = [];
+let _selectRefs = [];
+let _showIfDeps = new Map();
+let _disabledSelectDeps = new Map();
 
 function tr(key, params, fallback) {
   if (!key) return fallback ?? '';
@@ -641,6 +649,61 @@ function tr(key, params, fallback) {
 
 function waitI18n() {
   return new Promise((resolve) => I18n.onReady(resolve));
+}
+
+function _addDependency(depMap, path, target) {
+  if (!path || !target) return;
+  if (!depMap.has(path)) depMap.set(path, []);
+  depMap.get(path).push(target);
+}
+
+function _showIfPaths(showIf) {
+  if (!showIf) return [];
+  return [typeof showIf === 'string' ? showIf : showIf.path].filter(Boolean);
+}
+
+function _disabledWhenPaths(condition) {
+  if (condition === 'no_app_url') return ['app.app_url'];
+  return [];
+}
+
+function _collectDependentTargets(paths, depMap) {
+  if (!Array.isArray(paths) || !paths.length) return [];
+  const seen = new Set();
+  const items = [];
+  paths.forEach((path) => {
+    (depMap.get(path) || []).forEach((target) => {
+      if (seen.has(target)) return;
+      seen.add(target);
+      items.push(target);
+    });
+  });
+  return items;
+}
+
+function _syncTabDirtyState(tabId) {
+  const btn = _tabButtons.get(tabId);
+  if (!btn) return;
+  btn.classList.toggle('dirty', (_tabDirtyCounts.get(tabId) || 0) > 0);
+}
+
+function _updateDirtyCount(fp, delta) {
+  const tabId = _tabFieldIndex.get(fp);
+  if (!tabId || !delta) return;
+  const next = Math.max(0, (_tabDirtyCounts.get(tabId) || 0) + delta);
+  _tabDirtyCounts.set(tabId, next);
+  _syncTabDirtyState(tabId);
+}
+
+function _resetRenderCaches() {
+  _rowRefs = new Map();
+  _tabButtons = new Map();
+  _tabDirtyCounts = new Map();
+  _tabFieldIndex = new Map();
+  _conditionalRows = [];
+  _selectRefs = [];
+  _showIfDeps = new Map();
+  _disabledSelectDeps = new Map();
 }
 
 function _localizeOption(opt) {
@@ -763,11 +826,14 @@ function renderInput(field, section, value) {
   const fp = _fullPath(section, field.key);
 
   const onChange = (v) => {
+    const wasDirty = fp in _dirty;
     const orig = _getValue(section, field.key);
     const same = String(orig) === String(v) || orig === v;
     if (same) delete _dirty[fp]; else _dirty[fp] = v;
+    const isDirty = fp in _dirty;
+    if (wasDirty !== isDirty) _updateDirtyCount(fp, isDirty ? 1 : -1);
     _refreshRow(section, field.key);
-    _refreshDirtyState();
+    _refreshDirtyState({ changedPaths: [fp] });
   };
 
   if (field.type === 'bool') {
@@ -783,6 +849,7 @@ function renderInput(field, section, value) {
 
   if (field.type === 'select') {
     const sel = _el('select', { class: 'cfg-select', id: `field-${section}-${field.key}` });
+    const deps = new Set();
     (field.options || []).forEach(opt => {
       const o = document.createElement('option');
       o.value = (typeof opt === 'object') ? opt.value : opt;
@@ -794,9 +861,14 @@ function renderInput(field, section, value) {
         const isDisabled = _evalDisabledWhen(opt.disabledWhen);
         o.disabled = isDisabled;
         if (isDisabled && opt.disabledTip) o.title = opt.disabledTip;
+        _disabledWhenPaths(opt.disabledWhen).forEach((path) => deps.add(path));
       }
       sel.appendChild(o);
     });
+    if (deps.size) {
+      _selectRefs.push(sel);
+      deps.forEach((path) => _addDependency(_disabledSelectDeps, path, sel));
+    }
     sel.addEventListener('change', () => onChange(sel.value));
     return sel;
   }
@@ -844,7 +916,7 @@ function renderInput(field, section, value) {
   return inp;
 }
 
-function renderRow(field, section) {
+function renderRow(field, section, tabId) {
   const fp      = _fullPath(section, field.key);
   const value   = _getValue(section, field.key);
   const isDirty = fp in _dirty;
@@ -881,18 +953,24 @@ function renderRow(field, section) {
     'data-key': field.key,
   }, labelCol, inputCol);
 
+  _rowRefs.set(fp, row);
+  _tabFieldIndex.set(fp, tabId);
+  if (isDirty) _tabDirtyCounts.set(tabId, (_tabDirtyCounts.get(tabId) || 0) + 1);
+
   // Conditional visibility
   if (field.showIf) {
-    row.dataset.showIf = JSON.stringify(field.showIf);
+    row._showIfSpec = field.showIf;
     row.style.display = _evalShowIf(field.showIf) ? '' : 'none';
+    _conditionalRows.push(row);
+    _showIfPaths(field.showIf).forEach((path) => _addDependency(_showIfDeps, path, row));
   }
 
   return row;
 }
 
-function renderGroup(group) {
+function renderGroup(group, tabId) {
   const section = group.section;
-  const rows    = group.fields.map(f => renderRow(f, f.section || section));
+  const rows    = group.fields.map(f => renderRow(f, f.section || section, tabId));
   const titleEl = _el('div', { class: 'cfg-group-title' }, group.title || '');
   const wrap    = _el('div', { class: 'cfg-group' }, titleEl, ...rows);
   return wrap;
@@ -901,13 +979,14 @@ function renderGroup(group) {
 function renderPanel(tab) {
   const panel = _el('div', { class: `cfg-panel${tab.id === _activeTab ? ' active' : ''}`,
     id: `panel-${tab.id}` });
-  tab.groups.forEach(g => panel.appendChild(renderGroup(g)));
+  tab.groups.forEach(g => panel.appendChild(renderGroup(g, tab.id)));
   return panel;
 }
 
 function renderAll() {
   const nav    = document.getElementById('cfg-nav');
   const panels = document.getElementById('cfg-panels');
+  _resetRenderCaches();
   nav.innerHTML = ''; panels.innerHTML = '';
 
   SCHEMA.forEach(tab => {
@@ -917,11 +996,13 @@ function renderAll() {
       onclick: () => switchTab(tab.id),
       'data-tab': tab.id,
     }, tab.label, _el('span', { class: 'dot' }));
+    _tabButtons.set(tab.id, btn);
     nav.appendChild(btn);
 
     // Panel
     panels.appendChild(renderPanel(tab));
   });
+  _tabButtons.forEach((_, tabId) => _syncTabDirtyState(tabId));
 }
 
 function switchTab(id) {
@@ -934,11 +1015,39 @@ function switchTab(id) {
 
 // ── Dirty state helpers ────────────────────────────────────────────────────
 function _refreshRow(section, key) {
-  const row = document.querySelector(`.cfg-row[data-section="${section}"][data-key="${key}"]`);
+  const row = _rowRefs.get(_fullPath(section, key));
   if (row) row.classList.toggle('modified', _fullPath(section, key) in _dirty);
 }
 
-function _refreshDirtyState({ autoNormalizeSelects = true } = {}) {
+function _refreshConditionalRows(changedPaths = null) {
+  const rows = changedPaths ? _collectDependentTargets(changedPaths, _showIfDeps) : _conditionalRows;
+  rows.forEach((row) => {
+    row.style.display = _evalShowIf(row._showIfSpec) ? '' : 'none';
+  });
+}
+
+function _refreshSelectStates(changedPaths = null, { autoNormalizeSelects = true } = {}) {
+  const selects = changedPaths ? _collectDependentTargets(changedPaths, _disabledSelectDeps) : _selectRefs;
+  selects.forEach((sel) => {
+    let anyChanged = false;
+    [...sel.options].forEach(o => {
+      if (!o.dataset.disabledWhen) return;
+      const isDisabled = _evalDisabledWhen(o.dataset.disabledWhen);
+      o.disabled = isDisabled;
+      o.title = isDisabled ? (o.dataset.disabledTip || '') : '';
+      if (autoNormalizeSelects && isDisabled && o.selected) anyChanged = true;
+    });
+    if (anyChanged) {
+      const firstEnabled = [...sel.options].find(o => !o.disabled);
+      if (firstEnabled) {
+        firstEnabled.selected = true;
+        sel.dispatchEvent(new Event('change'));
+      }
+    }
+  });
+}
+
+function _refreshDirtyState({ autoNormalizeSelects = true, changedPaths = null } = {}) {
   const n = Object.keys(_dirty).length;
   document.getElementById('btn-save').disabled  = n === 0;
   document.getElementById('btn-reset').disabled = n === 0;
@@ -959,39 +1068,9 @@ function _refreshDirtyState({ autoNormalizeSelects = true } = {}) {
     webuiLinkBtn.setAttribute('aria-label', webuiLinkBtn.title);
   }
 
-  // Update showIf conditional rows
-  document.querySelectorAll('.cfg-row[data-show-if]').forEach(row => {
-    const spec = JSON.parse(row.dataset.showIf);
-    row.style.display = _evalShowIf(spec) ? '' : 'none';
-  });
-
-  // Re-evaluate disabled options in selects
-  document.querySelectorAll('select.cfg-select').forEach(sel => {
-    let anyChanged = false;
-    [...sel.options].forEach(o => {
-      if (!o.dataset.disabledWhen) return;
-      const isDisabled = _evalDisabledWhen(o.dataset.disabledWhen);
-      o.disabled = isDisabled;
-      o.title = isDisabled ? (o.dataset.disabledTip || '') : '';
-      if (autoNormalizeSelects && isDisabled && o.selected) anyChanged = true;
-    });
-    // If the currently selected option became disabled, switch to first enabled
-    if (anyChanged) {
-      const firstEnabled = [...sel.options].find(o => !o.disabled);
-      if (firstEnabled) {
-        firstEnabled.selected = true;
-        sel.dispatchEvent(new Event('change'));
-      }
-    }
-  });
-
-  // Tab dirty dots — check if any dirty key belongs to a row in that panel
-  SCHEMA.forEach(tab => {
-    const panel = document.getElementById(`panel-${tab.id}`);
-    const relevant = panel ? [...panel.querySelectorAll('.cfg-row')].some(r =>
-      _fullPath(r.dataset.section, r.dataset.key) in _dirty) : false;
-    document.querySelector(`.cfg-tab[data-tab="${tab.id}"]`)?.classList.toggle('dirty', relevant);
-  });
+  _refreshConditionalRows(changedPaths);
+  _refreshSelectStates(changedPaths, { autoNormalizeSelects });
+  if (!changedPaths) _tabButtons.forEach((_, tabId) => _syncTabDirtyState(tabId));
 }
 
 // ── Load config ────────────────────────────────────────────────────────────

--- a/app/statics/js/admin-header.js
+++ b/app/statics/js/admin-header.js
@@ -1,10 +1,36 @@
 window.renderAdminHeader = async function renderAdminHeader() {
   const mount = document.getElementById('admin-header');
   if (!mount || mount.children.length) return;
+  const scriptVersion = (() => {
+    try {
+      const script = document.querySelector('script[src*="/static/js/admin-header.js"]');
+      if (!script) return 'v1';
+      return new URL(script.src, window.location.href).searchParams.get('v') || 'v1';
+    } catch {
+      return 'v1';
+    }
+  })();
+  const HEADER_HTML_CACHE_KEY = `grok2api.admin_header_html.${scriptVersion}`;
+  const META_VERSION_CACHE_KEY = `grok2api.meta_version.${scriptVersion}`;
   let appVersion = '';
   let updateInfo = null;
   let updateStatus = 'idle';
   let updatePromise = null;
+
+  const readSessionCache = (key) => {
+    try {
+      return sessionStorage.getItem(key) || '';
+    } catch {
+      return '';
+    }
+  };
+
+  const writeSessionCache = (key, value) => {
+    if (!value) return;
+    try {
+      sessionStorage.setItem(key, value);
+    } catch {}
+  };
 
   const languageCodes = {
     zh: 'CN',
@@ -85,11 +111,19 @@ window.renderAdminHeader = async function renderAdminHeader() {
   };
 
   const loadVersion = async () => {
+    const cachedVersion = window.__grok2apiMetaVersion || readSessionCache(META_VERSION_CACHE_KEY);
+    if (cachedVersion) {
+      appVersion = String(cachedVersion).trim();
+      window.__grok2apiMetaVersion = appVersion;
+      return;
+    }
     try {
-      const res = await fetch('/meta', { cache: 'no-store' });
+      const res = await fetch('/meta');
       if (!res.ok) throw new Error('meta unavailable');
       const data = await res.json();
       appVersion = String(data?.version || '').trim();
+      window.__grok2apiMetaVersion = appVersion;
+      writeSessionCache(META_VERSION_CACHE_KEY, appVersion);
     } catch {
       appVersion = '';
     }
@@ -529,9 +563,17 @@ window.renderAdminHeader = async function renderAdminHeader() {
   await loadVersion();
 
   try {
-    const res = await fetch('/static/admin/header.html', { cache: 'no-store' });
-    if (!res.ok) throw new Error('header unavailable');
-    mount.innerHTML = await res.text();
+    const cachedHtml = window.__grok2apiAdminHeaderHtml || readSessionCache(HEADER_HTML_CACHE_KEY);
+    if (cachedHtml) {
+      mount.innerHTML = cachedHtml;
+    } else {
+      const res = await fetch('/static/admin/header.html');
+      if (!res.ok) throw new Error('header unavailable');
+      const html = await res.text();
+      mount.innerHTML = html;
+      window.__grok2apiAdminHeaderHtml = html;
+      writeSessionCache(HEADER_HTML_CACHE_KEY, html);
+    }
   } catch {
     mount.innerHTML = `
       <header class="admin-header">

--- a/app/statics/js/webui-header.js
+++ b/app/statics/js/webui-header.js
@@ -1,7 +1,33 @@
 window.renderWebuiHeader = async function renderWebuiHeader() {
   const mount = document.getElementById('webui-header');
   if (!mount || mount.children.length) return;
+  const scriptVersion = (() => {
+    try {
+      const script = document.querySelector('script[src*="/static/js/webui-header.js"]');
+      if (!script) return 'v1';
+      return new URL(script.src, window.location.href).searchParams.get('v') || 'v1';
+    } catch {
+      return 'v1';
+    }
+  })();
+  const HEADER_HTML_CACHE_KEY = `grok2api.webui_header_html.${scriptVersion}`;
+  const META_VERSION_CACHE_KEY = `grok2api.meta_version.${scriptVersion}`;
   let appVersion = '';
+
+  const readSessionCache = (key) => {
+    try {
+      return sessionStorage.getItem(key) || '';
+    } catch {
+      return '';
+    }
+  };
+
+  const writeSessionCache = (key, value) => {
+    if (!value) return;
+    try {
+      sessionStorage.setItem(key, value);
+    } catch {}
+  };
 
   const languageCodes = {
     zh: 'CN',
@@ -86,11 +112,19 @@ window.renderWebuiHeader = async function renderWebuiHeader() {
   };
 
   const loadVersion = async () => {
+    const cachedVersion = window.__grok2apiMetaVersion || readSessionCache(META_VERSION_CACHE_KEY);
+    if (cachedVersion) {
+      appVersion = String(cachedVersion).trim();
+      window.__grok2apiMetaVersion = appVersion;
+      return;
+    }
     try {
-      const res = await fetch('/meta', { cache: 'no-store' });
+      const res = await fetch('/meta');
       if (!res.ok) throw new Error('meta unavailable');
       const data = await res.json();
       appVersion = String(data?.version || '').trim();
+      window.__grok2apiMetaVersion = appVersion;
+      writeSessionCache(META_VERSION_CACHE_KEY, appVersion);
     } catch {
       appVersion = '';
     }
@@ -118,9 +152,17 @@ window.renderWebuiHeader = async function renderWebuiHeader() {
   await loadVersion();
 
   try {
-    const res = await fetch('/static/webui/header.html', { cache: 'no-store' });
-    if (!res.ok) throw new Error('header unavailable');
-    mount.innerHTML = await res.text();
+    const cachedHtml = window.__grok2apiWebuiHeaderHtml || readSessionCache(HEADER_HTML_CACHE_KEY);
+    if (cachedHtml) {
+      mount.innerHTML = cachedHtml;
+    } else {
+      const res = await fetch('/static/webui/header.html');
+      if (!res.ok) throw new Error('header unavailable');
+      const html = await res.text();
+      mount.innerHTML = html;
+      window.__grok2apiWebuiHeaderHtml = html;
+      writeSessionCache(HEADER_HTML_CACHE_KEY, html);
+    }
   } catch {
     mount.innerHTML = `
       <header class="admin-header webui-header-bar">

--- a/app/statics/js/webui/chat.js
+++ b/app/statics/js/webui/chat.js
@@ -40,6 +40,8 @@
   let activeEdit = null;
   const PROMPT_MIN_HEIGHT = 36;
   const PROMPT_MAX_HEIGHT = 108;
+  let pendingThreadScrollFrame = 0;
+  let sessionListRenderSignature = '';
 
   function text(key, fallback, params) {
     if (typeof window.t !== 'function') return fallback;
@@ -77,6 +79,11 @@
 
   function hasVisibleReasoning(value) {
     return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  function hasMessageContent(value) {
+    const textValue = typeof value === 'string' ? value : extractTextContent(value);
+    return Boolean((textValue || '').trim());
   }
 
   function sanitizeUrl(value) {
@@ -675,7 +682,11 @@
   }
 
   function scrollThread() {
-    thread.scrollTop = thread.scrollHeight;
+    if (pendingThreadScrollFrame) return;
+    pendingThreadScrollFrame = window.requestAnimationFrame(() => {
+      pendingThreadScrollFrame = 0;
+      thread.scrollTop = thread.scrollHeight;
+    });
   }
 
   function hideEmpty() {
@@ -878,7 +889,7 @@
   function createMessage(role, initialText = '', initialReasoning = '', messageIndex = -1) {
     hideEmpty();
     const hasReasoning = role === 'assistant' && hasVisibleReasoning(initialReasoning);
-    const isAssistantWaiting = role === 'assistant' && messageIndex < 0 && !hasReasoning && typeof initialText === 'string' && !initialText.trim();
+    const isAssistantWaiting = role === 'assistant' && messageIndex < 0 && !hasReasoning && !hasMessageContent(initialText);
 
     const wrap = document.createElement('div');
     wrap.className = `msg ${role}`;
@@ -959,6 +970,21 @@
       renderMessageContent(card, role, initialText);
     }
 
+    const entry = {
+      wrap,
+      reasoning,
+      reasoningBody,
+      card,
+      text: initialText,
+      reasoningText: initialReasoning,
+      waiting: isAssistantWaiting,
+      messageIndex,
+      actions: null,
+      likeBtn: null,
+      dislikeBtn: null,
+      renderFrame: 0,
+    };
+
     if (role === 'assistant') {
       wrap.appendChild(reasoning);
     }
@@ -1016,7 +1042,7 @@
       regenBtn.setAttribute('title', text('webui.chat.regenerate', 'Regenerate'));
       regenBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M21 2v6h-6" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 11a9 9 0 0 1 15.3-6.3L21 8" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 22v-6h6" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><path d="M21 13a9 9 0 0 1-15.3 6.3L3 16" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       regenBtn.addEventListener('click', () => {
-        regenerateAssistantAt(messageIndex);
+        regenerateAssistantAt(entry.messageIndex);
       });
 
       const copyBtn = document.createElement('button');
@@ -1027,7 +1053,7 @@
       copyBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="9" y="9" width="10" height="10" rx="3" stroke="currentColor" stroke-width="1.7"/><path d="M15 9V8a3 3 0 0 0-3-3H8a3 3 0 0 0-3 3v4a3 3 0 0 0 3 3h1" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>';
       copyBtn.addEventListener('click', async () => {
         try {
-          await copyToClipboard(typeof initialText === 'string' ? initialText : extractTextContent(initialText));
+          await copyToClipboard(typeof entry.text === 'string' ? entry.text : extractTextContent(entry.text));
           toast(text('webui.chat.copySuccess', 'Copied'), 'info');
         } catch (error) {
           toast(error.message || String(error), 'error');
@@ -1041,7 +1067,7 @@
       likeBtn.setAttribute('title', text('webui.chat.like', 'Like'));
       likeBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M7 11.5v7.5M10.5 19h6.1a1.8 1.8 0 0 0 1.76-1.44l1.12-5.6A1.8 1.8 0 0 0 17.72 10H14V6.9a1.7 1.7 0 0 0-3.12-.93L7 11.5v7.5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       likeBtn.addEventListener('click', () => {
-        setAssistantFeedback(messageIndex, 'up');
+        setAssistantFeedback(entry.messageIndex, 'up');
       });
 
       const dislikeBtn = document.createElement('button');
@@ -1051,7 +1077,7 @@
       dislikeBtn.setAttribute('title', text('webui.chat.dislike', 'Dislike'));
       dislikeBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M7 12.5V5M10.5 5h6.1a1.8 1.8 0 0 1 1.76 1.44l1.12 5.6A1.8 1.8 0 0 1 17.72 14H14v3.1a1.7 1.7 0 0 1-3.12.93L7 12.5V5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>';
       dislikeBtn.addEventListener('click', () => {
-        setAssistantFeedback(messageIndex, 'down');
+        setAssistantFeedback(entry.messageIndex, 'down');
       });
 
       right.appendChild(regenBtn);
@@ -1060,37 +1086,79 @@
       right.appendChild(dislikeBtn);
       actions.appendChild(right);
       wrap.appendChild(actions);
+      entry.actions = actions;
+      entry.likeBtn = likeBtn;
+      entry.dislikeBtn = dislikeBtn;
     }
 
     thread.appendChild(wrap);
 
-    return {
-      reasoning,
-      reasoningBody,
-      card,
-      text: initialText,
-      reasoningText: initialReasoning,
-      waiting: isAssistantWaiting,
-    };
+    syncAssistantActions(entry);
+    return entry;
+  }
+
+  function syncAssistantActions(entry) {
+    if (!entry || !entry.actions) return;
+    entry.actions.hidden = entry.messageIndex < 0;
+    const message = entry.messageIndex >= 0 ? messages[entry.messageIndex] : null;
+    if (entry.likeBtn) entry.likeBtn.classList.toggle('active', Boolean(message && message.feedback === 'up'));
+    if (entry.dislikeBtn) entry.dislikeBtn.classList.toggle('active', Boolean(message && message.feedback === 'down'));
+  }
+
+  function renderAssistantEntry(entry) {
+    if (!entry) return;
+    entry.renderFrame = 0;
+    if (entry.waiting) return;
+    if (hasMessageContent(entry.text)) {
+      renderMessageContent(entry.card, 'assistant', entry.text);
+    } else {
+      entry.card.innerHTML = '';
+    }
+    const hasReasoning = hasVisibleReasoning(entry.reasoningText);
+    entry.reasoning.hidden = !hasReasoning;
+    entry.reasoningBody.textContent = hasReasoning ? entry.reasoningText : '';
+  }
+
+  function scheduleAssistantEntryRender(entry) {
+    if (!entry) return;
+    if (!entry.renderFrame) {
+      entry.renderFrame = window.requestAnimationFrame(() => {
+        renderAssistantEntry(entry);
+        scrollThread();
+      });
+    } else {
+      scrollThread();
+    }
+  }
+
+  function flushAssistantEntry(entry) {
+    if (!entry) return;
+    if (entry.renderFrame) {
+      window.cancelAnimationFrame(entry.renderFrame);
+      entry.renderFrame = 0;
+    }
+    renderAssistantEntry(entry);
+  }
+
+  function finalizeAssistantEntry(entry, messageIndex) {
+    if (!entry) return;
+    entry.waiting = false;
+    flushAssistantEntry(entry);
+    entry.messageIndex = messageIndex;
+    syncAssistantActions(entry);
+    scrollThread();
   }
 
   function updateAssistant(entry, delta) {
     if (entry.waiting) entry.waiting = false;
     entry.text += delta;
-    renderMessageContent(entry.card, 'assistant', entry.text);
-    scrollThread();
+    scheduleAssistantEntryRender(entry);
   }
 
   function updateReasoning(entry, delta) {
-    if (entry.waiting) {
-      entry.waiting = false;
-      entry.card.innerHTML = '';
-    }
+    if (entry.waiting) entry.waiting = false;
     entry.reasoningText += delta;
-    const hasReasoning = hasVisibleReasoning(entry.reasoningText);
-    entry.reasoning.hidden = !hasReasoning;
-    entry.reasoningBody.textContent = hasReasoning ? entry.reasoningText : '';
-    scrollThread();
+    scheduleAssistantEntryRender(entry);
   }
 
   function renderThread() {
@@ -1114,8 +1182,11 @@
 
   function renderSessionList() {
     if (!sessionList) return;
-    sessionList.innerHTML = '';
     sessionList.dataset.empty = text('webui.chat.noSessions', 'No chats yet');
+    const nextSignature = `${currentSessionId}|${sessions.map((session) => `${session.id}:${session.title || ''}`).join('|')}`;
+    if (nextSignature === sessionListRenderSignature) return;
+    sessionListRenderSignature = nextSignature;
+    const fragment = document.createDocumentFragment();
 
     sessions.forEach((session) => {
       const item = document.createElement('button');
@@ -1154,8 +1225,9 @@
       item.appendChild(title);
       item.appendChild(actions);
       item.addEventListener('click', () => switchSession(session.id));
-      sessionList.appendChild(item);
+      fragment.appendChild(item);
     });
+    sessionList.replaceChildren(fragment);
   }
 
   function syncCurrentSession() {
@@ -1369,7 +1441,7 @@
             feedback: '',
           });
           syncCurrentSession();
-          renderThread();
+          finalizeAssistantEntry(assistantEntry, messages.length - 1);
           setStatus(text('webui.chat.statusDone', 'Completed'));
           return true;
         }
@@ -1427,7 +1499,7 @@
         feedback: '',
       });
       syncCurrentSession();
-      renderThread();
+      finalizeAssistantEntry(assistantEntry, messages.length - 1);
       setStatus(text('webui.chat.statusDone', 'Completed'));
     } catch (error) {
       if (error && error.name === 'AbortError') {

--- a/app/statics/js/webui/chatkit.js
+++ b/app/statics/js/webui/chatkit.js
@@ -20,6 +20,10 @@
   let orbLevel = 0;
   let orbBeat = 0;
   let orbMotionPhase = 0;
+  const audioElements = new Set();
+  let lastStatusState = '';
+  let lastStatusLabel = '';
+  let lastStatusDescription = '';
 
   const controlIcon = {
     start: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 7.25 17 12l-8 4.75V7.25Z" fill="currentColor" stroke="none"/></svg>',
@@ -206,12 +210,17 @@
   };
 
   const setStatus = (state, label, description) => {
-    if (connectionBadge) connectionBadge.textContent = label;
-    if (connectionBadge) connectionBadge.dataset.state = state;
-    if (connectionText) connectionText.textContent = description;
+    if (connectionBadge && lastStatusLabel !== label) connectionBadge.textContent = label;
+    if (connectionBadge && lastStatusState !== state) connectionBadge.dataset.state = state;
+    if (connectionText && lastStatusDescription !== description) connectionText.textContent = description;
+    lastStatusState = state;
+    lastStatusLabel = label;
+    lastStatusDescription = description;
     if (voiceOrb) {
-      voiceOrb.classList.remove('is-idle', 'is-connecting', 'is-live', 'is-paused', 'is-output-muted', 'is-error');
-      voiceOrb.classList.add(state);
+      if (!voiceOrb.classList.contains(state)) {
+        voiceOrb.classList.remove('is-idle', 'is-connecting', 'is-live', 'is-paused', 'is-output-muted', 'is-error');
+        voiceOrb.classList.add(state);
+      }
       if (state !== 'is-live') {
         voiceOrb.classList.remove('is-speaking');
         setOrbLevel(0);
@@ -285,14 +294,14 @@
 
   const detachAudio = () => {
     stopOrbAnalysis();
-    if (!audioRoot) return;
-    audioRoot.querySelectorAll('audio').forEach((node) => {
+    audioElements.forEach((node) => {
       try {
         node.pause();
         node.srcObject = null;
       } catch {}
       node.remove();
     });
+    audioElements.clear();
   };
 
   const getLiveKit = () => window.LiveKitClient || window.LivekitClient || null;
@@ -309,6 +318,7 @@
     element.playsInline = true;
     element.muted = outputMuted;
     audioRoot.appendChild(element);
+    audioElements.add(element);
     const stream = element.srcObject instanceof MediaStream ? element.srcObject : null;
     const streamId = stream?.id || stream?.getAudioTracks?.()[0]?.id || '';
     if (stream && streamId) {
@@ -330,6 +340,7 @@
             streamId = el.srcObject.id || el.srcObject.getAudioTracks?.()[0]?.id || '';
           }
           if (streamId) removeOrbInput(`remote:${streamId}`);
+          if (el instanceof HTMLAudioElement) audioElements.delete(el);
           el.remove();
         });
       } catch {}
@@ -437,11 +448,9 @@
   const toggleOutputMute = () => {
     if (!room) return;
     outputMuted = !outputMuted;
-    if (audioRoot) {
-      audioRoot.querySelectorAll('audio').forEach((node) => {
-        node.muted = outputMuted;
-      });
-    }
+    audioElements.forEach((node) => {
+      node.muted = outputMuted;
+    });
     setButtons(true);
     renderConnectedStatus();
   };

--- a/app/statics/js/webui/masonry.js
+++ b/app/statics/js/webui/masonry.js
@@ -19,6 +19,7 @@
   let activeSocket = null;
   let sending = false;
   let streamState = null;
+  let pendingGridSyncFrame = 0;
 
   function aspectRatioCss(value) {
     const ratio = String(value || '').trim();
@@ -40,12 +41,22 @@
   function syncBatchGrid(grid) {
     if (!(grid instanceof HTMLElement)) return;
     const columns = computeGridColumns(grid.clientWidth);
+    if (grid.dataset.columns === String(columns)) return;
+    grid.dataset.columns = String(columns);
     grid.style.setProperty('--masonry-columns', String(columns));
   }
 
   function syncAllBatchGrids() {
     feed?.querySelectorAll('.webui-masonry-grid').forEach((grid) => {
       syncBatchGrid(grid);
+    });
+  }
+
+  function scheduleAllBatchGridsSync() {
+    if (pendingGridSyncFrame) return;
+    pendingGridSyncFrame = window.requestAnimationFrame(() => {
+      pendingGridSyncFrame = 0;
+      syncAllBatchGrids();
     });
   }
 
@@ -154,6 +165,37 @@
 
     const body = document.createElement('div');
     body.className = 'webui-masonry-tile-body';
+
+    const link = document.createElement('a');
+    link.className = 'webui-masonry-tile-link';
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.setAttribute('aria-label', text('webui.masonry.openImage', '打开图片'));
+    link.title = text('webui.masonry.openImage', '打开图片');
+
+    const img = document.createElement('img');
+    img.alt = `image ${index}`;
+    img.loading = 'lazy';
+    link.appendChild(img);
+
+    const label = document.createElement('div');
+    label.className = 'webui-masonry-tile-label';
+
+    const progressShell = document.createElement('div');
+    progressShell.className = 'webui-masonry-tile-progress';
+
+    const progressValue = document.createElement('div');
+    progressValue.className = 'webui-masonry-tile-progress-value';
+
+    const progressTrack = document.createElement('div');
+    progressTrack.className = 'webui-masonry-tile-progress-track';
+
+    const progressFill = document.createElement('div');
+    progressFill.className = 'webui-masonry-tile-progress-fill';
+    progressTrack.appendChild(progressFill);
+    progressShell.appendChild(progressValue);
+    progressShell.appendChild(progressTrack);
+
     tile.appendChild(badge);
     tile.appendChild(body);
 
@@ -165,6 +207,15 @@
       moderated: false,
       tile,
       body,
+      link,
+      img,
+      label,
+      progressShell,
+      progressValue,
+      progressFill,
+      renderedState: '',
+      renderedProgress: -1,
+      renderedUrl: '',
     };
   }
 
@@ -240,12 +291,14 @@
       completed: false,
       failed: false,
       finalized: false,
+      readyCount: 0,
+      filteredCount: 0,
     };
   }
 
   function updateBatchMeta(batch) {
-    const completed = batch.slots.filter((slot) => slot.url && !slot.moderated).length;
-    const filtered = batch.slots.filter((slot) => slot.moderated).length;
+    const completed = batch.readyCount;
+    const filtered = batch.filteredCount;
     batch.count.textContent = `${completed}/${IMAGE_COUNT}`;
 
     if (!batch.finalized) {
@@ -284,59 +337,53 @@
   }
 
   function renderSlot(slot) {
-    slot.tile.classList.remove('is-pending', 'is-ready', 'is-filtered');
-    slot.body.replaceChildren();
+    const nextState = slot.url ? 'ready' : (slot.moderated ? 'filtered' : 'pending');
+    slot.tile.classList.toggle('is-pending', nextState === 'pending');
+    slot.tile.classList.toggle('is-ready', nextState === 'ready');
+    slot.tile.classList.toggle('is-filtered', nextState === 'filtered');
 
-    if (slot.url) {
-      slot.tile.classList.add('is-ready');
-      const link = document.createElement('a');
-      link.className = 'webui-masonry-tile-link';
-      link.href = slot.url;
-      link.target = '_blank';
-      link.rel = 'noopener';
-      link.setAttribute('aria-label', text('webui.masonry.openImage', '打开图片'));
-      link.title = text('webui.masonry.openImage', '打开图片');
-
-      const img = document.createElement('img');
-      img.src = slot.url;
-      img.alt = `image ${slot.index}`;
-      img.loading = 'lazy';
-
-      link.appendChild(img);
-      slot.body.appendChild(link);
+    if (nextState === 'ready') {
+      if (slot.renderedUrl !== slot.url) {
+        slot.link.href = slot.url;
+        slot.img.src = slot.url;
+        slot.renderedUrl = slot.url;
+      }
+      if (slot.renderedState !== nextState) slot.body.replaceChildren(slot.link);
+      slot.renderedState = nextState;
       return;
     }
 
-    const label = document.createElement('div');
-    if (slot.moderated) {
-      label.className = 'webui-masonry-tile-label';
-      label.textContent = text('webui.masonry.batchFiltered', '已过滤');
-      slot.tile.classList.add('is-filtered');
-    } else {
-      const progress = Math.max(0, Math.min(99, slot.progress || 0));
-      const shell = document.createElement('div');
-      shell.className = 'webui-masonry-tile-progress';
-
-      const value = document.createElement('div');
-      value.className = 'webui-masonry-tile-progress-value';
-      value.textContent = `${progress}%`;
-
-      const track = document.createElement('div');
-      track.className = 'webui-masonry-tile-progress-track';
-
-      const fill = document.createElement('div');
-      fill.className = 'webui-masonry-tile-progress-fill';
-      fill.style.width = `${progress}%`;
-
-      track.appendChild(fill);
-      shell.appendChild(value);
-      shell.appendChild(track);
-      slot.tile.classList.add('is-pending');
-      slot.body.appendChild(shell);
+    slot.renderedUrl = '';
+    if (nextState === 'filtered') {
+      slot.label.textContent = text('webui.masonry.batchFiltered', '已过滤');
+      if (slot.renderedState !== nextState) slot.body.replaceChildren(slot.label);
+      slot.renderedState = nextState;
       return;
     }
 
-    slot.body.appendChild(label);
+    const progress = Math.max(0, Math.min(99, slot.progress || 0));
+    if (slot.renderedProgress !== progress) {
+      slot.progressValue.textContent = `${progress}%`;
+      slot.progressFill.style.width = `${progress}%`;
+      slot.renderedProgress = progress;
+    }
+    if (slot.renderedState !== nextState) slot.body.replaceChildren(slot.progressShell);
+    slot.renderedState = nextState;
+  }
+
+  function slotOutcome(slot) {
+    if (slot.url && !slot.moderated) return 'ready';
+    if (slot.moderated) return 'filtered';
+    return 'pending';
+  }
+
+  function updateBatchCounts(batch, previousOutcome, nextOutcome) {
+    if (previousOutcome === nextOutcome) return false;
+    if (previousOutcome === 'ready') batch.readyCount = Math.max(0, batch.readyCount - 1);
+    if (previousOutcome === 'filtered') batch.filteredCount = Math.max(0, batch.filteredCount - 1);
+    if (nextOutcome === 'ready') batch.readyCount += 1;
+    if (nextOutcome === 'filtered') batch.filteredCount += 1;
+    return true;
   }
 
   function findSlot(batch, payload) {
@@ -364,6 +411,7 @@
   function syncBatch(batch, payload) {
     const slot = findSlot(batch, payload);
     if (!slot) return;
+    const previousOutcome = slotOutcome(slot);
 
     if (payload.type === 'progress') {
       slot.progress = Number(payload.progress) || slot.progress || 0;
@@ -377,8 +425,10 @@
       slot.moderated = true;
     }
 
+    const nextOutcome = slotOutcome(slot);
+    const countsChanged = updateBatchCounts(batch, previousOutcome, nextOutcome);
     renderSlot(slot);
-    updateBatchMeta(batch);
+    if (countsChanged || payload.type !== 'progress') updateBatchMeta(batch);
   }
 
   function createStreamState(prompt, aspectRatio, quality, mode) {
@@ -470,8 +520,7 @@
 
       if (payload.type === 'progress' || payload.type === 'image' || payload.type === 'moderated') {
         syncBatch(batch, payload);
-        const ready = batch.slots.filter((slot) => slot.url && !slot.moderated).length;
-        setStatus(`${text('webui.masonry.statusGenerating', '生成中…')} ${ready}/${IMAGE_COUNT} · ${formatRoundLabel(batch.round)}`, 'running');
+        setStatus(`${text('webui.masonry.statusGenerating', '生成中…')} ${batch.readyCount}/${IMAGE_COUNT} · ${formatRoundLabel(batch.round)}`, 'running');
         return;
       }
 
@@ -666,7 +715,7 @@
     } catch {}
     activeSocket = null;
   });
-  window.addEventListener('resize', syncAllBatchGrids);
+  window.addEventListener('resize', scheduleAllBatchGridsSync);
 
   boot().catch((error) => {
     console.error('webui masonry boot failed', error);


### PR DESCRIPTION
## Summary

- 优化前端渲染性能，覆盖 WebUI 和 Admin 两侧的主要卡顿点。
- WebUI Chat 改为按帧批处理流式更新，减少滚动抖动，并避免在回复完成时整段会话全量重渲染。
- WebUI Masonry 改为复用 tile 节点、增量更新进度和完成计数，减少高频 `replaceChildren()` 带来的重排重绘。
- WebUI ChatKit 优化状态栏与音频节点更新，避免重复 DOM 写入和全量音频节点扫描。
- Admin 账号页缓存筛选/统计结果，减少同一批数据被重复遍历；配置页改为按依赖局部刷新，避免每次输入都全页面扫描。
- Header 增加按构建版本隔离的缓存，减少跨页重复请求 header 模板和版本信息，同时避免部署新版本后继续读取旧缓存。

## Testing

- `node --check app/statics/js/webui/chat.js`
- `node --check app/statics/js/webui/masonry.js`
- `node --check app/statics/js/webui/chatkit.js`
- `node --check app/statics/js/webui-header.js`
- `node --check app/statics/js/admin-header.js`
- 使用 Node 解析校验 `app/statics/admin/account.html` 与 `app/statics/admin/config.html` 内联脚本语法
- 本地启动服务进行 smoke test：`uv run granian --interface asgi --host 127.0.0.1 --port 18082 --workers 1 app.main:app`
- 路由验证：当前本地配置 `data/config.toml` 中 `webui_enabled = false`，因此 `GET /webui/chat`、`/webui/masonry`、`/webui/chatkit` 返回 `404`，符合当前配置预期

## Related

- N/A
