### PR TITLE
feat: Add support for Grok 4.3 Beta models

### DIFF
--- a/app/control/account/models.py
+++ b/app/control/account/models.py
@@ -13,6 +13,7 @@ from .enums import AccountStatus, QuotaSource
 # QuotaWindow
 # ---------------------------------------------------------------------------
 
+
 @dataclass(slots=True)
 class QuotaWindow:
     """Rate-limit window for one mode (auto / fast / expert).
@@ -25,12 +26,12 @@ class QuotaWindow:
     ``source``         — reliability of this value.
     """
 
-    remaining:      int
-    total:          int
+    remaining: int
+    total: int
     window_seconds: int
-    reset_at:       int | None
-    synced_at:      int | None
-    source:         QuotaSource
+    reset_at: int | None
+    synced_at: int | None
+    source: QuotaSource
 
     def is_exhausted(self) -> bool:
         return self.remaining <= 0
@@ -41,23 +42,23 @@ class QuotaWindow:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "remaining":      self.remaining,
-            "total":          self.total,
+            "remaining": self.remaining,
+            "total": self.total,
             "window_seconds": self.window_seconds,
-            "reset_at":       self.reset_at,
-            "synced_at":      self.synced_at,
-            "source":         int(self.source),
+            "reset_at": self.reset_at,
+            "synced_at": self.synced_at,
+            "source": int(self.source),
         }
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "QuotaWindow":
         return cls(
-            remaining      = int(d.get("remaining", 0)),
-            total          = int(d.get("total", 0)),
-            window_seconds = int(d.get("window_seconds", 0)),
-            reset_at       = d.get("reset_at"),
-            synced_at      = d.get("synced_at"),
-            source         = QuotaSource(int(d.get("source", 0))),
+            remaining=int(d.get("remaining", 0)),
+            total=int(d.get("total", 0)),
+            window_seconds=int(d.get("window_seconds", 0)),
+            reset_at=d.get("reset_at"),
+            synced_at=d.get("synced_at"),
+            source=QuotaSource(int(d.get("source", 0))),
         )
 
 
@@ -65,27 +66,34 @@ class QuotaWindow:
 # AccountQuotaSet
 # ---------------------------------------------------------------------------
 
+
 @dataclass(slots=True)
 class AccountQuotaSet:
-    """Quota set — one window per mode (auto / fast / expert / heavy).
+    """Quota set — one window per mode (auto / fast / expert / heavy / grok_4_3).
 
-    ``heavy`` is ``None`` for basic and super accounts.
+    ``heavy``    is ``None`` for basic and super accounts.
+    ``grok_4_3`` is ``None`` for basic accounts (super/heavy only).
     """
 
-    auto:   QuotaWindow
-    fast:   QuotaWindow
+    auto: QuotaWindow
+    fast: QuotaWindow
     expert: QuotaWindow
-    heavy:  QuotaWindow | None = None  # heavy-pool accounts only
+    heavy: QuotaWindow | None = None  # heavy-pool accounts only
+    grok_4_3: QuotaWindow | None = None  # super/heavy accounts only
 
     def get(self, mode_id: int) -> QuotaWindow | None:
-        """Return the quota window for *mode_id* (0=auto, 1=fast, 2=expert, 3=heavy)."""
+        """Return the quota window for *mode_id* (0=auto, 1=fast, 2=expert, 3=heavy, 4=grok_4_3)."""
         if mode_id == 0:
             return self.auto
         if mode_id == 1:
             return self.fast
         if mode_id == 2:
             return self.expert
-        return self.heavy  # mode_id == 3
+        if mode_id == 3:
+            return self.heavy
+        if mode_id == 4:
+            return self.grok_4_3
+        return None
 
     def set(self, mode_id: int, window: QuotaWindow) -> None:
         """Replace the quota window for *mode_id*."""
@@ -95,27 +103,33 @@ class AccountQuotaSet:
             self.fast = window
         elif mode_id == 2:
             self.expert = window
+        elif mode_id == 3:
+            self.heavy = window
         else:
-            self.heavy = window  # mode_id == 3
+            self.grok_4_3 = window  # mode_id == 4
 
     def to_dict(self) -> dict[str, dict[str, Any]]:
         d: dict[str, dict[str, Any]] = {
-            "auto":   self.auto.to_dict(),
-            "fast":   self.fast.to_dict(),
+            "auto": self.auto.to_dict(),
+            "fast": self.fast.to_dict(),
             "expert": self.expert.to_dict(),
         }
         if self.heavy is not None:
             d["heavy"] = self.heavy.to_dict()
+        if self.grok_4_3 is not None:
+            d["grok_4_3"] = self.grok_4_3.to_dict()
         return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "AccountQuotaSet":
         heavy_d = d.get("heavy")
+        grok_4_3_d = d.get("grok_4_3")
         return cls(
-            auto   = QuotaWindow.from_dict(d.get("auto",   {})),
-            fast   = QuotaWindow.from_dict(d.get("fast",   {})),
-            expert = QuotaWindow.from_dict(d.get("expert", {})),
-            heavy  = QuotaWindow.from_dict(heavy_d) if heavy_d else None,
+            auto=QuotaWindow.from_dict(d.get("auto", {})),
+            fast=QuotaWindow.from_dict(d.get("fast", {})),
+            expert=QuotaWindow.from_dict(d.get("expert", {})),
+            heavy=QuotaWindow.from_dict(heavy_d) if heavy_d else None,
+            grok_4_3=QuotaWindow.from_dict(grok_4_3_d) if grok_4_3_d else None,
         )
 
 
@@ -123,17 +137,18 @@ class AccountQuotaSet:
 # AccountUsageStats
 # ---------------------------------------------------------------------------
 
+
 @dataclass(slots=True)
 class AccountUsageStats:
     """Cumulative usage counters for an account."""
 
-    use_count:  int = 0  # Successful calls (SUCCESS feedback)
+    use_count: int = 0  # Successful calls (SUCCESS feedback)
     fail_count: int = 0  # Failed calls (non-success feedback)
     sync_count: int = 0  # Usage API sync calls
 
     def to_dict(self) -> dict[str, int]:
         return {
-            "use_count":  self.use_count,
+            "use_count": self.use_count,
             "fail_count": self.fail_count,
             "sync_count": self.sync_count,
         }
@@ -141,15 +156,16 @@ class AccountUsageStats:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "AccountUsageStats":
         return cls(
-            use_count  = int(d.get("use_count",  0)),
-            fail_count = int(d.get("fail_count", 0)),
-            sync_count = int(d.get("sync_count", 0)),
+            use_count=int(d.get("use_count", 0)),
+            fail_count=int(d.get("fail_count", 0)),
+            sync_count=int(d.get("sync_count", 0)),
         )
 
 
 # ---------------------------------------------------------------------------
 # AccountRecord  (Pydantic — control plane only)
 # ---------------------------------------------------------------------------
+
 
 class AccountRecord(BaseModel):
     """Persistent account record — single source of truth for all backends.
@@ -159,28 +175,28 @@ class AccountRecord(BaseModel):
     ``ext`` carries non-core extension data only.
     """
 
-    token:            str
-    pool:             str                  = "basic"
-    status:           AccountStatus        = AccountStatus.ACTIVE
-    created_at:       int                  = Field(default_factory=now_ms)
-    updated_at:       int                  = Field(default_factory=now_ms)
-    tags:             list[str]            = Field(default_factory=list)
+    token: str
+    pool: str = "basic"
+    status: AccountStatus = AccountStatus.ACTIVE
+    created_at: int = Field(default_factory=now_ms)
+    updated_at: int = Field(default_factory=now_ms)
+    tags: list[str] = Field(default_factory=list)
     # Serialised form of AccountQuotaSet.  Stored as dict for Pydantic
     # round-tripping; use .quota_set() to deserialise, .with_quota_set()
     # to produce an updated copy.
-    quota:            dict[str, Any]       = Field(default_factory=dict)
-    usage_use_count:  int                  = 0
-    usage_fail_count: int                  = 0
-    usage_sync_count: int                  = 0
-    last_use_at:      int | None           = None
-    last_fail_at:     int | None           = None
-    last_fail_reason: str | None           = None
-    last_sync_at:     int | None           = None
-    last_clear_at:    int | None           = None
-    state_reason:     str | None           = None
-    deleted_at:       int | None           = None
-    ext:              dict[str, Any]       = Field(default_factory=dict)
-    revision:         int                  = 0
+    quota: dict[str, Any] = Field(default_factory=dict)
+    usage_use_count: int = 0
+    usage_fail_count: int = 0
+    usage_sync_count: int = 0
+    last_use_at: int | None = None
+    last_fail_at: int | None = None
+    last_fail_reason: str | None = None
+    last_sync_at: int | None = None
+    last_clear_at: int | None = None
+    state_reason: str | None = None
+    deleted_at: int | None = None
+    ext: dict[str, Any] = Field(default_factory=dict)
+    revision: int = 0
 
     # --- computed properties ---
 
@@ -219,10 +235,18 @@ class AccountRecord(BaseModel):
         token = token.translate(
             str.maketrans(
                 {
-                    "\u2010": "-", "\u2011": "-", "\u2012": "-",
-                    "\u2013": "-", "\u2014": "-", "\u2212": "-",
-                    "\u00a0": " ", "\u2007": " ", "\u202f": " ",
-                    "\u200b": "",  "\u200c": "",  "\u200d": "",
+                    "\u2010": "-",
+                    "\u2011": "-",
+                    "\u2012": "-",
+                    "\u2013": "-",
+                    "\u2014": "-",
+                    "\u2212": "-",
+                    "\u00a0": " ",
+                    "\u2007": " ",
+                    "\u202f": " ",
+                    "\u200b": "",
+                    "\u200c": "",
+                    "\u200d": "",
                     "\ufeff": "",
                 }
             )
@@ -268,32 +292,33 @@ class AccountRecord(BaseModel):
 # Lightweight result types
 # ---------------------------------------------------------------------------
 
+
 class AccountMutationResult(BaseModel):
     upserted: int = 0
-    patched:  int = 0
-    deleted:  int = 0
+    patched: int = 0
+    deleted: int = 0
     revision: int = 0
 
 
 class AccountPage(BaseModel):
-    items:       list[AccountRecord] = Field(default_factory=list)
-    total:       int = 0
-    page:        int = 1
-    page_size:   int = 50
+    items: list[AccountRecord] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 50
     total_pages: int = 1
-    revision:    int = 0
+    revision: int = 0
 
 
 class AccountChangeSet(BaseModel):
-    revision:       int                  = 0
-    items:          list[AccountRecord]  = Field(default_factory=list)
-    deleted_tokens: list[str]            = Field(default_factory=list)
-    has_more:       bool                 = False
+    revision: int = 0
+    items: list[AccountRecord] = Field(default_factory=list)
+    deleted_tokens: list[str] = Field(default_factory=list)
+    has_more: bool = False
 
 
 class RuntimeSnapshot(BaseModel):
-    revision: int                  = 0
-    items:    list[AccountRecord]  = Field(default_factory=list)
+    revision: int = 0
+    items: list[AccountRecord] = Field(default_factory=list)
 
 
 __all__ = [

--- a/app/control/account/quota_defaults.py
+++ b/app/control/account/quota_defaults.py
@@ -24,14 +24,15 @@ if TYPE_CHECKING:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _w(remaining: int, total: int, window_seconds: int) -> QuotaWindow:
     return QuotaWindow(
-        remaining      = remaining,
-        total          = total,
-        window_seconds = window_seconds,
-        reset_at       = None,
-        synced_at      = None,
-        source         = QuotaSource.DEFAULT,
+        remaining=remaining,
+        total=total,
+        window_seconds=window_seconds,
+        reset_at=None,
+        synced_at=None,
+        source=QuotaSource.DEFAULT,
     )
 
 
@@ -40,22 +41,24 @@ def _w(remaining: int, total: int, window_seconds: int) -> QuotaWindow:
 # ---------------------------------------------------------------------------
 
 BASIC_QUOTA_DEFAULTS = AccountQuotaSet(
-    auto   = _w(20,  20,  72_000),   # 20  queries / 20 h
-    fast   = _w(60,  60,  72_000),   # 60  queries / 20 h
-    expert = _w(8,   8,   36_000),   # 8   queries / 10 h
+    auto=_w(20, 20, 72_000),  # 20  queries / 20 h
+    fast=_w(60, 60, 72_000),  # 60  queries / 20 h
+    expert=_w(8, 8, 36_000),  # 8   queries / 10 h
 )
 
 SUPER_QUOTA_DEFAULTS = AccountQuotaSet(
-    auto   = _w(50,  50,  7_200),    # 50  queries / 2 h
-    fast   = _w(140, 140, 7_200),    # 140 queries / 2 h
-    expert = _w(50,  50,  7_200),    # 50  queries / 2 h
+    auto=_w(50, 50, 7_200),  # 50  queries / 2 h
+    fast=_w(140, 140, 7_200),  # 140 queries / 2 h
+    expert=_w(50, 50, 7_200),  # 50  queries / 2 h
+    grok_4_3=_w(50, 50, 7_200),  # 50  queries / 2 h
 )
 
 HEAVY_QUOTA_DEFAULTS = AccountQuotaSet(
-    auto   = _w(150, 150, 7_200),    # 150 queries / 2 h
-    fast   = _w(400, 400, 7_200),    # 400 queries / 2 h
-    expert = _w(150, 150, 7_200),    # 150 queries / 2 h
-    heavy  = _w(20,  20,  7_200),    # 20  queries / 2 h
+    auto=_w(150, 150, 7_200),  # 150 queries / 2 h
+    fast=_w(400, 400, 7_200),  # 400 queries / 2 h
+    expert=_w(150, 150, 7_200),  # 150 queries / 2 h
+    heavy=_w(20, 20, 7_200),  # 20  queries / 2 h
+    grok_4_3=_w(150, 150, 7_200),  # 150 queries / 2 h
 )
 
 # Map pool name → defaults object (used by backends on upsert).
@@ -67,8 +70,8 @@ _POOL_DEFAULTS: dict[str, AccountQuotaSet] = {
 
 _SUPPORTED_MODE_IDS_BY_POOL: dict[str, frozenset[int]] = {
     "basic": frozenset((0, 1, 2)),
-    "super": frozenset((0, 1, 2)),
-    "heavy": frozenset((0, 1, 2, 3)),
+    "super": frozenset((0, 1, 2, 4)),
+    "heavy": frozenset((0, 1, 2, 3, 4)),
 }
 
 # ---------------------------------------------------------------------------
@@ -76,8 +79,8 @@ _SUPPORTED_MODE_IDS_BY_POOL: dict[str, frozenset[int]] = {
 # ---------------------------------------------------------------------------
 
 _AUTO_TOTAL_TO_POOL: dict[int, str] = {
-    20:  "basic",
-    50:  "super",
+    20: "basic",
+    50: "super",
     150: "heavy",
 }
 
@@ -86,23 +89,31 @@ def default_quota_set(pool: str) -> AccountQuotaSet:
     """Return a fresh copy of the default quota set for *pool*."""
     src = _POOL_DEFAULTS.get(pool, BASIC_QUOTA_DEFAULTS)
     qs = AccountQuotaSet(
-        auto   = _w(src.auto.remaining,   src.auto.total,   src.auto.window_seconds),
-        fast   = _w(src.fast.remaining,   src.fast.total,   src.fast.window_seconds),
-        expert = _w(src.expert.remaining, src.expert.total, src.expert.window_seconds),
+        auto=_w(src.auto.remaining, src.auto.total, src.auto.window_seconds),
+        fast=_w(src.fast.remaining, src.fast.total, src.fast.window_seconds),
+        expert=_w(src.expert.remaining, src.expert.total, src.expert.window_seconds),
     )
     if src.heavy is not None:
         qs.heavy = _w(src.heavy.remaining, src.heavy.total, src.heavy.window_seconds)
+    if src.grok_4_3 is not None:
+        qs.grok_4_3 = _w(
+            src.grok_4_3.remaining, src.grok_4_3.total, src.grok_4_3.window_seconds
+        )
     return qs
 
 
 def supports_mode(pool: str, mode_id: int) -> bool:
     """Return whether *pool* has a default quota window for *mode_id*."""
-    return mode_id in _SUPPORTED_MODE_IDS_BY_POOL.get(pool, _SUPPORTED_MODE_IDS_BY_POOL["basic"])
+    return mode_id in _SUPPORTED_MODE_IDS_BY_POOL.get(
+        pool, _SUPPORTED_MODE_IDS_BY_POOL["basic"]
+    )
 
 
 def supported_mode_ids(pool: str) -> tuple[int, ...]:
     """Return the supported mode IDs for *pool* in stable request order."""
-    supported = _SUPPORTED_MODE_IDS_BY_POOL.get(pool, _SUPPORTED_MODE_IDS_BY_POOL["basic"])
+    supported = _SUPPORTED_MODE_IDS_BY_POOL.get(
+        pool, _SUPPORTED_MODE_IDS_BY_POOL["basic"]
+    )
     return tuple(mode_id for mode_id in (0, 1, 2, 3) if mode_id in supported)
 
 

--- a/app/control/model/enums.py
+++ b/app/control/model/enums.py
@@ -9,13 +9,17 @@ class ModeId(IntEnum):
     Integer values are stable — used as array indices in the hot path.
     """
 
-    AUTO   = 0  # modeId="auto"
-    FAST   = 1  # modeId="fast"
+    AUTO = 0  # modeId="auto"
+    FAST = 1  # modeId="fast"
     EXPERT = 2  # modeId="expert"
-    HEAVY  = 3  # modeId="heavy"  — only available on heavy-pool accounts
+    HEAVY = 3  # modeId="heavy"    — only available on heavy-pool accounts
+    GROK_4_3 = 4  # modeId="grok-420-computer-use-sa" — super/heavy only
 
     def to_api_str(self) -> str:
-        return self.name.lower()
+        _OVERRIDES: dict[int, str] = {
+            ModeId.GROK_4_3: "grok-420-computer-use-sa",
+        }
+        return _OVERRIDES.get(self, self.name.lower())  # type: ignore[arg-type]
 
 
 class Tier(IntEnum):
@@ -29,23 +33,43 @@ class Tier(IntEnum):
 class Capability(IntFlag):
     """Bitmask of features a model supports."""
 
-    CHAT       = 1
-    IMAGE      = 2
+    CHAT = 1
+    IMAGE = 2
     IMAGE_EDIT = 4
-    VIDEO      = 8
-    VOICE      = 16
-    ASSET      = 32
+    VIDEO = 8
+    VOICE = 16
+    ASSET = 32
 
 
 # Human-readable mode strings in API order.
 MODE_STRINGS: dict[ModeId, str] = {
-    ModeId.AUTO:   "auto",
-    ModeId.FAST:   "fast",
+    ModeId.AUTO: "auto",
+    ModeId.FAST: "fast",
     ModeId.EXPERT: "expert",
-    ModeId.HEAVY:  "heavy",
+    ModeId.HEAVY: "heavy",
 }
 
-ALL_MODES:          tuple[ModeId, ...] = (ModeId.AUTO, ModeId.FAST, ModeId.EXPERT)
-ALL_MODES_WITH_HEAVY: tuple[ModeId, ...] = (ModeId.AUTO, ModeId.FAST, ModeId.EXPERT, ModeId.HEAVY)
+ALL_MODES: tuple[ModeId, ...] = (ModeId.AUTO, ModeId.FAST, ModeId.EXPERT)
+ALL_MODES_WITH_HEAVY: tuple[ModeId, ...] = (
+    ModeId.AUTO,
+    ModeId.FAST,
+    ModeId.EXPERT,
+    ModeId.HEAVY,
+)
+ALL_MODES_FULL: tuple[ModeId, ...] = (
+    ModeId.AUTO,
+    ModeId.FAST,
+    ModeId.EXPERT,
+    ModeId.HEAVY,
+    ModeId.GROK_4_3,
+)
 
-__all__ = ["ModeId", "Tier", "Capability", "MODE_STRINGS", "ALL_MODES", "ALL_MODES_WITH_HEAVY"]
+__all__ = [
+    "ModeId",
+    "Tier",
+    "Capability",
+    "MODE_STRINGS",
+    "ALL_MODES",
+    "ALL_MODES_WITH_HEAVY",
+    "ALL_MODES_FULL",
+]

--- a/app/control/model/registry.py
+++ b/app/control/model/registry.py
@@ -8,47 +8,53 @@ from .spec import ModelSpec
 # Add new models here; no other files need to change.
 # ---------------------------------------------------------------------------
 
+# fmt: off
 MODELS: tuple[ModelSpec, ...] = (
     # === Chat ==============================================================
 
     # Basic+
-    ModelSpec("grok-4.20-0309-non-reasoning",           ModeId.FAST,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning"),
-    ModelSpec("grok-4.20-0309",                         ModeId.AUTO,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309"),
-    ModelSpec("grok-4.20-0309-reasoning",               ModeId.EXPERT, Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning"),
+    ModelSpec("grok-4.20-0309-non-reasoning",           ModeId.FAST,     Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning"),
+    ModelSpec("grok-4.20-0309",                         ModeId.AUTO,     Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309"),
+    ModelSpec("grok-4.20-0309-reasoning",               ModeId.EXPERT,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning"),
     # Super+
-    ModelSpec("grok-4.20-0309-non-reasoning-super",     ModeId.FAST,   Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning Super"),
-    ModelSpec("grok-4.20-0309-super",                   ModeId.AUTO,   Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Super"),
-    ModelSpec("grok-4.20-0309-reasoning-super",         ModeId.EXPERT, Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning Super"),
+    ModelSpec("grok-4.20-0309-non-reasoning-super",     ModeId.FAST,     Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning Super"),
+    ModelSpec("grok-4.20-0309-super",                   ModeId.AUTO,     Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Super"),
+    ModelSpec("grok-4.20-0309-reasoning-super",         ModeId.EXPERT,   Tier.SUPER, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning Super"),
     # Heavy+
-    ModelSpec("grok-4.20-0309-non-reasoning-heavy",     ModeId.FAST,   Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning Heavy"),
-    ModelSpec("grok-4.20-0309-heavy",                   ModeId.AUTO,   Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Heavy"),
-    ModelSpec("grok-4.20-0309-reasoning-heavy",         ModeId.EXPERT, Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning Heavy"),
-    ModelSpec("grok-4.20-multi-agent-0309",             ModeId.HEAVY,  Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Multi-Agent 0309"),
+    ModelSpec("grok-4.20-0309-non-reasoning-heavy",     ModeId.FAST,     Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Non-Reasoning Heavy"),
+    ModelSpec("grok-4.20-0309-heavy",                   ModeId.AUTO,     Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Heavy"),
+    ModelSpec("grok-4.20-0309-reasoning-heavy",         ModeId.EXPERT,   Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 0309 Reasoning Heavy"),
+    ModelSpec("grok-4.20-multi-agent-0309",             ModeId.HEAVY,    Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Multi-Agent 0309"),
 
     # --- 硬优先级反向选池 (heavy → super → basic) ---
-    ModelSpec("grok-4.20-fast",                        ModeId.FAST,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Fast",          prefer_best=True),
-    ModelSpec("grok-4.20-auto",                        ModeId.AUTO,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Auto",          prefer_best=True),
-    ModelSpec("grok-4.20-expert",                      ModeId.EXPERT, Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Expert",        prefer_best=True),
-    ModelSpec("grok-4.20-heavy",                       ModeId.HEAVY,  Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Heavy",         prefer_best=True),
+    ModelSpec("grok-4.20-fast",                         ModeId.FAST,     Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Fast",          prefer_best=True),
+    ModelSpec("grok-4.20-auto",                         ModeId.AUTO,     Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Auto",          prefer_best=True),
+    ModelSpec("grok-4.20-expert",                       ModeId.EXPERT,   Tier.BASIC, Capability.CHAT,       True, "Grok 4.20 Expert",        prefer_best=True),
+    ModelSpec("grok-4.20-heavy",                        ModeId.HEAVY,    Tier.HEAVY, Capability.CHAT,       True, "Grok 4.20 Heavy",         prefer_best=True),
+
+    # === grok-4.3 (grok-420-computer-use-sa) ==================================
+    # Super+（basic 池不支持此模式）
+    ModelSpec("grok-4.3-beta",                          ModeId.GROK_4_3, Tier.SUPER, Capability.CHAT,       True, "Grok 4.3 Beta"),
 
     # === Image ==============================================================
 
     # Basic+
-    ModelSpec("grok-imagine-image-lite",                ModeId.FAST,   Tier.BASIC, Capability.IMAGE,      True, "Grok Imagine Image Lite"),
+    ModelSpec("grok-imagine-image-lite",                ModeId.FAST,     Tier.BASIC, Capability.IMAGE,      True, "Grok Imagine Image Lite"),
     # Super+
-    ModelSpec("grok-imagine-image",                     ModeId.AUTO,   Tier.SUPER, Capability.IMAGE,      True, "Grok Imagine Image"),
-    ModelSpec("grok-imagine-image-pro",                 ModeId.AUTO,   Tier.SUPER, Capability.IMAGE,      True, "Grok Imagine Image Pro"),
-    
+    ModelSpec("grok-imagine-image",                     ModeId.AUTO,     Tier.SUPER, Capability.IMAGE,      True, "Grok Imagine Image"),
+    ModelSpec("grok-imagine-image-pro",                 ModeId.AUTO,     Tier.SUPER, Capability.IMAGE,      True, "Grok Imagine Image Pro"),
+
     # === Image Edit =========================================================
 
     # Super+
-    ModelSpec("grok-imagine-image-edit",                ModeId.AUTO,   Tier.SUPER, Capability.IMAGE_EDIT, True, "Grok Imagine Image Edit"),
-    
+    ModelSpec("grok-imagine-image-edit",                ModeId.AUTO,     Tier.SUPER, Capability.IMAGE_EDIT, True, "Grok Imagine Image Edit"),
+
     # === Video ==============================================================
 
     # Super+
-    ModelSpec("grok-imagine-video",                     ModeId.AUTO,   Tier.SUPER, Capability.VIDEO,      True, "Grok Imagine Video"),
+    ModelSpec("grok-imagine-video",                     ModeId.AUTO,     Tier.SUPER, Capability.VIDEO,      True, "Grok Imagine Video"),
 )
+# fmt: on
 
 # ---------------------------------------------------------------------------
 # Internal lookup structures — built once at import time.
@@ -64,6 +70,7 @@ for _m in MODELS:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def get(model_name: str) -> ModelSpec | None:
     """Return the spec for *model_name*, or ``None`` if not registered."""

--- a/app/control/model/spec.py
+++ b/app/control/model/spec.py
@@ -22,26 +22,37 @@ class ModelSpec:
                     pools first (hard priority, not soft preference).
     """
 
-    model_name:  str
-    mode_id:     ModeId
-    tier:        Tier
-    capability:  Capability
-    enabled:     bool
+    model_name: str
+    mode_id: ModeId
+    tier: Tier
+    capability: Capability
+    enabled: bool
     public_name: str
     prefer_best: bool = False
 
     # --- convenience predicates ---
 
-    def is_chat(self)       -> bool: return bool(self.capability & Capability.CHAT)
-    def is_image(self)      -> bool: return bool(self.capability & Capability.IMAGE)
-    def is_image_edit(self) -> bool: return bool(self.capability & Capability.IMAGE_EDIT)
-    def is_video(self)      -> bool: return bool(self.capability & Capability.VIDEO)
-    def is_voice(self)      -> bool: return bool(self.capability & Capability.VOICE)
+    def is_chat(self) -> bool:
+        return bool(self.capability & Capability.CHAT)
+
+    def is_image(self) -> bool:
+        return bool(self.capability & Capability.IMAGE)
+
+    def is_image_edit(self) -> bool:
+        return bool(self.capability & Capability.IMAGE_EDIT)
+
+    def is_video(self) -> bool:
+        return bool(self.capability & Capability.VIDEO)
+
+    def is_voice(self) -> bool:
+        return bool(self.capability & Capability.VOICE)
 
     def pool_name(self) -> str:
         """Return the canonical pool string for this tier."""
-        if self.tier == Tier.SUPER:  return "super"
-        if self.tier == Tier.HEAVY:  return "heavy"
+        if self.tier == Tier.SUPER:
+            return "super"
+        if self.tier == Tier.HEAVY:
+            return "heavy"
         return "basic"
 
     def pool_id(self) -> int:
@@ -67,11 +78,14 @@ class ModelSpec:
           HEAVY tier  → heavy only
         """
         if self.prefer_best:
-            if self.tier == Tier.HEAVY:  return (2,)       # heavy only
-            return (2, 1, 0)                                # heavy, super, basic
-        if self.tier == Tier.BASIC:  return (0, 1, 2)   # basic, super, heavy
-        if self.tier == Tier.SUPER:  return (1, 2)       # super, heavy
-        return (2,)                                       # heavy only
+            if self.tier == Tier.HEAVY:
+                return (2,)  # heavy only
+            return (2, 1, 0)  # heavy, super, basic
+        if self.tier == Tier.BASIC:
+            return (0, 1, 2)  # basic, super, heavy
+        if self.tier == Tier.SUPER:
+            return (1, 2)  # super, heavy
+        return (2,)  # heavy only
 
 
 __all__ = ["ModelSpec"]


### PR DESCRIPTION
## Summary

新增 `grok-4.3-beta` 模型支持，对应上游 `grok-420-computer-use-sa` modeId。该模式有独立配额维度（super 50/2h，heavy 150/2h），不对 basic 池开放。

- `enums.py`：新增 `ModeId.GROK_4_3 = 4`，`to_api_str()` 加覆盖映射
- `models.py`：`AccountQuotaSet` 新增 `grok_4_3` 配额字段
- `quota_defaults.py`：SUPER/HEAVY 默认配额补充 `grok_4_3`，basic 不含 mode_id=4
- `registry.py`：注册 `grok-4.3-beta`（`Tier.SUPER`，天然排除 basic 池）


## Testing

```bash
# 确认模型出现在列表中（需要 super/heavy 账号在线）
curl http://localhost:8000/v1/models | jq '.data[].id' | grep 4.3

# 确认请求成功，上游收到正确 modeId
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"grok-4.3-beta","messages":[{"role":"user","content":"hi"}]}'
```

## Related

- Closes #484 
