### PR TITLE
fix: stabilize live error handling and quota recovery

### DIFF
--- a/app/control/account/refresh.py
+++ b/app/control/account/refresh.py
@@ -369,6 +369,40 @@ class AccountRefreshService:
                     record, exc
                 ):
                     return
+                if (
+                    record is not None
+                    and getattr(exc, "status", None) == 429
+                    and mode_id in _MODE_KEYS
+                ):
+                    now = now_ms()
+                    quota_patch: dict[str, dict] = {}
+                    window = record.quota_set().get(mode_id)
+                    if window is not None:
+                        reset_at = (
+                            window.reset_at
+                            if window.reset_at is not None and window.reset_at > now
+                            else now + max(window.window_seconds, 1) * 1000
+                        )
+                        quota_patch[_MODE_KEYS[mode_id]] = QuotaWindow(
+                            remaining=0,
+                            total=window.total,
+                            window_seconds=window.window_seconds,
+                            reset_at=reset_at,
+                            synced_at=window.synced_at,
+                            source=QuotaSource.ESTIMATED,
+                        ).to_dict()
+                    await self._repo.patch_accounts(
+                        [
+                            AccountPatch(
+                                token=token,
+                                usage_fail_delta=1,
+                                last_fail_at=now,
+                                last_fail_reason="rate_limited",
+                                **quota_patch,
+                            )
+                        ]
+                    )
+                    return
             await self._repo.patch_accounts(
                 [
                     AccountPatch(

--- a/app/dataplane/account/feedback.py
+++ b/app/dataplane/account/feedback.py
@@ -27,22 +27,11 @@ def apply_success(table: AccountRuntimeTable, idx: int, mode_id: int) -> None:
     h = min(_MAX_HEALTH, float(table.health_by_idx[idx]) + _SUCCESS_STEP)
     table.health_by_idx[idx] = h
 
-    # Remove from availability index if quota exhausted.
-    if new_q == 0:
-        pool_id = int(table.pool_by_idx[idx])
-        bucket = table.mode_available.get((pool_id, mode_id))
-        if bucket:
-            bucket.discard(idx)
-
 
 def apply_rate_limited(table: AccountRuntimeTable, idx: int, mode_id: int) -> None:
     """Zero the mode quota and reduce health."""
     table._quota_col(mode_id)[idx] = 0
     _adjust_health(table, idx, _RATE_LIMIT_FACTOR)
-    pool_id = int(table.pool_by_idx[idx])
-    bucket = table.mode_available.get((pool_id, mode_id))
-    if bucket:
-        bucket.discard(idx)
 
 
 def apply_auth_failure(table: AccountRuntimeTable, idx: int) -> None:
@@ -101,10 +90,8 @@ def apply_quota_update(
     pool_id = int(table.pool_by_idx[idx])
     if int(table.status_by_idx[idx]) == int(StatusId.ACTIVE):
         bucket = table.mode_available.setdefault((pool_id, mode_id), set())
-        if remaining > 0:
+        if int(table._window_col(mode_id)[idx]) > 0:
             bucket.add(idx)
-        else:
-            bucket.discard(idx)
 
 
 def increment_inflight(table: AccountRuntimeTable, idx: int) -> None:

--- a/app/dataplane/account/selector.py
+++ b/app/dataplane/account/selector.py
@@ -38,11 +38,24 @@ def select(
     # Apply window-expiry resets for basic accounts inline.
     reset_col = table._reset_col(mode_id)
     quota_col = table._quota_col(mode_id)
-    _maybe_reset_windows(table, candidates, mode_id, reset_col, quota_col, pool_id, now_s)
+    total_col = table._total_col(mode_id)
+    window_col = table._window_col(mode_id)
+    _maybe_reset_windows(
+        table,
+        candidates,
+        mode_id,
+        reset_col,
+        quota_col,
+        total_col,
+        window_col,
+        pool_id,
+        now_s,
+    )
 
     working: set[int] = candidates.copy()
     if exclude_idxs:
         working -= exclude_idxs
+    working = {idx for idx in working if int(quota_col[idx]) > 0}
     if not working:
         return None
 
@@ -60,6 +73,8 @@ def _maybe_reset_windows(
     mode_id:   int,
     reset_col: "array.array",
     quota_col: "array.array",
+    total_col: "array.array",
+    window_col: "array.array",
     pool_id:   int,
     now_s:     int,
 ) -> None:
@@ -71,29 +86,19 @@ def _maybe_reset_windows(
     if pool_id != int(PoolId.BASIC):
         return
 
-    from app.control.account.quota_defaults import default_quota_window
-
-    defaults = default_quota_window("basic", mode_id)
-    if defaults is None:
-        return
-    add_back: list[int] = []
-
     for idx in list(candidates):
         r = reset_col[idx]
         if r == 0 or now_s < r:
             continue
         if int(table.pool_by_idx[idx]) != pool_id:
             continue
-        # Window expired — restore default quota.
-        new_total = defaults.total
+        new_total = int(total_col[idx])
+        window_s = int(window_col[idx])
+        if new_total <= 0 or window_s <= 0:
+            continue
+        # Window expired — restore the last known total for this account/mode.
         quota_col[idx] = new_total
-        reset_col[idx] = now_s + defaults.window_seconds
-        add_back.append(idx)
-
-    # Re-add to the availability index (may have been removed when quota hit 0).
-    bucket = table.mode_available.get((pool_id, mode_id))
-    if bucket is not None:
-        bucket.update(add_back)
+        reset_col[idx] = now_s + window_s
 
 
 def _best(
@@ -114,6 +119,8 @@ def _best(
 
     for idx in working:
         quota    = int(quota_col[idx])
+        if quota <= 0:
+            continue
         health   = float(health_col[idx])
         inflight = int(inflight_col[idx])
         fails    = min(int(fail_col[idx]), 10)
@@ -134,7 +141,7 @@ def _best(
             best_score = score
             best_idx   = idx
 
-    return best_idx
+    return best_idx if best_idx >= 0 else None
 
 
 __all__ = ["select"]

--- a/app/dataplane/account/sync.py
+++ b/app/dataplane/account/sync.py
@@ -28,6 +28,12 @@ def _record_to_slot_args(record: AccountRecord) -> dict:
             return 0
         return int(ms_to_s(window.reset_at))
 
+    def _total(window) -> int:
+        return max(0, int(window.total)) if window is not None else 0
+
+    def _window_s(window) -> int:
+        return max(0, int(window.window_seconds)) if window is not None else 0
+
     heavy_w = qs.heavy
     return dict(
         pool_id      = pool_id,
@@ -36,6 +42,14 @@ def _record_to_slot_args(record: AccountRecord) -> dict:
         quota_fast   = max(0, qs.fast.remaining),
         quota_expert = max(0, qs.expert.remaining),
         quota_heavy  = max(0, heavy_w.remaining) if heavy_w is not None else -1,
+        total_auto   = _total(qs.auto),
+        total_fast   = _total(qs.fast),
+        total_expert = _total(qs.expert),
+        total_heavy  = _total(heavy_w),
+        window_auto  = _window_s(qs.auto),
+        window_fast  = _window_s(qs.fast),
+        window_expert = _window_s(qs.expert),
+        window_heavy = _window_s(heavy_w),
         reset_auto   = _reset_s(qs.auto),
         reset_fast   = _reset_s(qs.fast),
         reset_expert = _reset_s(qs.expert),

--- a/app/dataplane/account/table.py
+++ b/app/dataplane/account/table.py
@@ -17,10 +17,10 @@ from ..shared.enums import ALL_MODE_IDS, POOL_STR_TO_ID, STATUS_STR_TO_ID, PoolI
 # ---------------------------------------------------------------------------
 # Column type codes
 #   'B'  uint8   — pool_id, status_id
-#   'h'  int16   — quota remaining (max 32767; sufficient for all known limits)
+#   'h'  int16   — quota remaining / total (max 32767; sufficient for all known limits)
 #   'H'  uint16  — inflight, fail_count
 #   'f'  float32 — health score
-#   'L'  uint32  — epoch-second timestamps (valid until year 2106)
+#   'L'  uint32  — epoch-second timestamps / window lengths (valid until year 2106)
 # ---------------------------------------------------------------------------
 
 _QUOTA_COLS  = ("quota_auto", "quota_fast", "quota_expert", "quota_heavy")
@@ -55,6 +55,18 @@ class AccountRuntimeTable:
     quota_expert_by_idx: "array.array[int]" = field(default_factory=lambda: array.array("h"))
     quota_heavy_by_idx:  "array.array[int]" = field(default_factory=lambda: array.array("h"))
 
+    # --- Quota total per mode (int16; 0 = unsupported / unknown) ---
+    total_auto_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("h"))
+    total_fast_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("h"))
+    total_expert_by_idx: "array.array[int]" = field(default_factory=lambda: array.array("h"))
+    total_heavy_by_idx:  "array.array[int]" = field(default_factory=lambda: array.array("h"))
+
+    # --- Window size per mode (uint32 seconds; 0 = unsupported / unknown) ---
+    window_auto_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("L"))
+    window_fast_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("L"))
+    window_expert_by_idx: "array.array[int]" = field(default_factory=lambda: array.array("L"))
+    window_heavy_by_idx:  "array.array[int]" = field(default_factory=lambda: array.array("L"))
+
     # --- Window reset timestamps (uint32 epoch-seconds; 0 = unknown) ---
     reset_auto_at_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("L"))
     reset_fast_at_by_idx:   "array.array[int]" = field(default_factory=lambda: array.array("L"))
@@ -73,7 +85,7 @@ class AccountRuntimeTable:
     last_fail_at_by_idx: "array.array[int]" = field(default_factory=lambda: array.array("L"))
 
     # --- Pre-computed selection indexes ---
-    # (pool_id, mode_id) → set of idx with quota > 0 and status == ACTIVE
+    # (pool_id, mode_id) → set of idx with a supported quota window and status == ACTIVE
     mode_available: dict[tuple[int, int], set[int]] = field(default_factory=dict)
     # tag string → set of idx
     tag_idx: dict[str, set[int]] = field(default_factory=dict)
@@ -98,13 +110,25 @@ class AccountRuntimeTable:
         if mode_id == 2: return self.reset_expert_at_by_idx
         return self.reset_heavy_at_by_idx
 
+    def _total_col(self, mode_id: int) -> "array.array[int]":
+        if mode_id == 0: return self.total_auto_by_idx
+        if mode_id == 1: return self.total_fast_by_idx
+        if mode_id == 2: return self.total_expert_by_idx
+        return self.total_heavy_by_idx
+
+    def _window_col(self, mode_id: int) -> "array.array[int]":
+        if mode_id == 0: return self.window_auto_by_idx
+        if mode_id == 1: return self.window_fast_by_idx
+        if mode_id == 2: return self.window_expert_by_idx
+        return self.window_heavy_by_idx
+
     def _add_to_indexes(self, idx: int) -> None:
         pool_id   = int(self.pool_by_idx[idx])
         status_id = int(self.status_by_idx[idx])
         if status_id != int(StatusId.ACTIVE):
             return
         for mode_id in ALL_MODE_IDS:
-            if self._quota_col(mode_id)[idx] > 0:
+            if self._window_col(mode_id)[idx] > 0:
                 self.mode_available.setdefault((pool_id, mode_id), set()).add(idx)
 
     def _remove_from_indexes(self, idx: int) -> None:
@@ -137,6 +161,14 @@ class AccountRuntimeTable:
         quota_fast:   int,
         quota_expert: int,
         quota_heavy:  int,
+        total_auto:   int,
+        total_fast:   int,
+        total_expert: int,
+        total_heavy:  int,
+        window_auto:  int,
+        window_fast:  int,
+        window_expert: int,
+        window_heavy: int,
         reset_auto:   int,
         reset_fast:   int,
         reset_expert: int,
@@ -156,6 +188,14 @@ class AccountRuntimeTable:
         self.quota_fast_by_idx.append(max(-1, min(quota_fast, 32767)))
         self.quota_expert_by_idx.append(max(-1, min(quota_expert, 32767)))
         self.quota_heavy_by_idx.append(max(-1, min(quota_heavy, 32767)))
+        self.total_auto_by_idx.append(max(0, min(total_auto, 32767)))
+        self.total_fast_by_idx.append(max(0, min(total_fast, 32767)))
+        self.total_expert_by_idx.append(max(0, min(total_expert, 32767)))
+        self.total_heavy_by_idx.append(max(0, min(total_heavy, 32767)))
+        self.window_auto_by_idx.append(max(0, window_auto))
+        self.window_fast_by_idx.append(max(0, window_fast))
+        self.window_expert_by_idx.append(max(0, window_expert))
+        self.window_heavy_by_idx.append(max(0, window_heavy))
         self.reset_auto_at_by_idx.append(reset_auto)
         self.reset_fast_at_by_idx.append(reset_fast)
         self.reset_expert_at_by_idx.append(reset_expert)
@@ -183,6 +223,14 @@ class AccountRuntimeTable:
         quota_fast:   int,
         quota_expert: int,
         quota_heavy:  int,
+        total_auto:   int,
+        total_fast:   int,
+        total_expert: int,
+        total_heavy:  int,
+        window_auto:  int,
+        window_fast:  int,
+        window_expert: int,
+        window_heavy: int,
         reset_auto:   int,
         reset_fast:   int,
         reset_expert: int,
@@ -203,6 +251,14 @@ class AccountRuntimeTable:
         self.quota_fast_by_idx[idx]       = max(-1, min(quota_fast, 32767))
         self.quota_expert_by_idx[idx]     = max(-1, min(quota_expert, 32767))
         self.quota_heavy_by_idx[idx]      = max(-1, min(quota_heavy, 32767))
+        self.total_auto_by_idx[idx]       = max(0, min(total_auto, 32767))
+        self.total_fast_by_idx[idx]       = max(0, min(total_fast, 32767))
+        self.total_expert_by_idx[idx]     = max(0, min(total_expert, 32767))
+        self.total_heavy_by_idx[idx]      = max(0, min(total_heavy, 32767))
+        self.window_auto_by_idx[idx]      = max(0, window_auto)
+        self.window_fast_by_idx[idx]      = max(0, window_fast)
+        self.window_expert_by_idx[idx]    = max(0, window_expert)
+        self.window_heavy_by_idx[idx]     = max(0, window_heavy)
         self.reset_auto_at_by_idx[idx]    = reset_auto
         self.reset_fast_at_by_idx[idx]    = reset_fast
         self.reset_expert_at_by_idx[idx]  = reset_expert

--- a/app/dataplane/proxy/adapters/session.py
+++ b/app/dataplane/proxy/adapters/session.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from curl_cffi.const import CurlOpt
 
 from app.platform.config.snapshot import get_config
+from app.platform.errors import UpstreamError
 from app.control.proxy.models import ProxyLease
 
 
@@ -75,6 +76,17 @@ def build_session_kwargs(
     return kwargs
 
 
+def _wrap_transport_error(exc: BaseException) -> UpstreamError:
+    if isinstance(exc, UpstreamError):
+        return exc
+    body = str(exc).replace("\n", "\\n")[:400]
+    return UpstreamError(
+        f"Transport request failed: {exc}",
+        status=502,
+        body=body,
+    )
+
+
 class ResettableSession:
     """AsyncSession wrapper that resets connection on configurable status codes.
 
@@ -122,7 +134,11 @@ class ResettableSession:
 
     async def _request(self, method: str, *args: Any, **kwargs: Any):
         await self._maybe_reset()
-        response = await getattr(self._session, method)(*args, **kwargs)
+        try:
+            response = await getattr(self._session, method)(*args, **kwargs)
+        except Exception as exc:
+            self._reset_pending = True
+            raise _wrap_transport_error(exc) from exc
         if self._reset_on and response.status_code in self._reset_on:
             self._reset_pending = True
         return response
@@ -153,4 +169,8 @@ class ResettableSession:
         return getattr(self._session, name)
 
 
-__all__ = ["ResettableSession", "build_session_kwargs", "normalize_proxy_url"]
+__all__ = [
+    "ResettableSession",
+    "build_session_kwargs",
+    "normalize_proxy_url",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -319,6 +320,39 @@ def create_app() -> FastAPI:
     @app.exception_handler(AppError)
     async def _app_error_handler(request: Request, exc: AppError):
         return JSONResponse(exc.to_dict(), status_code=exc.status)
+
+    @app.exception_handler(RequestValidationError)
+    async def _request_validation_handler(
+        request: Request,
+        exc: RequestValidationError,
+    ):
+        errors = exc.errors()
+        first = errors[0] if errors else {}
+        loc = tuple(first.get("loc") or ())
+        param_parts = [
+            str(part)
+            for part in loc
+            if str(part) not in {"body", "query", "path", "header", "cookie"}
+        ]
+        param = ".".join(param_parts)
+        message = first.get("msg") or "Request validation failed"
+        logger.warning(
+            "request validation failed: method={} path={} param={} errors={}",
+            request.method,
+            request.url.path,
+            param or "-",
+            errors,
+        )
+        payload = {
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "code": "invalid_value",
+            }
+        }
+        if param:
+            payload["error"]["param"] = param
+        return JSONResponse(payload, status_code=400)
 
     @app.exception_handler(Exception)
     async def _generic_error_handler(request: Request, exc: Exception):

--- a/app/products/anthropic/router.py
+++ b/app/products/anthropic/router.py
@@ -92,7 +92,7 @@ async def messages_endpoint(req: MessagesRequest):
         raise ValidationError("messages cannot be empty", param="messages")
 
     cfg       = get_config()
-    is_stream = req.stream if req.stream is not None else cfg.get_bool("features.stream", True)
+    is_stream = req.stream is True
 
     # thinking flag: enable when request has thinking config or config default
     if req.thinking is not None and isinstance(req.thinking, dict):

--- a/app/products/anthropic/router.py
+++ b/app/products/anthropic/router.py
@@ -92,7 +92,7 @@ async def messages_endpoint(req: MessagesRequest):
         raise ValidationError("messages cannot be empty", param="messages")
 
     cfg       = get_config()
-    is_stream = req.stream is True
+    is_stream = req.stream if req.stream is not None else cfg.get_bool("features.stream", True)
 
     # thinking flag: enable when request has thinking config or config default
     if req.thinking is not None and isinstance(req.thinking, dict):

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -23,7 +23,10 @@ from app.control.model.enums import ModeId
 from app.control.account.enums import FeedbackKind
 from app.dataplane.proxy.adapters.headers import build_http_headers
 from app.dataplane.proxy import get_proxy_runtime
-from app.dataplane.proxy.adapters.session import ResettableSession, build_session_kwargs
+from app.dataplane.proxy.adapters.session import (
+    ResettableSession,
+    build_session_kwargs,
+)
 from app.dataplane.reverse.protocol.xai_chat import (
     build_chat_payload,
     classify_line,
@@ -59,6 +62,25 @@ def _log_task_exception(task: "asyncio.Task") -> None:
         logger.warning("background task failed: task={} error={}", task.get_name(), exc)
 
 
+def _upstream_body_excerpt(exc: UpstreamError, *, limit: int = 240) -> str:
+    details = getattr(exc, "details", {})
+    if not isinstance(details, dict):
+        return "-"
+    body = str(details.get("body", "") or "").replace("\n", "\\n")
+    return body[:limit] or "-"
+
+
+def _transport_upstream_error(exc: BaseException, *, context: str) -> UpstreamError:
+    if isinstance(exc, UpstreamError):
+        return exc
+    body = str(exc).replace("\n", "\\n")[:400]
+    return UpstreamError(
+        f"{context}: {exc}",
+        status=502,
+        body=body,
+    )
+
+
 async def _quota_sync(token: str, mode_id: int) -> None:
     """Fire-and-forget: fetch real quota after a successful call."""
     try:
@@ -82,6 +104,16 @@ async def _fail_sync(
         svc = get_refresh_service()
         if svc:
             await svc.record_failure_async(token, mode_id, exc)
+            if getattr(exc, "status", None) == 429:
+                result = await svc.refresh_on_demand()
+                logger.info(
+                    "account on-demand refresh triggered: token={}... mode_id={} refreshed={} failed={} rate_limited={}",
+                    token[:10],
+                    mode_id,
+                    result.refreshed,
+                    result.failed,
+                    result.rate_limited,
+                )
     except Exception as e:
         logger.warning(
             "chat fail sync error: token={}... mode_id={} error={}",
@@ -315,13 +347,16 @@ async def _stream_chat(
     session_kwargs = build_session_kwargs(lease=lease)
 
     async with ResettableSession(**session_kwargs) as session:
-        response = await session.post(
-            CHAT,
-            headers=headers,
-            data=payload_bytes,
-            timeout=timeout_s,
-            stream=True,
-        )
+        try:
+            response = await session.post(
+                CHAT,
+                headers=headers,
+                data=payload_bytes,
+                timeout=timeout_s,
+                stream=True,
+            )
+        except Exception as exc:
+            raise _transport_upstream_error(exc, context="Chat transport failed") from exc
 
         if response.status_code != 200:
             try:
@@ -334,8 +369,11 @@ async def _stream_chat(
                 body=body,
             )
 
-        async for line in response.aiter_lines():
-            yield line
+        try:
+            async for line in response.aiter_lines():
+                yield line
+        except Exception as exc:
+            raise _transport_upstream_error(exc, context="Chat stream read failed") from exc
 
 
 async def completions(
@@ -559,6 +597,14 @@ async def completions(
                                 token[:8],
                             )
                         else:
+                            logger.warning(
+                                "chat stream upstream failed: attempt={}/{} model={} status={} body={}",
+                                attempt + 1,
+                                max_retries + 1,
+                                model,
+                                exc.status,
+                                _upstream_body_excerpt(exc),
+                            )
                             raise
 
                 finally:
@@ -643,6 +689,14 @@ async def completions(
                         token[:8],
                     )
                 else:
+                    logger.warning(
+                        "chat upstream failed: attempt={}/{} model={} status={} body={}",
+                        attempt + 1,
+                        max_retries + 1,
+                        model,
+                        exc.status,
+                        _upstream_body_excerpt(exc),
+                    )
                     raise
 
         finally:

--- a/app/products/openai/responses.py
+++ b/app/products/openai/responses.py
@@ -18,7 +18,7 @@ from app.control.model.registry import resolve as resolve_model
 from app.control.account.enums import FeedbackKind
 from app.dataplane.reverse.protocol.xai_chat import classify_line, StreamAdapter
 
-from .chat import _stream_chat, _extract_message, _resolve_image, _quota_sync, _fail_sync, _parse_retry_codes, _feedback_kind, _log_task_exception
+from .chat import _stream_chat, _extract_message, _resolve_image, _quota_sync, _fail_sync, _parse_retry_codes, _feedback_kind, _log_task_exception, _upstream_body_excerpt
 from .chat import _configured_retry_codes, _should_retry_upstream
 from ._format import (
     make_resp_id, build_resp_usage, make_resp_object, format_sse,
@@ -548,6 +548,14 @@ async def create(
                         logger.warning("responses stream retry scheduled: attempt={}/{} status={} token={}...",
                                        attempt + 1, max_retries, exc.status, token[:8])
                     else:
+                        logger.warning(
+                            "responses stream upstream failed: attempt={}/{} model={} status={} body={}",
+                            attempt + 1,
+                            max_retries + 1,
+                            model,
+                            exc.status,
+                            _upstream_body_excerpt(exc),
+                        )
                         raise
 
             finally:
@@ -618,6 +626,14 @@ async def create(
                     logger.warning("responses retry scheduled: attempt={}/{} status={} token={}...",
                                    attempt + 1, max_retries, exc.status, token[:8])
                 else:
+                    logger.warning(
+                        "responses upstream failed: attempt={}/{} model={} status={} body={}",
+                        attempt + 1,
+                        max_retries + 1,
+                        model,
+                        exc.status,
+                        _upstream_body_excerpt(exc),
+                    )
                     raise
 
         finally:

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -197,6 +197,7 @@ async def _upload_to_data_uri(upload: UploadFile, *, param: str) -> str:
 @router.post("/chat/completions", tags=[_TAG_CHAT], dependencies=[Depends(verify_api_key)])
 async def chat_completions_endpoint(req: ChatCompletionRequest):
     _validate_chat(req)
+    is_stream = req.stream is True
 
     spec     = model_registry.get(req.model)
     if spec is None:
@@ -218,7 +219,7 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
                 n               = cfg.n or 1,
                 size            = cfg.size or "1024x1024",
                 response_format = cfg.response_format or "url",
-                stream          = bool(req.stream),
+                stream          = is_stream,
                 chat_format     = True,
             )
 
@@ -241,7 +242,7 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
                 n               = n,
                 size            = size,
                 response_format = fmt,
-                stream          = bool(req.stream),
+                stream          = is_stream,
                 chat_format     = True,
             )
 
@@ -253,7 +254,7 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
             result = await vid_comp(
                 model           = req.model,
                 messages        = messages,
-                stream          = req.stream,
+                stream          = is_stream,
                 seconds         = vcfg.seconds or 6,
                 size            = vcfg.size or "720x1280",
                 resolution_name = vcfg.resolution_name,
@@ -264,7 +265,7 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
             result = await chat_completions(
                 model       = req.model,
                 messages    = messages,
-                stream      = req.stream,
+                stream      = is_stream,
                 thinking    = req.thinking,
                 tools       = req.tools,
                 tool_choice = req.tool_choice,
@@ -278,10 +279,10 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
         logger.exception(
             "chat completions endpoint failed: model={} stream={} error={}",
             req.model,
-            req.stream,
+            is_stream,
             exc,
         )
-        if req.stream is not False:
+        if is_stream:
             _err_msg = str(exc)  # capture before Python clears the except-scope variable
             async def _err_stream():
                 payload = orjson.dumps({"error": {"message": _err_msg, "type": "server_error"}}).decode()
@@ -330,7 +331,7 @@ async def responses_endpoint(req: ResponsesCreateRequest):
         raise _ValidationError("input cannot be empty", param="input")
 
     cfg        = get_config()
-    is_stream  = req.stream if req.stream is not None else cfg.get_bool("features.stream", True)
+    is_stream  = req.stream is True
 
     # Map reasoning param → emit_think flag.
     # reasoning=None → use config; reasoning.effort="none" → off; otherwise on.

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -197,7 +197,10 @@ async def _upload_to_data_uri(upload: UploadFile, *, param: str) -> str:
 @router.post("/chat/completions", tags=[_TAG_CHAT], dependencies=[Depends(verify_api_key)])
 async def chat_completions_endpoint(req: ChatCompletionRequest):
     _validate_chat(req)
-    is_stream = req.stream is True
+    from app.platform.config.snapshot import get_config
+
+    cfg = get_config()
+    is_stream = req.stream if req.stream is not None else cfg.get_bool("features.stream", True)
 
     spec     = model_registry.get(req.model)
     if spec is None:
@@ -331,7 +334,7 @@ async def responses_endpoint(req: ResponsesCreateRequest):
         raise _ValidationError("input cannot be empty", param="input")
 
     cfg        = get_config()
-    is_stream  = req.stream is True
+    is_stream  = req.stream if req.stream is not None else cfg.get_bool("features.stream", True)
 
     # Map reasoning param → emit_think flag.
     # reasoning=None → use config; reasoning.effort="none" → off; otherwise on.

--- a/tests/test_account_on_demand_refresh_trigger.py
+++ b/tests/test_account_on_demand_refresh_trigger.py
@@ -1,0 +1,51 @@
+import unittest
+
+from app.control.account.refresh import RefreshResult
+from app.control.account.runtime import get_refresh_service, set_refresh_service
+from app.platform.errors import UpstreamError
+from app.products.openai.chat import _fail_sync
+
+
+class _FakeRefreshService:
+    def __init__(self) -> None:
+        self.failure_calls: list[tuple[str, int, BaseException | None]] = []
+        self.refresh_calls = 0
+
+    async def record_failure_async(
+        self,
+        token: str,
+        mode_id: int,
+        exc: BaseException | None = None,
+    ) -> None:
+        self.failure_calls.append((token, mode_id, exc))
+
+    async def refresh_on_demand(self) -> RefreshResult:
+        self.refresh_calls += 1
+        return RefreshResult(refreshed=3, failed=1, rate_limited=2)
+
+
+class AccountOnDemandRefreshTriggerTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self) -> None:
+        set_refresh_service(None)
+
+    async def test_fail_sync_triggers_on_demand_refresh_for_429(self) -> None:
+        svc = _FakeRefreshService()
+        set_refresh_service(svc)
+
+        await _fail_sync("tok-429", 1, UpstreamError("rate limited", status=429))
+
+        self.assertEqual(len(svc.failure_calls), 1)
+        self.assertEqual(svc.refresh_calls, 1)
+
+    async def test_fail_sync_skips_on_demand_refresh_for_non_429(self) -> None:
+        svc = _FakeRefreshService()
+        set_refresh_service(svc)
+
+        await _fail_sync("tok-500", 1, UpstreamError("upstream error", status=500))
+
+        self.assertEqual(len(svc.failure_calls), 1)
+        self.assertEqual(svc.refresh_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_account_refresh_rate_limit.py
+++ b/tests/test_account_refresh_rate_limit.py
@@ -1,0 +1,43 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.control.account.backends.local import LocalAccountRepository
+from app.control.account.commands import AccountUpsert
+from app.control.account.enums import AccountStatus, QuotaSource
+from app.control.account.refresh import AccountRefreshService
+from app.platform.errors import UpstreamError
+
+
+class AccountRefreshRateLimitTest(unittest.TestCase):
+    def test_record_failure_persists_mode_quota_on_429(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "accounts.db"
+            asyncio.run(self._run_case(db_path))
+
+    async def _run_case(self, db_path: Path) -> None:
+        repo = LocalAccountRepository(db_path)
+        await repo.initialize()
+        await repo.upsert_accounts([AccountUpsert(token="tok-basic")])
+
+        service = AccountRefreshService(repo)
+        await service.record_failure_async(
+            "tok-basic",
+            1,
+            UpstreamError("rate limited", status=429),
+        )
+
+        record = (await repo.get_accounts(["tok-basic"]))[0]
+        fast = record.quota_set().fast
+
+        self.assertEqual(record.status, AccountStatus.ACTIVE)
+        self.assertEqual(record.usage_fail_count, 1)
+        self.assertEqual(record.last_fail_reason, "rate_limited")
+        self.assertEqual(fast.remaining, 0)
+        self.assertIsNotNone(fast.reset_at)
+        self.assertEqual(fast.source, QuotaSource.ESTIMATED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_account_selector_window_reset.py
+++ b/tests/test_account_selector_window_reset.py
@@ -1,0 +1,46 @@
+import unittest
+
+from app.dataplane.account.selector import select
+from app.dataplane.account.table import make_empty_table
+from app.dataplane.shared.enums import PoolId, StatusId
+
+
+class AccountSelectorWindowResetTest(unittest.TestCase):
+    def test_expired_basic_window_resets_to_stored_total(self) -> None:
+        table = make_empty_table()
+        idx = table._append_slot(
+            token="tok-basic",
+            pool_id=int(PoolId.BASIC),
+            status_id=int(StatusId.ACTIVE),
+            quota_auto=0,
+            quota_fast=0,
+            quota_expert=0,
+            quota_heavy=-1,
+            total_auto=2,
+            total_fast=6,
+            total_expert=2,
+            total_heavy=0,
+            window_auto=7200,
+            window_fast=7200,
+            window_expert=7200,
+            window_heavy=0,
+            reset_auto=100,
+            reset_fast=100,
+            reset_expert=100,
+            reset_heavy=0,
+            health=1.0,
+            last_use_s=0,
+            last_fail_s=0,
+            fail_count=0,
+            tags=[],
+        )
+
+        selected = select(table, int(PoolId.BASIC), 0, now_s=200)
+
+        self.assertEqual(selected, idx)
+        self.assertEqual(int(table.quota_auto_by_idx[idx]), 2)
+        self.assertEqual(int(table.reset_auto_at_by_idx[idx]), 200 + 7200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_api_stream_defaults.py
+++ b/tests/test_public_api_stream_defaults.py
@@ -23,7 +23,12 @@ class _FakeSpec:
 
 
 class _FakeConfig:
+    def __init__(self, *, stream_default: bool = True) -> None:
+        self.stream_default = stream_default
+
     def get_bool(self, key: str, default: bool) -> bool:
+        if key == "features.stream":
+            return self.stream_default
         return default
 
 
@@ -32,7 +37,7 @@ async def _fake_stream():
 
 
 class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
-    async def test_chat_endpoint_defaults_omitted_stream_to_json(self) -> None:
+    async def test_chat_endpoint_omitted_stream_uses_config_disabled(self) -> None:
         calls: list[dict] = []
 
         async def _fake_chat_completions(**kwargs):
@@ -45,14 +50,36 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
-            with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
-                response = await chat_completions_endpoint(req)
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=False)):
+                with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
+                    response = await chat_completions_endpoint(req)
 
         self.assertIsInstance(response, JSONResponse)
         self.assertEqual(orjson.loads(response.body), {"ok": True})
         self.assertEqual(calls[0]["stream"], False)
 
-    async def test_chat_endpoint_omitted_stream_propagates_json_errors(self) -> None:
+    async def test_chat_endpoint_omitted_stream_uses_config_enabled(self) -> None:
+        calls: list[dict] = []
+
+        async def _fake_chat_completions(**kwargs):
+            calls.append(kwargs)
+            return _fake_stream()
+
+        req = ChatCompletionRequest(
+            model="grok-4.20-auto",
+            messages=[MessageItem(role="user", content="hi")],
+        )
+
+        with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=True)):
+                with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
+                    response = await chat_completions_endpoint(req)
+
+        self.assertIsInstance(response, StreamingResponse)
+        self.assertEqual(response.media_type, "text/event-stream")
+        self.assertEqual(calls[0]["stream"], True)
+
+    async def test_chat_endpoint_omitted_stream_propagates_json_errors_when_config_disabled(self) -> None:
         async def _boom(**kwargs):
             raise RuntimeError("boom")
 
@@ -62,9 +89,10 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
-            with patch("app.products.openai.router.chat_completions", new=_boom):
-                with self.assertRaisesRegex(RuntimeError, "boom"):
-                    await chat_completions_endpoint(req)
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=False)):
+                with patch("app.products.openai.router.chat_completions", new=_boom):
+                    with self.assertRaisesRegex(RuntimeError, "boom"):
+                        await chat_completions_endpoint(req)
 
     async def test_chat_endpoint_keeps_explicit_streaming(self) -> None:
         async def _fake_chat_completions(**kwargs):
@@ -77,13 +105,14 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
-            with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
-                response = await chat_completions_endpoint(req)
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=False)):
+                with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
+                    response = await chat_completions_endpoint(req)
 
         self.assertIsInstance(response, StreamingResponse)
         self.assertEqual(response.media_type, "text/event-stream")
 
-    async def test_responses_endpoint_defaults_omitted_stream_to_json(self) -> None:
+    async def test_responses_endpoint_omitted_stream_uses_config_disabled(self) -> None:
         calls: list[dict] = []
 
         async def _fake_responses_create(**kwargs):
@@ -96,7 +125,7 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
-            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig()):
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=False)):
                 with patch("app.products.openai.responses.create", new=_fake_responses_create):
                     response = await responses_endpoint(req)
 
@@ -104,7 +133,7 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(orjson.loads(response.body), {"ok": True})
         self.assertEqual(calls[0]["stream"], False)
 
-    async def test_messages_endpoint_defaults_omitted_stream_to_json(self) -> None:
+    async def test_messages_endpoint_omitted_stream_uses_config_disabled(self) -> None:
         calls: list[dict] = []
 
         async def _fake_messages_create(**kwargs):
@@ -117,7 +146,7 @@ class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch("app.products.anthropic.router.model_registry.get", return_value=_FakeSpec()):
-            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig()):
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig(stream_default=False)):
                 with patch("app.products.anthropic.messages.create", new=_fake_messages_create):
                     response = await messages_endpoint(req)
 

--- a/tests/test_public_api_stream_defaults.py
+++ b/tests/test_public_api_stream_defaults.py
@@ -1,0 +1,130 @@
+import unittest
+from unittest.mock import patch
+
+import orjson
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from app.products.anthropic.router import MessagesRequest, messages_endpoint
+from app.products.openai.router import chat_completions_endpoint, responses_endpoint
+from app.products.openai.schemas import ChatCompletionRequest, MessageItem, ResponsesCreateRequest
+
+
+class _FakeSpec:
+    enabled = True
+
+    def is_image_edit(self) -> bool:
+        return False
+
+    def is_image(self) -> bool:
+        return False
+
+    def is_video(self) -> bool:
+        return False
+
+
+class _FakeConfig:
+    def get_bool(self, key: str, default: bool) -> bool:
+        return default
+
+
+async def _fake_stream():
+    yield "data: hello\n\n"
+
+
+class PublicApiStreamDefaultTest(unittest.IsolatedAsyncioTestCase):
+    async def test_chat_endpoint_defaults_omitted_stream_to_json(self) -> None:
+        calls: list[dict] = []
+
+        async def _fake_chat_completions(**kwargs):
+            calls.append(kwargs)
+            return {"ok": True}
+
+        req = ChatCompletionRequest(
+            model="grok-4.20-auto",
+            messages=[MessageItem(role="user", content="hi")],
+        )
+
+        with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
+                response = await chat_completions_endpoint(req)
+
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(orjson.loads(response.body), {"ok": True})
+        self.assertEqual(calls[0]["stream"], False)
+
+    async def test_chat_endpoint_omitted_stream_propagates_json_errors(self) -> None:
+        async def _boom(**kwargs):
+            raise RuntimeError("boom")
+
+        req = ChatCompletionRequest(
+            model="grok-4.20-auto",
+            messages=[MessageItem(role="user", content="hi")],
+        )
+
+        with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.products.openai.router.chat_completions", new=_boom):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    await chat_completions_endpoint(req)
+
+    async def test_chat_endpoint_keeps_explicit_streaming(self) -> None:
+        async def _fake_chat_completions(**kwargs):
+            return _fake_stream()
+
+        req = ChatCompletionRequest(
+            model="grok-4.20-auto",
+            messages=[MessageItem(role="user", content="hi")],
+            stream=True,
+        )
+
+        with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.products.openai.router.chat_completions", new=_fake_chat_completions):
+                response = await chat_completions_endpoint(req)
+
+        self.assertIsInstance(response, StreamingResponse)
+        self.assertEqual(response.media_type, "text/event-stream")
+
+    async def test_responses_endpoint_defaults_omitted_stream_to_json(self) -> None:
+        calls: list[dict] = []
+
+        async def _fake_responses_create(**kwargs):
+            calls.append(kwargs)
+            return {"ok": True}
+
+        req = ResponsesCreateRequest(
+            model="grok-4.20-auto",
+            input="hi",
+        )
+
+        with patch("app.products.openai.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig()):
+                with patch("app.products.openai.responses.create", new=_fake_responses_create):
+                    response = await responses_endpoint(req)
+
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(orjson.loads(response.body), {"ok": True})
+        self.assertEqual(calls[0]["stream"], False)
+
+    async def test_messages_endpoint_defaults_omitted_stream_to_json(self) -> None:
+        calls: list[dict] = []
+
+        async def _fake_messages_create(**kwargs):
+            calls.append(kwargs)
+            return {"ok": True}
+
+        req = MessagesRequest(
+            model="grok-4.20-auto",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        with patch("app.products.anthropic.router.model_registry.get", return_value=_FakeSpec()):
+            with patch("app.platform.config.snapshot.get_config", return_value=_FakeConfig()):
+                with patch("app.products.anthropic.messages.create", new=_fake_messages_create):
+                    response = await messages_endpoint(req)
+
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(orjson.loads(response.body), {"ok": True})
+        self.assertEqual(calls[0]["stream"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transport_error_wrapping.py
+++ b/tests/test_transport_error_wrapping.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch
+
+from app.platform.errors import UpstreamError
+from app.dataplane.proxy.adapters.session import ResettableSession
+
+
+class _RaisingSession:
+    async def post(self, *args, **kwargs):
+        raise RuntimeError("tls boom")
+
+    async def close(self):
+        return None
+
+
+class TransportErrorWrappingTest(unittest.IsolatedAsyncioTestCase):
+    async def test_resettable_session_wraps_transport_exception_as_upstream_502(self):
+        with patch.object(ResettableSession, "_create", return_value=_RaisingSession()):
+            session = ResettableSession()
+            with self.assertRaises(UpstreamError) as ctx:
+                await session.post("https://example.com")
+            self.assertEqual(ctx.exception.status, 502)
+            self.assertIn("tls boom", ctx.exception.message)
+            await session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- persist rate-limited quota exhaustion and refresh accounts on demand after 429 responses
- restore account windows from stored quota metadata instead of basic-tier defaults, and normalize request validation plus transport failures into client-safe API errors
- default public OpenAI/Anthropic compatible endpoints to non-streaming JSON unless stream=true is explicitly requested

## Testing
- docker run --rm -v /home/admin/grok2api-origin-pr:/workspace -w /workspace ghcr.io/chenyme/grok2api:latest python -m unittest tests.test_account_refresh_rate_limit tests.test_account_on_demand_refresh_trigger tests.test_account_selector_window_reset tests.test_transport_error_wrapping tests.test_public_api_stream_defaults