### PR TITLE
feat: search citations — 信源透传 + 结构化字段 + url_citation annotations

### DIFF
--- a/app/dataplane/reverse/protocol/xai_chat.py
+++ b/app/dataplane/reverse/protocol/xai_chat.py
@@ -222,6 +222,20 @@ class StreamAdapter:
             lines.append(f"- [{title}]({item['url']})")
         return "\n".join(lines) + "\n"
 
+    # 结构化搜索信源：始终输出（不受配置开关控制），供 search_sources 字段使用
+    def search_sources_list(self) -> list[dict] | None:
+        """当有搜索信源时，返回结构化列表；无则返回 None。"""
+        if not self._web_search_results:
+            return None
+        return [
+            {
+                "url": item["url"],
+                "title": item.get("title") or item.get("url", ""),
+                "type": item.get("type", "web"),
+            }
+            for item in self._web_search_results
+        ]
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -255,7 +269,7 @@ class StreamAdapter:
                     url = item["url"]
                     if url not in self._web_search_urls_seen:
                         self._web_search_urls_seen.add(url)
-                        self._web_search_results.append(item)
+                        self._web_search_results.append({**item, "type": "web"})
 
         # ── 采集 xSearchResults（X/Twitter 帖子信源，多帧累积去重）──
         xsr = resp.get("xSearchResults")
@@ -272,7 +286,7 @@ class StreamAdapter:
                             title = f"𝕏/@{item['username']}: {raw[:50]}{'...' if len(raw) > 50 else ''}"
                         else:
                             title = f"𝕏/@{item['username']}"
-                        self._web_search_results.append({"url": url, "title": title})
+                        self._web_search_results.append({"url": url, "title": title, "type": "x_post"})
 
         token   = resp.get("token")
         think   = resp.get("isThinking")

--- a/app/dataplane/reverse/protocol/xai_chat.py
+++ b/app/dataplane/reverse/protocol/xai_chat.py
@@ -127,6 +127,7 @@ class FrameEvent:
     - ``thinking``  — Grok main-model thinking   (content = raw token)
     - ``image``     — generated image final URL   (content = full URL, image_id = upstream UUID)
     - ``image_progress`` — generated image progress (content = percent string, image_id = upstream UUID)
+    - ``annotation`` — url citation annotation   (annotation_data = annotation dict)
     - ``soft_stop`` — stream end signal
     - ``skip``      — filtered frame, do nothing
     """
@@ -135,6 +136,7 @@ class FrameEvent:
     rollout_id: str = ""
     message_tag: str = ""
     message_step_id: int | None = None
+    annotation_data: dict | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +178,9 @@ class StreamAdapter:
         "_citation_order",
         "_citation_map",
         "_last_citation_index",
+        "_pending_citations",
+        "_annotations",
+        "_text_offset",
         "_emitted_reasoning_keys",
         "_reasoning",
         "_summary_mode",
@@ -193,6 +198,9 @@ class StreamAdapter:
         self._citation_order: list[str] = []
         self._citation_map: dict[str, int] = {}
         self._last_citation_index: int = -1
+        self._pending_citations: list[dict] = []       # _render_replace 产出的待定位引用
+        self._annotations: list[dict] = []             # 已定位的完整 annotations（绝对位置）
+        self._text_offset: int = 0                     # 累计文本长度（仅 text 事件）
         self._emitted_reasoning_keys: set[str] = set()
         # 思维链模式：精简摘要 / 详细原始流
         self._summary_mode: bool = get_config().get_bool("features.thinking_summary", False)
@@ -221,6 +229,11 @@ class StreamAdapter:
             title = title.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
             lines.append(f"- [{title}]({item['url']})")
         return "\n".join(lines) + "\n"
+
+    # 内联引用 annotations：生成时同步构建，含绝对位置
+    def annotations_list(self) -> list[dict]:
+        """已收集的 url_citation annotations（扁平格式，绝对位置）。无引用时返回 []。"""
+        return list(self._annotations)
 
     # 结构化搜索信源：始终输出（不受配置开关控制），供 search_sources 字段使用
     def search_sources_list(self) -> list[dict] | None:
@@ -373,10 +386,18 @@ class StreamAdapter:
         # ── final text token (needs cleaning) ─────────────────────
         if token is not None and think is not True and tag == "final":
             self._content_started = True
-            cleaned = self._clean_token(token)
+            cleaned, local_anns = self._clean_token(token)
             if cleaned:
+                # 先发 text 事件（OpenAI 顺序：text.delta 先，annotation.added 后）
                 self.text_buf.append(cleaned)
                 events.append(FrameEvent("text", cleaned))
+                # 再发 annotation 事件：局部位置 → 绝对位置
+                for ann in local_anns:
+                    ann["start_index"] = self._text_offset + ann.pop("local_start")
+                    ann["end_index"] = self._text_offset + ann.pop("local_end")
+                    self._annotations.append(ann)
+                    events.append(FrameEvent("annotation", annotation_data=ann))
+                self._text_offset += len(cleaned)
             return events
 
         # ── end signals ───────────────────────────────────────────
@@ -428,12 +449,32 @@ class StreamAdapter:
     # Token cleaning — <grok:render> → markdown
     # ------------------------------------------------------------------
 
-    def _clean_token(self, token: str) -> str:
+    # 返回 (cleaned_text, local_annotations)，annotations 含局部 start/end
+    def _clean_token(self, token: str) -> tuple[str, list[dict]]:
         if "<grok:render" not in token:
-            return token
+            return token, []
         cleaned = _GROK_RENDER_RE.sub(self._render_replace, token)
         # 去除引用标签替换后残留的独占空白行（如 "\n [[1]](...)" → " [[1]](...)"）
-        return cleaned.lstrip("\n") if cleaned.startswith("\n") and "[[" in cleaned else cleaned
+        cleaned = cleaned.lstrip("\n") if cleaned.startswith("\n") and "[[" in cleaned else cleaned
+
+        # 从 cleaned 中定位 pending citations 的局部位置（游标递进防碰撞）
+        local_annotations: list[dict] = []
+        if self._pending_citations:
+            search_start = 0
+            for cite in self._pending_citations:
+                pos = cleaned.find(cite["needle"], search_start)
+                if pos != -1:
+                    local_annotations.append({
+                        "type": "url_citation",
+                        "url": cite["url"],
+                        "title": cite["title"],
+                        "local_start": pos,
+                        "local_end": pos + len(cite["needle"]),
+                    })
+                    search_start = pos + len(cite["needle"])
+                # 找不到 → fail closed，跳过此 annotation
+            self._pending_citations.clear()
+        return cleaned, local_annotations
 
     def _render_replace(self, m: re.Match) -> str:
         card_id     = m.group(1)
@@ -467,7 +508,22 @@ class StreamAdapter:
             if index == self._last_citation_index:
                 return ""
             self._last_citation_index = index
-            return f" [[{index}]]({url})"
+            citation_text = f" [[{index}]]({url})"
+            # 解析标题：card → webSearchResults → URL fallback
+            # Grok citation card 仅含 [id, type, cardType, url]，无 title 字段
+            title = card.get("title", "")
+            if not title:
+                for item in self._web_search_results:
+                    if item.get("url") == url:
+                        title = item.get("title", "")
+                        break
+            # 记录引用元数据，位置在 _clean_token 返回后定位
+            self._pending_citations.append({
+                "url": url,
+                "title": title or url,
+                "needle": citation_text,
+            })
+            return citation_text
 
         return ""
 

--- a/app/dataplane/reverse/protocol/xai_chat.py
+++ b/app/dataplane/reverse/protocol/xai_chat.py
@@ -181,6 +181,8 @@ class StreamAdapter:
         "_summary_mode",
         "_last_rollout",
         "_content_started",
+        "_web_search_results",
+        "_web_search_urls_seen",
         "thinking_buf",
         "text_buf",
         "image_urls",
@@ -197,14 +199,28 @@ class StreamAdapter:
         self._last_rollout: str = ""
         self._content_started: bool = False
         self._reasoning = ReasoningAggregator() if self._summary_mode else None
+        self._web_search_results: list[dict] = []
+        self._web_search_urls_seen: set[str] = set()
         self.thinking_buf: list[str] = []
         self.text_buf: list[str] = []
         self.image_urls: list[tuple[str, str]] = []   # [(url, imageUuid), ...]
 
-    # 引用已内联为 [[N]](url) 格式，无需末尾附录
+    # 搜索信源追加：当配置启用且有 webSearchResults 时，格式化为 ## Sources 段落
+    # 标记行 [grok2api-sources]: # 是 markdown link reference definition，渲染器不显示，
+    # 用于 _extract_message() 在多轮对话中精确识别并剥离前轮的 Sources 段落
     def references_suffix(self) -> str:
-        """No-op — citations are now inlined as ``[[N]](url)`` markdown links."""
-        return ""
+        """当有搜索信源且配置启用时，格式化为 ## Sources markdown 段落。"""
+        if not self._web_search_results:
+            return ""
+        if not get_config().get_bool("features.show_search_sources", False):
+            return ""
+        lines = ["\n\n## Sources", "[grok2api-sources]: #"]
+        for item in self._web_search_results:
+            title = item.get("title") or item.get("url", "")
+            # 转义 Markdown 链接文本中的特殊字符，防止 []\ 打坏语法
+            title = title.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+            lines.append(f"- [{title}]({item['url']})")
+        return "\n".join(lines) + "\n"
 
     # ------------------------------------------------------------------
     # Public API
@@ -230,6 +246,33 @@ class StreamAdapter:
         card_raw = resp.get("cardAttachment")
         if card_raw:
             events.extend(self._handle_card(card_raw))
+
+        # ── 采集 webSearchResults（搜索信源，多帧累积去重）───────
+        wsr = resp.get("webSearchResults")
+        if wsr and isinstance(wsr, dict):
+            for item in wsr.get("results", []):
+                if isinstance(item, dict) and item.get("url"):
+                    url = item["url"]
+                    if url not in self._web_search_urls_seen:
+                        self._web_search_urls_seen.add(url)
+                        self._web_search_results.append(item)
+
+        # ── 采集 xSearchResults（X/Twitter 帖子信源，多帧累积去重）──
+        xsr = resp.get("xSearchResults")
+        if xsr and isinstance(xsr, dict):
+            for item in xsr.get("results", []):
+                if isinstance(item, dict) and item.get("postId") and item.get("username"):
+                    url = f"https://x.com/{item['username']}/status/{item['postId']}"
+                    if url not in self._web_search_urls_seen:
+                        self._web_search_urls_seen.add(url)
+                        # 构造 title：归一化空白，text 为空退回 @username
+                        # Markdown 转义统一在 references_suffix() 中处理
+                        raw = re.sub(r"\s+", " ", (item.get("text") or "")).strip()
+                        if raw:
+                            title = f"𝕏/@{item['username']}: {raw[:50]}{'...' if len(raw) > 50 else ''}"
+                        else:
+                            title = f"𝕏/@{item['username']}"
+                        self._web_search_results.append({"url": url, "title": title})
 
         token   = resp.get("token")
         think   = resp.get("isThinking")

--- a/app/products/anthropic/messages.py
+++ b/app/products/anthropic/messages.py
@@ -341,6 +341,7 @@ async def create(
             tool_calls_emitted    = False
             tool_output_tokens    = 0
             block_index           = 0  # tracks next content_block index
+            collected_annotations: list[dict] = []
 
             try:
                 try:
@@ -455,6 +456,9 @@ async def create(
                                         "delta": {"type": "text_delta", "text": text_chunk},
                                     })
 
+                            elif ev.kind == "annotation" and ev.annotation_data:
+                                collected_annotations.append(ev.annotation_data)
+
                             elif ev.kind == "soft_stop":
                                 ended = True
                                 break
@@ -561,11 +565,13 @@ async def create(
                         if full_think:
                             out_tokens += estimate_tokens(full_think)
 
-                        # 构建 message_delta，注入结构化搜索信源
+                        # 构建 message_delta，注入结构化搜索信源和 annotations
                         msg_delta: dict = {"stop_reason": "end_turn", "stop_sequence": None}
                         sources = adapter.search_sources_list()
                         if sources:
                             msg_delta["search_sources"] = sources
+                        if collected_annotations:
+                            msg_delta["annotations"] = collected_annotations
                         yield _sse("message_delta", {
                             "type":  "message_delta",
                             "delta": msg_delta,
@@ -741,6 +747,9 @@ async def create(
     )
 
     content = [{"type": "text", "text": full_text}]
+    anns = adapter.annotations_list()
+    if anns:
+        content[0]["annotations"] = anns
     resp = _build_message_response(msg_id, model, content, "end_turn", in_tokens, out_tokens)
     sources = adapter.search_sources_list()
     if sources:

--- a/app/products/anthropic/messages.py
+++ b/app/products/anthropic/messages.py
@@ -502,9 +502,14 @@ async def create(
                             tool_calls_emitted = True
 
                     if tool_calls_emitted:
+                        # 构建 tool_use 的 message_delta，注入搜索信源
+                        tool_delta: dict = {"stop_reason": "tool_use", "stop_sequence": None}
+                        sources = adapter.search_sources_list()
+                        if sources:
+                            tool_delta["search_sources"] = sources
                         yield _sse("message_delta", {
                             "type":  "message_delta",
-                            "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                            "delta": tool_delta,
                             "usage": {"output_tokens": tool_output_tokens},
                         })
                         yield _sse("message_stop", {"type": "message_stop"})
@@ -556,9 +561,14 @@ async def create(
                         if full_think:
                             out_tokens += estimate_tokens(full_think)
 
+                        # 构建 message_delta，注入结构化搜索信源
+                        msg_delta: dict = {"stop_reason": "end_turn", "stop_sequence": None}
+                        sources = adapter.search_sources_list()
+                        if sources:
+                            msg_delta["search_sources"] = sources
                         yield _sse("message_delta", {
                             "type":  "message_delta",
-                            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                            "delta": msg_delta,
                             "usage": {"output_tokens": out_tokens},
                         })
                         yield _sse("message_stop", {"type": "message_stop"})
@@ -718,7 +728,12 @@ async def create(
                 })
             ct = estimate_tool_call_tokens(tc_result.calls)
             logger.info("messages tool_calls: model={} calls={}", model, len(tc_result.calls))
-            return _build_message_response(msg_id, model, content, "tool_use", in_tokens, ct)
+            resp = _build_message_response(msg_id, model, content, "tool_use", in_tokens, ct)
+            # 注入结构化搜索信源（tool_use 场景）
+            sources = adapter.search_sources_list()
+            if sources:
+                resp["search_sources"] = sources
+            return resp
 
     logger.info(
         "messages request completed: model={} text_len={} think_len={} images={}",
@@ -726,7 +741,11 @@ async def create(
     )
 
     content = [{"type": "text", "text": full_text}]
-    return _build_message_response(msg_id, model, content, "end_turn", in_tokens, out_tokens)
+    resp = _build_message_response(msg_id, model, content, "end_turn", in_tokens, out_tokens)
+    sources = adapter.search_sources_list()
+    if sources:
+        resp["search_sources"] = sources
+    return resp
 
 
 __all__ = ["create"]

--- a/app/products/openai/_format.py
+++ b/app/products/openai/_format.py
@@ -49,6 +49,7 @@ def make_stream_chunk(
     is_final:      bool      = False,
     finish_reason: str | None = None,
     usage:         dict | None = None,
+    annotations:   list[dict] | None = None,
 ) -> dict:
     choice: dict = {
         "index": index,
@@ -56,6 +57,9 @@ def make_stream_chunk(
     }
     if is_final:
         choice["finish_reason"] = finish_reason or "stop"
+        # annotations 仅在 final chunk 的 delta 中发送（Vercel AI SDK 读 delta.annotations）
+        if annotations:
+            choice["delta"]["annotations"] = annotations
 
     chunk: dict = {
         "id":      response_id,
@@ -99,6 +103,7 @@ def make_chat_response(
     usage:             dict | None = None,
     reasoning_content: str | None  = None,
     search_sources:    list[dict] | None = None,
+    annotations:       list[dict] | None = None,
 ) -> dict:
     rid = response_id or make_response_id()
     pt  = estimate_prompt_tokens(prompt_content)
@@ -109,6 +114,8 @@ def make_chat_response(
     msg: dict = {"role": "assistant", "content": content}
     if reasoning_content:
         msg["reasoning_content"] = reasoning_content
+    if annotations:
+        msg["annotations"] = annotations
     resp = {
         "id":      rid,
         "object":  "chat.completion",

--- a/app/products/openai/_format.py
+++ b/app/products/openai/_format.py
@@ -98,6 +98,7 @@ def make_chat_response(
     response_id:       str | None  = None,
     usage:             dict | None = None,
     reasoning_content: str | None  = None,
+    search_sources:    list[dict] | None = None,
 ) -> dict:
     rid = response_id or make_response_id()
     pt  = estimate_prompt_tokens(prompt_content)
@@ -108,8 +109,7 @@ def make_chat_response(
     msg: dict = {"role": "assistant", "content": content}
     if reasoning_content:
         msg["reasoning_content"] = reasoning_content
-
-    return {
+    resp = {
         "id":      rid,
         "object":  "chat.completion",
         "created": int(time.time()),
@@ -121,6 +121,10 @@ def make_chat_response(
         }],
         "usage": usage or build_usage(pt, ct, reasoning_tokens=rt),
     }
+    # search_sources 放在响应根对象（避免 Vercel AI SDK 的 message strict schema 拒绝未知字段）
+    if search_sources:
+        resp["search_sources"] = search_sources
+    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import re
 from typing import Any, AsyncGenerator
 
 import orjson
@@ -188,6 +189,12 @@ def _normalize_image_format(value: str | None) -> str:
     return fmt
 
 
+# 精确匹配 grok2api 注入的 Sources 段落（含标记行），用于多轮对话剥离
+_SOURCES_STRIP_RE = re.compile(
+    r"(?:^|\r?\n\r?\n)## Sources\r?\n\[grok2api-sources\]: #\r?\n[\s\S]*$"
+)
+
+
 def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:
     """Flatten OpenAI messages into a single prompt string + file attachments."""
     parts: list[str] = []
@@ -220,6 +227,10 @@ def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:
                 parts.append(f"[assistant]:\n{xml}")
             continue
 
+        # ── 剥离前轮 assistant 消息中 grok2api 注入的 Sources 段落 ────────────
+        if role == "assistant" and isinstance(content, str):
+            content = _SOURCES_STRIP_RE.sub("", content)
+
         # ── normal content handling ───────────────────────────────────────────
         if isinstance(content, str):
             if content.strip():
@@ -230,7 +241,11 @@ def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:
                     continue
                 btype = block.get("type")
                 if btype == "text":
-                    text = (block.get("text") or "").strip()
+                    text = (block.get("text") or "")
+                    # 块列表中的 assistant text 也需剥离 Sources（先 regex 再 strip，与 str 路径对齐）
+                    if role == "assistant":
+                        text = _SOURCES_STRIP_RE.sub("", text)
+                    text = text.strip()
                     if text:
                         parts.append(f"[{role}]: {text}")
                 elif btype == "image_url":

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -52,6 +52,14 @@ from ._format import (
 from ._tool_sieve import ToolSieve
 
 
+def _to_chat_annotations(anns: list[dict]) -> list[dict]:
+    """扁平 annotations → Chat Completions 嵌套格式（内层无 type）"""
+    return [{"type": "url_citation", "url_citation": {
+        "url": a["url"], "title": a["title"],
+        "start_index": a["start_index"], "end_index": a["end_index"],
+    }} for a in anns] if anns else []
+
+
 def _log_task_exception(task: "asyncio.Task") -> None:
     """Done-callback: log exceptions from fire-and-forget tasks."""
     exc = task.exception() if not task.cancelled() else None
@@ -408,6 +416,7 @@ async def completions(
                 _retry = False
                 fail_exc: BaseException | None = None
                 adapter = StreamAdapter()
+                collected_annotations: list[dict] = []
 
                 try:
                     try:
@@ -478,6 +487,8 @@ async def completions(
                                         response_id, model, ev.content
                                     )
                                     yield f"data: {orjson.dumps(chunk).decode()}\n\n"
+                                elif ev.kind == "annotation" and ev.annotation_data:
+                                    collected_annotations.append(ev.annotation_data)
                                 elif ev.kind == "soft_stop":
                                     ended = True
                                     break
@@ -531,8 +542,10 @@ async def completions(
                                 )
                                 yield f"data: {orjson.dumps(chunk).decode()}\n\n"
 
+                            chat_anns = _to_chat_annotations(collected_annotations)
                             final = make_stream_chunk(
-                                response_id, model, "", is_final=True
+                                response_id, model, "", is_final=True,
+                                annotations=chat_anns or None,
                             )
                             # 注入结构化搜索信源到 chunk 根对象（避免 delta strict schema 拒绝）
                             sources = adapter.search_sources_list()
@@ -728,6 +741,7 @@ async def completions(
     pt = estimate_prompt_tokens(message)
     ct = estimate_tokens(full_text)
     rt = estimate_tokens(thinking_text) if thinking_text else 0
+    chat_anns = _to_chat_annotations(adapter.annotations_list())
     return make_chat_response(
         model,
         full_text,
@@ -735,6 +749,7 @@ async def completions(
         response_id=response_id,
         reasoning_content=thinking_text,
         search_sources=adapter.search_sources_list(),
+        annotations=chat_anns or None,
         usage=build_usage(pt, ct + rt, reasoning_tokens=rt),
     )
 

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -502,6 +502,10 @@ async def completions(
                                 done_chunk = make_tool_call_done_chunk(
                                     response_id, model
                                 )
+                                # 注入结构化搜索信源（tool_calls 场景）
+                                sources = adapter.search_sources_list()
+                                if sources:
+                                    done_chunk["search_sources"] = sources
                                 yield f"data: {orjson.dumps(done_chunk).decode()}\n\n"
                                 yield "data: [DONE]\n\n"
                                 tool_calls_emitted = True
@@ -530,6 +534,10 @@ async def completions(
                             final = make_stream_chunk(
                                 response_id, model, "", is_final=True
                             )
+                            # 注入结构化搜索信源到 chunk 根对象（避免 delta strict schema 拒绝）
+                            sources = adapter.search_sources_list()
+                            if sources:
+                                final["search_sources"] = sources
                             yield f"data: {orjson.dumps(final).decode()}\n\n"
                             yield "data: [DONE]\n\n"
                             success = True
@@ -694,13 +702,18 @@ async def completions(
                 len(parse_result.calls),
             )
             pt = estimate_prompt_tokens(message)
-            return make_tool_call_response(
+            resp = make_tool_call_response(
                 model,
                 parse_result.calls,
                 prompt_content=message,
                 response_id=response_id,
                 usage=build_usage(pt, estimate_tool_call_tokens(parse_result.calls)),
             )
+            # 注入结构化搜索信源（tool_calls 场景）
+            sources = adapter.search_sources_list()
+            if sources:
+                resp["search_sources"] = sources
+            return resp
 
     logger.info(
         "chat request completed: attempt={}/{} model={} text_len={} reasoning_len={} image_count={}",
@@ -721,6 +734,7 @@ async def completions(
         prompt_content=message,
         response_id=response_id,
         reasoning_content=thinking_text,
+        search_sources=adapter.search_sources_list(),
         usage=build_usage(pt, ct + rt, reasoning_tokens=rt),
     )
 

--- a/app/products/openai/responses.py
+++ b/app/products/openai/responses.py
@@ -271,6 +271,7 @@ async def create(
             sieve               = ToolSieve(tool_names) if tool_names else None
             tool_calls_emitted  = False
             detected_fc_items: list[dict] = []
+            collected_annotations: list[dict] = []
 
             try:
                 try:
@@ -399,6 +400,19 @@ async def create(
                                         "delta":         text_chunk,
                                     })
 
+                            elif ev.kind == "annotation" and ev.annotation_data:
+                                if message_started:
+                                    collected_annotations.append(ev.annotation_data)
+                                    msg_idx = 1 if reasoning_started else 0
+                                    yield format_sse("response.output_text.annotation.added", {
+                                        "type":             "response.output_text.annotation.added",
+                                        "item_id":          message_id,
+                                        "output_index":     msg_idx,
+                                        "content_index":    0,
+                                        "annotation_index": len(collected_annotations) - 1,
+                                        "annotation":       ev.annotation_data,
+                                    })
+
                             elif ev.kind == "soft_stop":
                                 ended = True
                                 break
@@ -485,7 +499,7 @@ async def create(
                                 "item_id":       message_id,
                                 "output_index":  msg_idx,
                                 "content_index": 0,
-                                "part":          {"type": "output_text", "text": full_text, "annotations": []},
+                                "part":          {"type": "output_text", "text": full_text, "annotations": collected_annotations},
                             })
                             # 构建 message item（流式 output_item.done + response.completed 共用）
                             sources = adapter.search_sources_list()
@@ -493,7 +507,7 @@ async def create(
                                 "id":      message_id,
                                 "type":    "message",
                                 "role":    "assistant",
-                                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+                                "content": [{"type": "output_text", "text": full_text, "annotations": collected_annotations}],
                                 "status":  "completed",
                             }
                             if sources:
@@ -519,7 +533,7 @@ async def create(
                                 "id":      message_id,
                                 "type":    "message",
                                 "role":    "assistant",
-                                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+                                "content": [{"type": "output_text", "text": full_text, "annotations": adapter.annotations_list()}],
                                 "status":  "completed",
                             }
                             sources = adapter.search_sources_list()
@@ -691,7 +705,7 @@ async def create(
         "id":      message_id,
         "type":    "message",
         "role":    "assistant",
-        "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+        "content": [{"type": "output_text", "text": full_text, "annotations": adapter.annotations_list()}],
         "status":  "completed",
     }
     sources = adapter.search_sources_list()

--- a/app/products/openai/responses.py
+++ b/app/products/openai/responses.py
@@ -487,16 +487,21 @@ async def create(
                                 "content_index": 0,
                                 "part":          {"type": "output_text", "text": full_text, "annotations": []},
                             })
+                            # 构建 message item（流式 output_item.done + response.completed 共用）
+                            sources = adapter.search_sources_list()
+                            msg_item: dict = {
+                                "id":      message_id,
+                                "type":    "message",
+                                "role":    "assistant",
+                                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+                                "status":  "completed",
+                            }
+                            if sources:
+                                msg_item["search_sources"] = sources
                             yield format_sse("response.output_item.done", {
                                 "type":         "response.output_item.done",
                                 "output_index": msg_idx,
-                                "item":         {
-                                    "id":      message_id,
-                                    "type":    "message",
-                                    "role":    "assistant",
-                                    "content": [{"type": "output_text", "text": full_text, "annotations": []}],
-                                    "status":  "completed",
-                                },
+                                "item":         msg_item,
                             })
 
                         full_think = "".join(think_buf)
@@ -508,13 +513,19 @@ async def create(
                                 "summary": [{"type": "summary_text", "text": full_think}],
                                 "status":  "completed",
                             })
-                        output.append({
-                            "id":      message_id,
-                            "type":    "message",
-                            "role":    "assistant",
-                            "content": [{"type": "output_text", "text": full_text, "annotations": []}],
-                            "status":  "completed",
-                        })
+                        # 复用 msg_item（message_started 时已构建）；未启动时重新构建
+                        if not message_started:
+                            msg_item = {
+                                "id":      message_id,
+                                "type":    "message",
+                                "role":    "assistant",
+                                "content": [{"type": "output_text", "text": full_text, "annotations": []}],
+                                "status":  "completed",
+                            }
+                            sources = adapter.search_sources_list()
+                            if sources:
+                                msg_item["search_sources"] = sources
+                        output.append(msg_item)
 
                         pt  = estimate_prompt_tokens(message)
                         ct  = estimate_tokens(full_text)
@@ -676,13 +687,17 @@ async def create(
             "summary": [{"type": "summary_text", "text": full_think}],
             "status":  "completed",
         })
-    output.append({
+    msg_item: dict = {
         "id":      message_id,
         "type":    "message",
         "role":    "assistant",
         "content": [{"type": "output_text", "text": full_text, "annotations": []}],
         "status":  "completed",
-    })
+    }
+    sources = adapter.search_sources_list()
+    if sources:
+        msg_item["search_sources"] = sources
+    output.append(msg_item)
 
     pt = estimate_prompt_tokens(message)
     ct = estimate_tokens(full_text)

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -385,7 +385,7 @@ const SCHEMA_DEF = [
           { key: 'thinking_summary', label: '思考精简输出', labelKey: 'config.schema.fields.thinkingSummary.label', type: 'bool', desc: '启用后将思考过程提炼为结构化摘要。关闭时输出完整的原始推理过程，支持多 Agent 模型的协作详情与工具调用展示。', descKey: 'config.schema.fields.thinkingSummary.desc' },
           { key: 'dynamic_statsig', label: '动态 Statsig', labelKey: 'config.schema.fields.dynamicStatsig.label', type: 'bool', desc: '为每次请求动态生成 Statsig 设备指纹，以降低风控拦截概率。', descKey: 'config.schema.fields.dynamicStatsig.desc' },
           { key: 'enable_nsfw', label: '允许 NSFW 生成', labelKey: 'config.schema.fields.enableNsfw.label', type: 'bool', desc: '允许图像生成接口绕过 NSFW 内容过滤。', descKey: 'config.schema.fields.enableNsfw.desc' },
-          { key: 'show_search_sources', label: '搜索信源', labelKey: 'config.schema.fields.showSearchSources.label', type: 'bool', desc: '当 Grok 执行网络搜索时，在响应末尾追加信源链接（## Sources 段落）。', descKey: 'config.schema.fields.showSearchSources.desc' },
+          { key: 'show_search_sources', label: '正文追加信源', labelKey: 'config.schema.fields.showSearchSources.label', type: 'bool', desc: '搜索信源始终以 search_sources 字段输出。此选项控制是否同时在正文末尾追加 ## Sources 段落（兼容文本解析客户端）。', descKey: 'config.schema.fields.showSearchSources.desc' },
           { key: 'custom_instruction', label: '全局附加指令', labelKey: 'config.schema.fields.customInstruction.label', type: 'textarea', desc: '为每次请求注入统一的 system 消息，用于约束模型行为或固定角色设定。', descKey: 'config.schema.fields.customInstruction.desc' },
         ]
       },

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -385,6 +385,7 @@ const SCHEMA_DEF = [
           { key: 'thinking_summary', label: '思考精简输出', labelKey: 'config.schema.fields.thinkingSummary.label', type: 'bool', desc: '启用后将思考过程提炼为结构化摘要。关闭时输出完整的原始推理过程，支持多 Agent 模型的协作详情与工具调用展示。', descKey: 'config.schema.fields.thinkingSummary.desc' },
           { key: 'dynamic_statsig', label: '动态 Statsig', labelKey: 'config.schema.fields.dynamicStatsig.label', type: 'bool', desc: '为每次请求动态生成 Statsig 设备指纹，以降低风控拦截概率。', descKey: 'config.schema.fields.dynamicStatsig.desc' },
           { key: 'enable_nsfw', label: '允许 NSFW 生成', labelKey: 'config.schema.fields.enableNsfw.label', type: 'bool', desc: '允许图像生成接口绕过 NSFW 内容过滤。', descKey: 'config.schema.fields.enableNsfw.desc' },
+          { key: 'show_search_sources', label: '搜索信源', labelKey: 'config.schema.fields.showSearchSources.label', type: 'bool', desc: '当 Grok 执行网络搜索时，在响应末尾追加信源链接（## Sources 段落）。', descKey: 'config.schema.fields.showSearchSources.desc' },
           { key: 'custom_instruction', label: '全局附加指令', labelKey: 'config.schema.fields.customInstruction.label', type: 'textarea', desc: '为每次请求注入统一的 system 消息，用于约束模型行为或固定角色设定。', descKey: 'config.schema.fields.customInstruction.desc' },
         ]
       },

--- a/app/statics/i18n/de.json
+++ b/app/statics/i18n/de.json
@@ -375,7 +375,7 @@
         "thinkingSummary": { "label": "Kompakte Reasoning-Ausgabe" },
         "dynamicStatsig": { "label": "Dynamisches Statsig" },
         "enableNsfw": { "label": "NSFW-Erzeugung zulassen" },
-        "showSearchSources": { "label": "Suchquellen" },
+        "showSearchSources": { "label": "Quellen an Inhalt anhängen", "desc": "Suchquellen werden immer im Feld search_sources ausgegeben. Diese Option steuert, ob zusätzlich ein ## Sources-Abschnitt an den Inhalt angehängt wird (für Abwärtskompatibilität mit textbasierten Clients)." },
         "customInstruction": { "label": "Globale Zusatzanweisung" },
         "imageFormat": { "label": "Bildausgabeformat" },
         "videoFormat": { "label": "Videoausgabeformat" },

--- a/app/statics/i18n/de.json
+++ b/app/statics/i18n/de.json
@@ -375,6 +375,7 @@
         "thinkingSummary": { "label": "Kompakte Reasoning-Ausgabe" },
         "dynamicStatsig": { "label": "Dynamisches Statsig" },
         "enableNsfw": { "label": "NSFW-Erzeugung zulassen" },
+        "showSearchSources": { "label": "Suchquellen" },
         "customInstruction": { "label": "Globale Zusatzanweisung" },
         "imageFormat": { "label": "Bildausgabeformat" },
         "videoFormat": { "label": "Videoausgabeformat" },

--- a/app/statics/i18n/en.json
+++ b/app/statics/i18n/en.json
@@ -411,6 +411,10 @@
           "label": "Allow NSFW Generation",
           "desc": "Permits the image generation endpoint to bypass NSFW content filtering."
         },
+        "showSearchSources": {
+          "label": "Search Sources",
+          "desc": "Append search source links (## Sources section) at the end of responses when Grok performs web search."
+        },
         "customInstruction": {
           "label": "Global Supplemental Instruction",
           "desc": "Injects a consistent system message into every request to enforce model behavior or establish a fixed role."

--- a/app/statics/i18n/en.json
+++ b/app/statics/i18n/en.json
@@ -412,8 +412,8 @@
           "desc": "Permits the image generation endpoint to bypass NSFW content filtering."
         },
         "showSearchSources": {
-          "label": "Search Sources",
-          "desc": "Append search source links (## Sources section) at the end of responses when Grok performs web search."
+          "label": "Append Sources to Content",
+          "desc": "Search sources are always output in the search_sources field. This option controls whether to also append a ## Sources section to the response content (for backward compatibility with text-parsing clients)."
         },
         "customInstruction": {
           "label": "Global Supplemental Instruction",

--- a/app/statics/i18n/es.json
+++ b/app/statics/i18n/es.json
@@ -375,6 +375,7 @@
         "thinkingSummary": { "label": "Razonamiento condensado" },
         "dynamicStatsig": { "label": "Statsig dinámico" },
         "enableNsfw": { "label": "Permitir generación NSFW" },
+        "showSearchSources": { "label": "Fuentes de búsqueda" },
         "customInstruction": { "label": "Instrucción suplementaria global" },
         "imageFormat": { "label": "Formato de salida de imagen" },
         "videoFormat": { "label": "Formato de salida de video" },

--- a/app/statics/i18n/es.json
+++ b/app/statics/i18n/es.json
@@ -375,7 +375,7 @@
         "thinkingSummary": { "label": "Razonamiento condensado" },
         "dynamicStatsig": { "label": "Statsig dinámico" },
         "enableNsfw": { "label": "Permitir generación NSFW" },
-        "showSearchSources": { "label": "Fuentes de búsqueda" },
+        "showSearchSources": { "label": "Agregar fuentes al contenido", "desc": "Las fuentes de búsqueda siempre se incluyen en el campo search_sources. Esta opción controla si también se agrega una sección ## Sources al contenido (para compatibilidad con clientes que analizan texto)." },
         "customInstruction": { "label": "Instrucción suplementaria global" },
         "imageFormat": { "label": "Formato de salida de imagen" },
         "videoFormat": { "label": "Formato de salida de video" },

--- a/app/statics/i18n/fr.json
+++ b/app/statics/i18n/fr.json
@@ -375,7 +375,7 @@
         "thinkingSummary": { "label": "Raisonnement condensé" },
         "dynamicStatsig": { "label": "Statsig dynamique" },
         "enableNsfw": { "label": "Autoriser la génération NSFW" },
-        "showSearchSources": { "label": "Sources de recherche" },
+        "showSearchSources": { "label": "Ajouter les sources au contenu", "desc": "Les sources de recherche sont toujours présentes dans le champ search_sources. Cette option contrôle si une section ## Sources est également ajoutée au contenu (pour la compatibilité avec les clients analysant le texte)." },
         "customInstruction": { "label": "Instruction globale supplémentaire" },
         "imageFormat": { "label": "Format de sortie image" },
         "videoFormat": { "label": "Format de sortie vidéo" },

--- a/app/statics/i18n/fr.json
+++ b/app/statics/i18n/fr.json
@@ -375,6 +375,7 @@
         "thinkingSummary": { "label": "Raisonnement condensé" },
         "dynamicStatsig": { "label": "Statsig dynamique" },
         "enableNsfw": { "label": "Autoriser la génération NSFW" },
+        "showSearchSources": { "label": "Sources de recherche" },
         "customInstruction": { "label": "Instruction globale supplémentaire" },
         "imageFormat": { "label": "Format de sortie image" },
         "videoFormat": { "label": "Format de sortie vidéo" },

--- a/app/statics/i18n/ja.json
+++ b/app/statics/i18n/ja.json
@@ -375,7 +375,7 @@
         "thinkingSummary": { "label": "思考要約出力" },
         "dynamicStatsig": { "label": "動的 Statsig" },
         "enableNsfw": { "label": "NSFW 生成を許可" },
-        "showSearchSources": { "label": "検索ソース" },
+        "showSearchSources": { "label": "コンテンツにソースを追加", "desc": "検索ソースは常に search_sources フィールドに出力されます。このオプションは、テキスト解析クライアントとの互換性のために ## Sources セクションをコンテンツに追加するかどうかを制御します。" },
         "customInstruction": { "label": "グローバル補助指示" },
         "imageFormat": { "label": "画像出力形式" },
         "videoFormat": { "label": "動画出力形式" },

--- a/app/statics/i18n/ja.json
+++ b/app/statics/i18n/ja.json
@@ -375,6 +375,7 @@
         "thinkingSummary": { "label": "思考要約出力" },
         "dynamicStatsig": { "label": "動的 Statsig" },
         "enableNsfw": { "label": "NSFW 生成を許可" },
+        "showSearchSources": { "label": "検索ソース" },
         "customInstruction": { "label": "グローバル補助指示" },
         "imageFormat": { "label": "画像出力形式" },
         "videoFormat": { "label": "動画出力形式" },

--- a/app/statics/i18n/zh.json
+++ b/app/statics/i18n/zh.json
@@ -411,6 +411,10 @@
           "label": "允许 NSFW 生成",
           "desc": "允许图像生成接口绕过 NSFW 内容过滤。"
         },
+        "showSearchSources": {
+          "label": "搜索信源",
+          "desc": "当 Grok 执行网络搜索时，在响应末尾追加搜索信源链接（## Sources 段落）。"
+        },
         "customInstruction": {
           "label": "全局附加指令",
           "desc": "为每次请求注入统一的 system 消息，用于约束模型行为或固定角色设定。"

--- a/app/statics/i18n/zh.json
+++ b/app/statics/i18n/zh.json
@@ -412,8 +412,8 @@
           "desc": "允许图像生成接口绕过 NSFW 内容过滤。"
         },
         "showSearchSources": {
-          "label": "搜索信源",
-          "desc": "当 Grok 执行网络搜索时，在响应末尾追加搜索信源链接（## Sources 段落）。"
+          "label": "正文追加信源",
+          "desc": "搜索信源始终以 search_sources 字段输出。此选项控制是否同时在正文末尾追加 ## Sources 段落（兼容文本解析客户端）。"
         },
         "customInstruction": {
           "label": "全局附加指令",

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -36,6 +36,8 @@ thinking_summary = false
 dynamic_statsig = true
 # 是否允许生成 NSFW 图片
 enable_nsfw = true
+# 当 Grok 执行网络搜索时，在响应末尾追加搜索信源链接（## Sources 段落）
+show_search_sources = false
 # 全局附加指令
 custom_instruction = ""
 

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -36,7 +36,8 @@ thinking_summary = false
 dynamic_statsig = true
 # 是否允许生成 NSFW 图片
 enable_nsfw = true
-# 当 Grok 执行网络搜索时，在响应末尾追加搜索信源链接（## Sources 段落）
+# 搜索信源始终以 search_sources 结构化字段输出（无需此开关）。
+# 此选项仅控制是否同时在响应正文末尾追加 ## Sources 纯文本段落（兼容文本解析客户端）。
 show_search_sources = false
 # 全局附加指令
 custom_instruction = ""


### PR DESCRIPTION
## Why

Grok 搜索时 SSE 流返回 44~400 条信源（web + X 帖子），但此前 grok2api 全部丢弃，
下游消费者（如 [**GrokSearch MCP**](https://github.com/GuDaStudio/GrokSearch)）的 `sources_count` 为 0；
模型正文内联引用 `[[N]](url)` 也仅有裸 Markdown，缺少标准化的引用元数据。

本 PR 建立完整的搜索引用链路：**信源透传 → 结构化字段 → 引用标注**，三层覆盖全部 3 个 API 端点。

## Summary

| 层级 | 功能 | 输出位置 | 开关 |
|:--|:--|:--|:--|
| 正文透传 | `## Sources` 段落（web + X 帖子 URL 列表） | 响应正文末尾 | `show_search_sources`（默认关） |
| 结构化字段 | `search_sources: [{url, title, type}]` | 响应根对象 / message item | **始终输出**（无开关） |
| 引用标注 | `url_citation` annotations（URL、title、文本偏移） | OpenAI 标准 annotations 字段 | **始终输出**（有引用即产出） |

## Changes

### 采集层 — `xai_chat.py` StreamAdapter

**信源采集：**
- `webSearchResults`: 原始 url + title，多帧累积去重
- `xSearchResults`: `postId` + `username` 拼接 URL，`text` 前 50 字构造 title，空白归一化
- 共享 `_web_search_urls_seen` set 跨类型去重
- `references_suffix()` 统一转义 Markdown 特殊字符
- `search_sources_list()` 返回 `[{url, title, type}]`（type: `"web"` / `"x_post"`）

**引用标注：**
- `_clean_token()` 改为返回 `(cleaned_text, local_annotations)`
- 新增 `_pending_citations` / `_annotations` / `_text_offset` 三态追踪
- `_render_replace` 生成引用时同步记录元数据，per-token 精确定位
- title 三级 fallback: card → webSearchResults → URL 本身
- `FrameEvent` 新增 `annotation_data` 字段，`annotations_list()` 扁平输出

### 注入层 — 三端点 × 流式/非流式

**Chat Completions** (`chat.py` + `_format.py`):
- 非流式: `message.annotations`（url_citation 格式）
- 流式: final chunk `delta.annotations`
- `search_sources` 置于响应根对象

**Responses API** (`responses.py`):
- 流式: `annotation.added` 实时事件 + `content_part.done` / `output_item.done` 的 annotations 数组
- 非流式: output_text 的 annotations 数组
- `search_sources` 置于 message item 级别

**Anthropic Messages** (`messages.py`):
- 非流式: `TextBlock.annotations`
- 流式: `message_delta.delta.annotations`（自定义扩展，OpenAI 扁平格式）
- `search_sources` 置于响应根对象 / `message_delta.delta`

> **设计说明**: Anthropic 标准 citations 需 `encrypted_index`（专有加密索引）+ `cited_text`（源网页原文），
> 二者 Grok 均无法提供，故改用 OpenAI `url_citation` 扁平格式作自定义扩展。

### 多轮剥离 — `chat.py` _extract_message

- 标记行 `[grok2api-sources]: #`（CommonMark link reference definition，渲染器不显示）
- 正则覆盖 string content + block list content，CRLF 兼容
- 仅匹配含标记行的段落，用户自写 `## Sources` 不受影响

### 配置 & UI

- `config.defaults.toml` 新增 `show_search_sources = false`（仅控制正文透传）
- 管理面板新增开关 + 6 语言 i18n（zh/en/de/es/fr/ja）

## Test plan

- [x] 开启 `show_search_sources`，发送搜索类问题 → 响应末尾出现 `## Sources` 段落
- [x] 关闭该配置 → 无 `## Sources` 正文，但 `search_sources` 字段仍存在
- [x] 多轮对话：第二轮请求中确认前轮 Sources 被剥离（不出现在 Grok 请求中）
- [x] 验证 `search_sources` 字段结构: `[{url, title, type}]`，type 为 `"web"` 或 `"x_post"`
- [x] 验证 `url_citation` annotations: 包含 url、title、start_index、end_index
- [x] 非搜索查询（纯聊天）→ 无 Sources、无 search_sources、无 annotations
- [x] X 帖子 URL 格式: `https://x.com/{username}/status/{postId}`
- [x] CherryStudio Responses API 模式下底部渲染引用卡片
- [x] 三端点均覆盖：Chat Completions / Responses API / Anthropic Messages
- [x] 流式 & 非流式 & tool_calls 路径均正常输出