### PR TITLE
fix: recover auto chat mode when quota state stalls

### DIFF
--- a/app/products/_account_selection.py
+++ b/app/products/_account_selection.py
@@ -1,0 +1,63 @@
+"""Shared account selection helpers for products-layer request handlers."""
+
+from app.control.model.enums import ModeId
+from app.control.model.spec import ModelSpec
+from app.control.account.runtime import get_refresh_service
+from app.platform.config.snapshot import get_config
+
+
+def mode_candidates(spec: ModelSpec) -> tuple[int, ...]:
+    """Return mode IDs to try for *spec* in priority order.
+
+    Chat models using ``AUTO`` can optionally fall back to ``FAST`` and then
+    ``EXPERT`` when the upstream ``auto`` quota window is exhausted but the
+    account still has usable quota in the other chat windows.
+    """
+    primary = int(spec.mode_id)
+    if (
+        spec.is_chat()
+        and spec.mode_id == ModeId.AUTO
+        and get_config("features.auto_chat_mode_fallback", True)
+    ):
+        return (primary, int(ModeId.FAST), int(ModeId.EXPERT))
+    return (primary,)
+
+
+async def reserve_account(
+    directory,
+    spec: ModelSpec,
+    *,
+    exclude_tokens: list[str] | None = None,
+    now_s_override: int | None = None,
+):
+    """Reserve an account and return ``(lease, selected_mode_id)``.
+
+    Returns ``(None, original_mode_id)`` when no account is available.
+    """
+    original_mode_id = int(spec.mode_id)
+
+    async def _try_reserve():
+        for candidate_mode_id in mode_candidates(spec):
+            lease = await directory.reserve(
+                pool_candidates=spec.pool_candidates(),
+                mode_id=candidate_mode_id,
+                now_s_override=now_s_override,
+                exclude_tokens=exclude_tokens,
+            )
+            if lease is not None:
+                return lease, candidate_mode_id
+        return None, original_mode_id
+
+    lease, selected_mode_id = await _try_reserve()
+    if lease is not None:
+        return lease, selected_mode_id
+
+    if get_config("account.refresh.on_empty_retry_enabled", True):
+        refresh_svc = get_refresh_service()
+        if refresh_svc is not None:
+            await refresh_svc.refresh_on_demand()
+            lease, selected_mode_id = await _try_reserve()
+            if lease is not None:
+                return lease, selected_mode_id
+
+    return None, original_mode_id

--- a/app/products/_account_selection.py
+++ b/app/products/_account_selection.py
@@ -52,12 +52,11 @@ async def reserve_account(
     if lease is not None:
         return lease, selected_mode_id
 
-    if get_config("account.refresh.on_empty_retry_enabled", True):
-        refresh_svc = get_refresh_service()
-        if refresh_svc is not None:
-            await refresh_svc.refresh_on_demand()
-            lease, selected_mode_id = await _try_reserve()
-            if lease is not None:
-                return lease, selected_mode_id
+    refresh_svc = get_refresh_service()
+    if refresh_svc is not None:
+        await refresh_svc.refresh_on_demand()
+        lease, selected_mode_id = await _try_reserve()
+        if lease is not None:
+            return lease, selected_mode_id
 
     return None, original_mode_id

--- a/app/products/anthropic/messages.py
+++ b/app/products/anthropic/messages.py
@@ -19,6 +19,7 @@ from app.platform.config.snapshot import get_config
 from app.platform.errors import RateLimitError, UpstreamError
 from app.platform.runtime.clock import now_s
 from app.platform.tokens import estimate_prompt_tokens, estimate_tokens, estimate_tool_call_tokens
+from app.control.model.enums import ModeId
 from app.control.model.registry import resolve as resolve_model
 from app.control.account.enums import FeedbackKind
 from app.dataplane.reverse.protocol.xai_chat import classify_line, StreamAdapter
@@ -32,6 +33,7 @@ from app.products.openai.chat import (
     _quota_sync, _fail_sync, _parse_retry_codes, _feedback_kind, _log_task_exception,
     _configured_retry_codes, _should_retry_upstream,
 )
+from app.products._account_selection import reserve_account
 from app.products.openai._tool_sieve import ToolSieve
 
 
@@ -319,11 +321,11 @@ async def create(
     async def _run_stream() -> AsyncGenerator[str, None]:
         excluded: list[str] = []
         for attempt in range(max_retries + 1):
-            acct = await directory.reserve(
-                pool_candidates = spec.pool_candidates(),
-                mode_id         = mode_id,
-                now_s_override  = now_s(),
-                exclude_tokens  = excluded or None,
+            acct, selected_mode_id = await reserve_account(
+                directory,
+                spec,
+                now_s_override=now_s(),
+                exclude_tokens=excluded or None,
             )
             if acct is None:
                 raise RateLimitError("No available accounts for this model tier")
@@ -363,7 +365,7 @@ async def create(
                     ended = False
                     async for line in _stream_chat(
                         token     = token,
-                        mode_id   = spec.mode_id,
+                        mode_id   = ModeId(selected_mode_id),
                         message   = internal_message,
                         files     = files,
                         timeout_s = timeout_s,
@@ -589,11 +591,11 @@ async def create(
                     else _feedback_kind(fail_exc) if fail_exc
                     else FeedbackKind.SERVER_ERROR
                 )
-                await directory.feedback(token, kind, mode_id, now_s_val=now_s())
+                await directory.feedback(token, kind, selected_mode_id, now_s_val=now_s())
                 if success:
-                    asyncio.create_task(_quota_sync(token, mode_id)).add_done_callback(_log_task_exception)
+                    asyncio.create_task(_quota_sync(token, selected_mode_id)).add_done_callback(_log_task_exception)
                 else:
-                    asyncio.create_task(_fail_sync(token, mode_id, fail_exc)).add_done_callback(_log_task_exception)
+                    asyncio.create_task(_fail_sync(token, selected_mode_id, fail_exc)).add_done_callback(_log_task_exception)
 
             if success or not _retry:
                 return
@@ -610,11 +612,11 @@ async def create(
     adapter  = StreamAdapter()
 
     for attempt in range(max_retries + 1):
-        acct = await directory.reserve(
-            pool_candidates = spec.pool_candidates(),
-            mode_id         = mode_id,
-            now_s_override  = now_s(),
-            exclude_tokens  = excluded or None,
+        acct, selected_mode_id = await reserve_account(
+            directory,
+            spec,
+            now_s_override=now_s(),
+            exclude_tokens=excluded or None,
         )
         if acct is None:
             raise RateLimitError("No available accounts for this model tier")
@@ -630,7 +632,7 @@ async def create(
                 ended = False
                 async for line in _stream_chat(
                     token     = token,
-                    mode_id   = spec.mode_id,
+                    mode_id   = ModeId(selected_mode_id),
                     message   = internal_message,
                     files     = files,
                     timeout_s = timeout_s,
@@ -666,11 +668,11 @@ async def create(
                 else _feedback_kind(fail_exc) if fail_exc
                 else FeedbackKind.SERVER_ERROR
             )
-            await directory.feedback(token, kind, mode_id, now_s_val=now_s())
+            await directory.feedback(token, kind, selected_mode_id, now_s_val=now_s())
             if success:
-                asyncio.create_task(_quota_sync(token, mode_id)).add_done_callback(_log_task_exception)
+                asyncio.create_task(_quota_sync(token, selected_mode_id)).add_done_callback(_log_task_exception)
             else:
-                asyncio.create_task(_fail_sync(token, mode_id, fail_exc)).add_done_callback(_log_task_exception)
+                asyncio.create_task(_fail_sync(token, selected_mode_id, fail_exc)).add_done_callback(_log_task_exception)
 
         if success or not _retry:
             break

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -50,6 +50,7 @@ from ._format import (
     build_usage,
 )
 from ._tool_sieve import ToolSieve
+from app.products._account_selection import reserve_account
 
 
 def _log_task_exception(task: "asyncio.Task") -> None:
@@ -400,9 +401,9 @@ async def completions(
         async def _run_stream() -> AsyncGenerator[str, None]:
             excluded: list[str] = []
             for attempt in range(max_retries + 1):
-                acct = await directory.reserve(
-                    pool_candidates=spec.pool_candidates(),
-                    mode_id=mode_id,
+                acct, selected_mode_id = await reserve_account(
+                    directory,
+                    spec,
                     now_s_override=now_s(),
                     exclude_tokens=excluded or None,
                 )
@@ -422,7 +423,7 @@ async def completions(
                         tool_calls_emitted = False
                         async for line in _stream_chat(
                             token=token,
-                            mode_id=spec.mode_id,
+                            mode_id=ModeId(selected_mode_id),
                             message=message,
                             files=files,
                             tool_overrides=tool_overrides,
@@ -570,14 +571,14 @@ async def completions(
                         if fail_exc
                         else FeedbackKind.SERVER_ERROR
                     )
-                    await directory.feedback(token, kind, mode_id, now_s_val=now_s())
+                    await directory.feedback(token, kind, selected_mode_id, now_s_val=now_s())
                     if success:
                         asyncio.create_task(
-                            _quota_sync(token, mode_id)
+                            _quota_sync(token, selected_mode_id)
                         ).add_done_callback(_log_task_exception)
                     else:
                         asyncio.create_task(
-                            _fail_sync(token, mode_id, fail_exc)
+                            _fail_sync(token, selected_mode_id, fail_exc)
                         ).add_done_callback(_log_task_exception)
 
                 if success or not _retry:
@@ -591,9 +592,9 @@ async def completions(
     token = ""
     adapter = StreamAdapter()
     for attempt in range(max_retries + 1):
-        acct = await directory.reserve(
-            pool_candidates=spec.pool_candidates(),
-            mode_id=mode_id,
+        acct, selected_mode_id = await reserve_account(
+            directory,
+            spec,
             now_s_override=now_s(),
             exclude_tokens=excluded or None,
         )
@@ -610,7 +611,7 @@ async def completions(
             try:
                 async for line in _stream_chat(
                     token=token,
-                    mode_id=spec.mode_id,
+                    mode_id=ModeId(selected_mode_id),
                     message=message,
                     files=files,
                     tool_overrides=tool_overrides,
@@ -654,14 +655,14 @@ async def completions(
                 if fail_exc
                 else FeedbackKind.SERVER_ERROR
             )
-            await directory.feedback(token, kind, mode_id, now_s_val=now_s())
+            await directory.feedback(token, kind, selected_mode_id, now_s_val=now_s())
             if success:
-                asyncio.create_task(_quota_sync(token, mode_id)).add_done_callback(
+                asyncio.create_task(_quota_sync(token, selected_mode_id)).add_done_callback(
                     _log_task_exception
                 )
             else:
                 asyncio.create_task(
-                    _fail_sync(token, mode_id, fail_exc)
+                    _fail_sync(token, selected_mode_id, fail_exc)
                 ).add_done_callback(_log_task_exception)
 
         if success or not _retry:

--- a/app/products/openai/responses.py
+++ b/app/products/openai/responses.py
@@ -14,9 +14,11 @@ from app.platform.config.snapshot import get_config
 from app.platform.errors import RateLimitError, UpstreamError
 from app.platform.runtime.clock import now_s
 from app.platform.tokens import estimate_prompt_tokens, estimate_tokens, estimate_tool_call_tokens
+from app.control.model.enums import ModeId
 from app.control.model.registry import resolve as resolve_model
 from app.control.account.enums import FeedbackKind
 from app.dataplane.reverse.protocol.xai_chat import classify_line, StreamAdapter
+from app.products._account_selection import reserve_account
 
 from .chat import _stream_chat, _extract_message, _resolve_image, _quota_sync, _fail_sync, _parse_retry_codes, _feedback_kind, _log_task_exception
 from .chat import _configured_retry_codes, _should_retry_upstream
@@ -258,11 +260,11 @@ async def create(
     async def _run_stream() -> AsyncGenerator[str, None]:
         excluded: list[str] = []
         for attempt in range(max_retries + 1):
-            acct = await directory.reserve(
-                pool_candidates = spec.pool_candidates(),
-                mode_id         = mode_id,
-                now_s_override  = now_s(),
-                exclude_tokens  = excluded or None,
+            acct, selected_mode_id = await reserve_account(
+                directory,
+                spec,
+                now_s_override=now_s(),
+                exclude_tokens=excluded or None,
             )
             if acct is None:
                 raise RateLimitError("No available accounts for this model tier")
@@ -291,7 +293,7 @@ async def create(
                     ended = False
                     async for line in _stream_chat(
                         token     = token,
-                        mode_id   = spec.mode_id,
+                        mode_id   = ModeId(selected_mode_id),
                         message   = message,
                         files     = files,
                         timeout_s = timeout_s,
@@ -553,11 +555,11 @@ async def create(
             finally:
                 await directory.release(acct)
                 kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
-                await directory.feedback(token, kind, mode_id, now_s_val=now_s())
+                await directory.feedback(token, kind, selected_mode_id, now_s_val=now_s())
                 if success:
-                    asyncio.create_task(_quota_sync(token, mode_id)).add_done_callback(_log_task_exception)
+                    asyncio.create_task(_quota_sync(token, selected_mode_id)).add_done_callback(_log_task_exception)
                 else:
-                    asyncio.create_task(_fail_sync(token, mode_id, fail_exc)).add_done_callback(_log_task_exception)
+                    asyncio.create_task(_fail_sync(token, selected_mode_id, fail_exc)).add_done_callback(_log_task_exception)
 
             if success or not _retry:
                 return
@@ -573,11 +575,11 @@ async def create(
     token    = ""
     adapter  = StreamAdapter()
     for attempt in range(max_retries + 1):
-        acct = await directory.reserve(
-            pool_candidates = spec.pool_candidates(),
-            mode_id         = mode_id,
-            now_s_override  = now_s(),
-            exclude_tokens  = excluded or None,
+        acct, selected_mode_id = await reserve_account(
+            directory,
+            spec,
+            now_s_override=now_s(),
+            exclude_tokens=excluded or None,
         )
         if acct is None:
             raise RateLimitError("No available accounts for this model tier")
@@ -592,7 +594,7 @@ async def create(
             try:
                 async for line in _stream_chat(
                     token     = token,
-                    mode_id   = spec.mode_id,
+                    mode_id   = ModeId(selected_mode_id),
                     message   = message,
                     files     = files,
                     timeout_s = timeout_s,
@@ -623,11 +625,11 @@ async def create(
         finally:
             await directory.release(acct)
             kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
-            await directory.feedback(token, kind, mode_id)
+            await directory.feedback(token, kind, selected_mode_id)
             if success:
-                asyncio.create_task(_quota_sync(token, mode_id)).add_done_callback(_log_task_exception)
+                asyncio.create_task(_quota_sync(token, selected_mode_id)).add_done_callback(_log_task_exception)
             else:
-                asyncio.create_task(_fail_sync(token, mode_id, fail_exc)).add_done_callback(_log_task_exception)
+                asyncio.create_task(_fail_sync(token, selected_mode_id, fail_exc)).add_done_callback(_log_task_exception)
 
         if success or not _retry:
             break

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -382,6 +382,7 @@ const SCHEMA_DEF = [
           { key: 'memory', label: '开启会话记忆', labelKey: 'config.schema.fields.memory.label', type: 'bool', desc: '启用 Grok Memory，允许模型跨会话记忆用户偏好与上下文。', descKey: 'config.schema.fields.memory.desc' },
           { key: 'stream', label: '默认流式输出', labelKey: 'config.schema.fields.stream.label', type: 'bool', desc: '请求未显式指定 stream 参数时所采用的默认值。', descKey: 'config.schema.fields.stream.desc' },
           { key: 'thinking', label: '默认思考输出', labelKey: 'config.schema.fields.thinking.label', type: 'bool', desc: '请求未显式指定 thinking 参数时所采用的默认值。启用后将在 reasoning_content 字段返回思考过程。', descKey: 'config.schema.fields.thinking.desc' },
+          { key: 'auto_chat_mode_fallback', label: 'AUTO 聊天模式回退', labelKey: 'config.schema.fields.autoChatModeFallback.label', type: 'bool', desc: 'AUTO 聊天模型在 auto 额度不可用时，自动尝试 fast 和 expert 聊天额度窗口。', descKey: 'config.schema.fields.autoChatModeFallback.desc' },
           { key: 'thinking_summary', label: '思考精简输出', labelKey: 'config.schema.fields.thinkingSummary.label', type: 'bool', desc: '启用后将思考过程提炼为结构化摘要。关闭时输出完整的原始推理过程，支持多 Agent 模型的协作详情与工具调用展示。', descKey: 'config.schema.fields.thinkingSummary.desc' },
           { key: 'dynamic_statsig', label: '动态 Statsig', labelKey: 'config.schema.fields.dynamicStatsig.label', type: 'bool', desc: '为每次请求动态生成 Statsig 设备指纹，以降低风控拦截概率。', descKey: 'config.schema.fields.dynamicStatsig.desc' },
           { key: 'enable_nsfw', label: '允许 NSFW 生成', labelKey: 'config.schema.fields.enableNsfw.label', type: 'bool', desc: '允许图像生成接口绕过 NSFW 内容过滤。', descKey: 'config.schema.fields.enableNsfw.desc' },

--- a/app/statics/i18n/de.json
+++ b/app/statics/i18n/de.json
@@ -372,6 +372,7 @@
         "memory": { "label": "Konversationsspeicher" },
         "stream": { "label": "Standard-Streaming" },
         "thinking": { "label": "Standard-Ausgabe für Reasoning" },
+        "autoChatModeFallback": { "label": "AUTO-Chatmodus-Fallback" },
         "thinkingSummary": { "label": "Kompakte Reasoning-Ausgabe" },
         "dynamicStatsig": { "label": "Dynamisches Statsig" },
         "enableNsfw": { "label": "NSFW-Erzeugung zulassen" },

--- a/app/statics/i18n/en.json
+++ b/app/statics/i18n/en.json
@@ -399,6 +399,10 @@
           "label": "Default Reasoning Output",
           "desc": "Default value applied when the request does not explicitly provide the thinking parameter. When enabled, reasoning steps are returned in reasoning_content."
         },
+        "autoChatModeFallback": {
+          "label": "AUTO Chat Mode Fallback",
+          "desc": "When an AUTO chat model has no available auto quota, automatically try the fast and expert chat quota windows."
+        },
         "thinkingSummary": {
           "label": "Condensed Reasoning",
           "desc": "When enabled, reasoning steps are condensed into a structured summary. When disabled, the full raw reasoning stream is output, with multi-agent collaboration details and tool call traces."

--- a/app/statics/i18n/es.json
+++ b/app/statics/i18n/es.json
@@ -372,6 +372,7 @@
         "memory": { "label": "Memoria de conversación" },
         "stream": { "label": "Streaming predeterminado" },
         "thinking": { "label": "Salida de razonamiento predeterminada" },
+        "autoChatModeFallback": { "label": "Reserva de modo AUTO para chat" },
         "thinkingSummary": { "label": "Razonamiento condensado" },
         "dynamicStatsig": { "label": "Statsig dinámico" },
         "enableNsfw": { "label": "Permitir generación NSFW" },

--- a/app/statics/i18n/fr.json
+++ b/app/statics/i18n/fr.json
@@ -372,6 +372,7 @@
         "memory": { "label": "Mémoire conversationnelle" },
         "stream": { "label": "Streaming par défaut" },
         "thinking": { "label": "Sortie de raisonnement par défaut" },
+        "autoChatModeFallback": { "label": "Repli du mode AUTO pour le chat" },
         "thinkingSummary": { "label": "Raisonnement condensé" },
         "dynamicStatsig": { "label": "Statsig dynamique" },
         "enableNsfw": { "label": "Autoriser la génération NSFW" },

--- a/app/statics/i18n/ja.json
+++ b/app/statics/i18n/ja.json
@@ -372,6 +372,7 @@
         "memory": { "label": "会話メモリ" },
         "stream": { "label": "デフォルトのストリーミング" },
         "thinking": { "label": "デフォルトの推論出力" },
+        "autoChatModeFallback": { "label": "AUTO チャットモードのフォールバック" },
         "thinkingSummary": { "label": "思考要約出力" },
         "dynamicStatsig": { "label": "動的 Statsig" },
         "enableNsfw": { "label": "NSFW 生成を許可" },

--- a/app/statics/i18n/zh.json
+++ b/app/statics/i18n/zh.json
@@ -399,6 +399,10 @@
           "label": "默认思考输出",
           "desc": "请求未显式指定 thinking 参数时所采用的默认值。启用后将在 reasoning_content 字段返回思考过程。"
         },
+        "autoChatModeFallback": {
+          "label": "AUTO 聊天模式回退",
+          "desc": "AUTO 聊天模型在 auto 额度不可用时，自动尝试 fast 和 expert 聊天额度窗口。"
+        },
         "thinkingSummary": {
           "label": "思考精简输出",
           "desc": "启用后将思考过程提炼为结构化摘要。关闭时输出完整的原始推理过程，支持多 Agent 模型的协作详情与工具调用展示。"

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -30,6 +30,10 @@ memory = false
 stream = true
 # 是否输出思考过程
 thinking = true
+# 聊天类 AUTO 模型在 auto 额度耗尽时，是否自动降级到 fast/expert
+auto_chat_mode_fallback = true
+# 当本地额度缓存判定无可用账号时，是否先触发一次按需刷新再重试
+on_empty_retry_enabled = true
 # 思考精简输出（false=完整原始推理过程，true=提炼结构化摘要）
 thinking_summary = false
 # 是否动态生成 Statsig 指纹

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -32,8 +32,6 @@ stream = true
 thinking = true
 # 聊天类 AUTO 模型在 auto 额度耗尽时，是否自动降级到 fast/expert
 auto_chat_mode_fallback = true
-# 当本地额度缓存判定无可用账号时，是否先触发一次按需刷新再重试
-on_empty_retry_enabled = true
 # 思考精简输出（false=完整原始推理过程，true=提炼结构化摘要）
 thinking_summary = false
 # 是否动态生成 Statsig 指纹

--- a/tests/test_account_selection.py
+++ b/tests/test_account_selection.py
@@ -1,0 +1,141 @@
+import unittest
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from app.control.model.enums import Capability, ModeId, Tier
+from app.control.model.spec import ModelSpec
+from app.products._account_selection import mode_candidates, reserve_account
+
+
+@dataclass
+class _Lease:
+    token: str
+
+
+class _FakeDirectory:
+    def __init__(self, available_by_mode: dict[int, str | None]) -> None:
+        self.available_by_mode = available_by_mode
+        self.calls: list[int] = []
+
+    async def reserve(
+        self,
+        *,
+        pool_candidates,
+        mode_id,
+        now_s_override=None,
+        exclude_tokens=None,
+    ):
+        self.calls.append(mode_id)
+        token = self.available_by_mode.get(mode_id)
+        return _Lease(token) if token else None
+
+
+class _RefreshingDirectory:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+        self.after_refresh = False
+
+    async def reserve(
+        self,
+        *,
+        pool_candidates,
+        mode_id,
+        now_s_override=None,
+        exclude_tokens=None,
+    ):
+        self.calls.append(mode_id)
+        if self.after_refresh and mode_id == int(ModeId.AUTO):
+            return _Lease("auto-token")
+        return None
+
+
+class _RefreshService:
+    def __init__(self, directory: _RefreshingDirectory) -> None:
+        self.directory = directory
+        self.calls = 0
+
+    async def refresh_on_demand(self):
+        self.calls += 1
+        self.directory.after_refresh = True
+
+
+class AccountSelectionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.auto_chat_spec = ModelSpec(
+            "grok-4.20-0309",
+            ModeId.AUTO,
+            Tier.BASIC,
+            Capability.CHAT,
+            True,
+            "Grok 4.20 0309",
+        )
+        self.fast_chat_spec = ModelSpec(
+            "grok-4.20-fast",
+            ModeId.FAST,
+            Tier.BASIC,
+            Capability.CHAT,
+            True,
+            "Grok 4.20 Fast",
+        )
+
+    @patch("app.products._account_selection.get_config", return_value=True)
+    def test_auto_chat_mode_candidates_include_fallbacks(self, _mock_get_config) -> None:
+        self.assertEqual(
+            mode_candidates(self.auto_chat_spec),
+            (int(ModeId.AUTO), int(ModeId.FAST), int(ModeId.EXPERT)),
+        )
+
+    @patch("app.products._account_selection.get_config", return_value=False)
+    def test_auto_chat_mode_candidates_can_disable_fallback(self, _mock_get_config) -> None:
+        self.assertEqual(mode_candidates(self.auto_chat_spec), (int(ModeId.AUTO),))
+
+    @patch("app.products._account_selection.get_config", return_value=True)
+    def test_non_auto_models_do_not_change_mode_order(self, _mock_get_config) -> None:
+        self.assertEqual(mode_candidates(self.fast_chat_spec), (int(ModeId.FAST),))
+
+    @patch("app.products._account_selection.get_config", return_value=True)
+    async def test_reserve_account_falls_back_to_fast(self, _mock_get_config) -> None:
+        directory = _FakeDirectory(
+            {
+                int(ModeId.AUTO): None,
+                int(ModeId.FAST): "fast-token",
+                int(ModeId.EXPERT): "expert-token",
+            }
+        )
+
+        lease, selected_mode_id = await reserve_account(directory, self.auto_chat_spec)
+
+        self.assertIsNotNone(lease)
+        self.assertEqual(lease.token, "fast-token")
+        self.assertEqual(selected_mode_id, int(ModeId.FAST))
+        self.assertEqual(
+            directory.calls,
+            [int(ModeId.AUTO), int(ModeId.FAST)],
+        )
+
+    @patch("app.products._account_selection.get_refresh_service")
+    @patch("app.products._account_selection.get_config")
+    async def test_reserve_account_retries_after_on_demand_refresh(
+        self,
+        mock_get_config,
+        mock_get_refresh_service,
+    ) -> None:
+        directory = _RefreshingDirectory()
+        refresh_service = _RefreshService(directory)
+        mock_get_refresh_service.return_value = refresh_service
+        mock_get_config.side_effect = lambda key, default=None: {
+            "features.auto_chat_mode_fallback": False,
+            "account.refresh.on_empty_retry_enabled": True,
+        }.get(key, default)
+
+        lease, selected_mode_id = await reserve_account(directory, self.auto_chat_spec)
+
+        self.assertIsNotNone(lease)
+        self.assertEqual(lease.token, "auto-token")
+        self.assertEqual(selected_mode_id, int(ModeId.AUTO))
+        self.assertEqual(refresh_service.calls, 1)
+        self.assertEqual(directory.calls, [int(ModeId.AUTO), int(ModeId.AUTO)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared account-selection helper for chat handlers
- fall back from `AUTO` to `FAST` and then `EXPERT` when chat quota state is stale
- trigger one throttled on-demand quota refresh before returning `No available accounts`
- cover the new selection behavior with focused unit tests

## Problem
Some deployments can get stuck returning `No available accounts for this model tier` for chat requests using `AUTO` models even though quota becomes available again after a manual refresh or a process restart.

In practice there were two missing recovery paths:
- chat handlers treated `AUTO` as a hard mode and did not try other chat windows that were still available
- when the in-memory/runtime quota state said no account was available, request handling returned immediately instead of forcing a fresh quota sync and retrying once

This makes the service dependent on long periodic refresh intervals or manual intervention.

## What This Changes
### 1. Chat-mode fallback
For chat models whose public mode is `AUTO`, account selection now tries:
- `AUTO`
- `FAST`
- `EXPERT`

This behavior is enabled by default and guarded by:
- `features.auto_chat_mode_fallback = true`

### 2. Empty-pool refresh retry
If account selection still finds no candidate, the service now:
- runs one throttled `refresh_on_demand()`
- retries account selection once

This behavior is enabled by default and guarded by:
- `features.on_empty_retry_enabled = true`

### 3. Shared implementation
The recovery logic is centralized in a shared products-layer helper so OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages stay consistent.

## Why This Is Safe
- the fallback is limited to chat requests only
- image/video behavior is unchanged
- the on-demand refresh path is already throttled by existing refresh-service logic
- the feature flags keep the behavior configurable

## Verification
- `./.venv/bin/python -m unittest tests.test_account_selection`
- `./.venv/bin/python -m py_compile app/products/_account_selection.py tests/test_account_selection.py app/products/openai/chat.py app/products/openai/responses.py app/products/anthropic/messages.py`

## Notes
I observed this against a live deployment where:
- cached `AUTO` quota had stalled at zero
- `FAST` / `EXPERT` quota was still available
- a manual refresh or service restart restored `AUTO`

This patch addresses both the stale-state case and the no-self-recovery case.
