### PR TITLE
fix: Implement reserve_any method for account selection and update image generation to utilize it

### DIFF
--- a/app/dataplane/account/__init__.py
+++ b/app/dataplane/account/__init__.py
@@ -14,7 +14,7 @@ from app.control.account.repository import AccountRepository
 from app.control.account.enums import FeedbackKind
 from .table import AccountRuntimeTable
 from .lease import AccountLease, new_lease
-from .selector import select
+from .selector import select, select_any
 from .sync import bootstrap as _bootstrap, apply_changes
 from . import feedback as fb
 from ..shared.enums import StatusId
@@ -147,6 +147,73 @@ class AccountDirectory:
             token=token,
             pool_id=actual_pool,
             mode_id=mode_id,
+            selected_at=ts,
+        )
+
+    async def reserve_any(
+        self,
+        pool_candidates: tuple[int, ...] | int,
+        *,
+        exclude_tokens: list[str] | None = None,
+        prefer_tags: list[str] | None = None,
+        now_s_override: int | None = None,
+    ) -> AccountLease | None:
+        """Select any active account from pool_candidates without mode quota checking.
+
+        Used for WebSocket-based operations that manage their own upstream rate limiting.
+        Returns an AccountLease with mode_id=-1 (no specific mode is tracked).
+        """
+        table = self._table
+        if table is None:
+            return None
+
+        pools: tuple[int, ...] = (
+            (pool_candidates,) if isinstance(pool_candidates, int) else pool_candidates
+        )
+        ts = now_s_override if now_s_override is not None else now_s()
+
+        exclude_idxs: frozenset[int] | None = None
+        if exclude_tokens:
+            idxs = [
+                table.idx_by_token[t] for t in exclude_tokens if t in table.idx_by_token
+            ]
+            if idxs:
+                exclude_idxs = frozenset(idxs)
+
+        prefer_tag_idxs: set[int] | None = None
+        if prefer_tags:
+            sets = [
+                table.tag_idx.get(tag) for tag in prefer_tags if tag in table.tag_idx
+            ]
+            if sets:
+                prefer_tag_idxs = set().union(*sets)
+
+        async with self._lock:
+            idx: int | None = None
+            for pool_id in pools:
+                idx = select_any(
+                    table,
+                    pool_id,
+                    exclude_idxs=exclude_idxs,
+                    prefer_tag_idxs=prefer_tag_idxs,
+                    now_s=ts,
+                )
+                if idx is not None:
+                    break
+
+            if idx is None:
+                return None
+
+            fb.increment_inflight(table, idx)
+            fb.update_last_use(table, idx, ts)
+            token = table.get_token(idx)
+            actual_pool = table.get_pool_id(idx)
+
+        return new_lease(
+            idx=idx,
+            token=token,
+            pool_id=actual_pool,
+            mode_id=-1,  # no specific mode tracked for WS operations
             selected_at=ts,
         )
 

--- a/app/dataplane/account/selector.py
+++ b/app/dataplane/account/selector.py
@@ -5,7 +5,7 @@ overhead.  The caller provides the frozen set of excluded indices and
 pre-resolved tag index set.
 """
 
-from ..shared.enums import PoolId, StatusId
+from ..shared.enums import PoolId
 from .table import AccountRuntimeTable
 
 # Scoring weights — tuned for throughput/fairness balance.
@@ -144,4 +144,73 @@ def _best(
     return best_idx if best_idx >= 0 else None
 
 
-__all__ = ["select"]
+def select_any(
+    table: AccountRuntimeTable,
+    pool_id: int,
+    *,
+    exclude_idxs: frozenset[int] | None = None,
+    prefer_tag_idxs: set[int] | None = None,
+    now_s: int,
+) -> int | None:
+    """Select any active account from *pool_id* without mode-specific quota checking.
+
+    Used for WebSocket-based operations that manage their own upstream rate limiting
+    and do not consume tracked quota buckets.  Candidates are the union of all
+    mode_available sets for the pool so that accounts are reachable even when one
+    particular mode bucket (e.g. AUTO) is exhausted.
+    """
+    candidates: set[int] = set()
+    for (pid, _mid), accounts in table.mode_available.items():
+        if pid == pool_id:
+            candidates |= accounts
+
+    if not candidates:
+        return None
+
+    working = candidates.copy()
+    if exclude_idxs:
+        working -= exclude_idxs
+    if not working:
+        return None
+
+    if prefer_tag_idxs:
+        preferred = working & prefer_tag_idxs
+        working = preferred if preferred else working
+
+    return _best_no_quota(table, working, now_s)
+
+
+def _best_no_quota(
+    table: AccountRuntimeTable,
+    working: set[int],
+    now_s: int,
+) -> int | None:
+    """Score candidates by health and inflight only — no quota weighting."""
+    best_idx = -1
+    best_score = -1e18
+
+    health_col = table.health_by_idx
+    inflight_col = table.inflight_by_idx
+    fail_col = table.fail_count_by_idx
+    last_use_col = table.last_use_at_by_idx
+
+    for idx in working:
+        health = float(health_col[idx])
+        inflight = int(inflight_col[idx])
+        fails = min(int(fail_col[idx]), 10)
+        last_use = int(last_use_col[idx])
+
+        score = health * _W_HEALTH - inflight * _W_INFLIGHT - fails * _W_FAIL
+        if last_use > 0:
+            age_s = now_s - last_use
+            if age_s < _RECENT_WINDOW_S:
+                score -= (1.0 - age_s / _RECENT_WINDOW_S) * _W_RECENT
+
+        if score > best_score:
+            best_score = score
+            best_idx = idx
+
+    return best_idx if best_idx >= 0 else None
+
+
+__all__ = ["select", "select_any"]

--- a/app/products/openai/images.py
+++ b/app/products/openai/images.py
@@ -271,10 +271,9 @@ async def generate(
             chat_format     = chat_format,
         )
 
-    acct = await _acct_dir.reserve(
-        pool_candidates = spec.pool_candidates(),
-        mode_id         = int(spec.mode_id),
-        now_s_override  = now_s(),
+    acct = await _acct_dir.reserve_any(
+        spec.pool_candidates(),
+        now_s_override=now_s(),
     )
     if acct is None:
         raise RateLimitError("No available accounts for image generation")
@@ -282,6 +281,7 @@ async def generate(
     token       = acct.token
     response_id = make_response_id()
     enable_pro  = model in _PRO_IMAGE_MODELS
+    _ws_mode_id = int(spec.mode_id)
 
     if stream:
         async def _sse_stream() -> AsyncGenerator[str, None]:
@@ -349,12 +349,12 @@ async def generate(
                 raise
             finally:
                 await _acct_dir.release(acct)
-                kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
-                await _acct_dir.feedback(token, kind, int(spec.mode_id))
-                if success:
-                    asyncio.create_task(_quota_sync(token, int(spec.mode_id)))
-                else:
-                    asyncio.create_task(_fail_sync(token, int(spec.mode_id), fail_exc))
+                # WS image gen has its own upstream rate limiting — skip quota tracking.
+                # Still propagate auth failures so bad accounts get marked expired.
+                if not success and fail_exc is not None:
+                    kind = _feedback_kind(fail_exc)
+                    if kind in (FeedbackKind.UNAUTHORIZED, FeedbackKind.FORBIDDEN):
+                        await _acct_dir.feedback(token, kind, _ws_mode_id)
 
         return _sse_stream()
 
@@ -416,12 +416,11 @@ async def generate(
         raise
     finally:
         await _acct_dir.release(acct)
-        kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
-        await _acct_dir.feedback(token, kind, int(spec.mode_id))
-        if success:
-            asyncio.create_task(_quota_sync(token, int(spec.mode_id)))
-        else:
-            asyncio.create_task(_fail_sync(token, int(spec.mode_id), fail_exc))
+        # WS image gen has its own upstream rate limiting — skip quota tracking.
+        if not success and fail_exc is not None:
+            kind = _feedback_kind(fail_exc)
+            if kind in (FeedbackKind.UNAUTHORIZED, FeedbackKind.FORBIDDEN):
+                await _acct_dir.feedback(token, kind, _ws_mode_id)
 
     if chat_format:
         content = "\n\n".join(image.markdown_value for image in finals)

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -504,17 +504,18 @@ async def videos_create(
     preset: Annotated[
         Literal["fun", "normal", "spicy", "custom"] | None, Form()
     ] = None,
-    input_reference: Annotated[UploadFile | None, File()] = None,
+    input_reference: Annotated[
+        list[UploadFile] | None, File(alias="input_reference[]")
+    ] = None,
 ):
     from .video import create_video
 
-    reference_payload = None
-    if input_reference is not None:
-        reference_payload = {
-            "image_url": await _upload_to_data_uri(
-                input_reference, param="input_reference"
-            ),
-        }
+    references_payload = None
+    if input_reference:
+        references_payload = [
+            {"image_url": await _upload_to_data_uri(f, param="input_reference")}
+            for f in input_reference[:5]
+        ]
 
     result = await create_video(
         model=model or "grok-video",
@@ -523,7 +524,7 @@ async def videos_create(
         size=size or "720x1280",
         resolution_name=resolution_name,
         preset=preset,
-        input_reference=reference_payload,
+        input_references=references_payload,
     )
     return JSONResponse(result)
 

--- a/app/products/openai/video.py
+++ b/app/products/openai/video.py
@@ -135,14 +135,8 @@ _VIDEO_JOBS: dict[str, _VideoJob] = {}
 _VIDEO_JOBS_LOCK = asyncio.Lock()
 
 
-def _build_message(
-    prompt: str, preset: str, *, reference_content_urls: list[str] | None = None
-) -> str:
-    message = f"{prompt} {_PRESET_FLAGS.get(preset, '--mode=custom')}".strip()
-    if reference_content_urls:
-        prefix = " ".join(reference_content_urls)
-        return f"{prefix}  {message}"
-    return message
+def _build_message(prompt: str, preset: str) -> str:
+    return f"{prompt} {_PRESET_FLAGS.get(preset, '--mode=custom')}".strip()
 
 
 def _progress_reason(progress: int) -> str:
@@ -220,34 +214,33 @@ def _video_create_payload(
     resolution_name: str,
     video_length: int,
     preset: str,
-    reference_content_urls: list[str] | None = None,
-    file_attachments: list[str] | None = None,
+    image_references: list[str] | None = None,
 ) -> dict[str, Any]:
-    payload = {
+    video_gen_config: dict[str, Any] = {
+        "parentPostId": parent_post_id,
+        "aspectRatio": aspect_ratio,
+        "videoLength": video_length,
+        "resolutionName": resolution_name,
+    }
+    if image_references:
+        video_gen_config["isVideoEdit"] = False
+        video_gen_config["isReferenceToVideo"] = True
+        video_gen_config["imageReferences"] = image_references
+    return {
         "temporary": True,
         "modelName": _VIDEO_MODEL_NAME,
-        "message": _build_message(
-            prompt, preset, reference_content_urls=reference_content_urls
-        ),
+        "message": _build_message(prompt, preset),
         "toolOverrides": {"videoGen": True},
         "enableSideBySide": True,
         "responseMetadata": {
             "experiments": [],
             "modelConfigOverride": {
                 "modelMap": {
-                    "videoGenModelConfig": {
-                        "parentPostId": parent_post_id,
-                        "aspectRatio": aspect_ratio,
-                        "videoLength": video_length,
-                        "resolutionName": resolution_name,
-                    }
+                    "videoGenModelConfig": video_gen_config,
                 }
             },
         },
     }
-    if file_attachments:
-        payload["fileAttachments"] = file_attachments
-    return payload
 
 
 def _video_extend_start_time(seconds: int) -> float:
@@ -641,10 +634,7 @@ async def _generate_video_with_token(
                 resolution_name=resolution_name,
                 video_length=segment_length,
                 preset=preset,
-                reference_content_urls=[r.content_url for r in references]
-                if references
-                else None,
-                file_attachments=[r.post_id for r in references]
+                image_references=[r.content_url for r in references]
                 if references
                 else None,
             )

--- a/app/products/openai/video.py
+++ b/app/products/openai/video.py
@@ -18,7 +18,13 @@ from urllib.parse import urlparse
 import orjson
 
 from app.platform.config.snapshot import get_config
-from app.platform.errors import AppError, ErrorKind, RateLimitError, UpstreamError, ValidationError
+from app.platform.errors import (
+    AppError,
+    ErrorKind,
+    RateLimitError,
+    UpstreamError,
+    ValidationError,
+)
 from app.platform.logging.logger import logger
 from app.platform.runtime.clock import now_s
 from app.platform.storage import video_files_dir
@@ -28,7 +34,10 @@ from app.control.model.registry import resolve as resolve_model
 from app.dataplane.proxy import get_proxy_runtime
 from app.dataplane.proxy.adapters.headers import build_http_headers
 from app.dataplane.proxy.adapters.session import ResettableSession, build_session_kwargs
-from app.dataplane.reverse.protocol.xai_assets import resolve_asset_reference, resolve_download_url
+from app.dataplane.reverse.protocol.xai_assets import (
+    resolve_asset_reference,
+    resolve_download_url,
+)
 from app.dataplane.reverse.protocol.xai_chat import classify_line
 from app.dataplane.reverse.runtime.endpoint_table import CHAT
 from app.dataplane.reverse.transport.asset_upload import (
@@ -126,10 +135,13 @@ _VIDEO_JOBS: dict[str, _VideoJob] = {}
 _VIDEO_JOBS_LOCK = asyncio.Lock()
 
 
-def _build_message(prompt: str, preset: str, *, reference_content_url: str | None = None) -> str:
+def _build_message(
+    prompt: str, preset: str, *, reference_content_urls: list[str] | None = None
+) -> str:
     message = f"{prompt} {_PRESET_FLAGS.get(preset, '--mode=custom')}".strip()
-    if reference_content_url:
-        return f"{reference_content_url}  {message}"
+    if reference_content_urls:
+        prefix = " ".join(reference_content_urls)
+        return f"{prefix}  {message}"
     return message
 
 
@@ -148,7 +160,9 @@ def _coerce_seconds(value: str | int | None) -> int:
     try:
         return int(text)
     except ValueError as exc:
-        raise ValidationError("seconds must be an integer string", param="seconds") from exc
+        raise ValidationError(
+            "seconds must be an integer string", param="seconds"
+        ) from exc
 
 
 def validate_video_length(seconds: int) -> None:
@@ -169,7 +183,9 @@ def _resolve_video_size(size: str) -> tuple[str, str]:
 def _resolve_video_resolution_name(value: str | None, *, default: str = "720p") -> str:
     normalized = (value or default).strip().lower()
     if normalized not in {"480p", "720p"}:
-        raise ValidationError("resolution_name must be one of [480p, 720p]", param="resolution_name")
+        raise ValidationError(
+            "resolution_name must be one of [480p, 720p]", param="resolution_name"
+        )
     return normalized
 
 
@@ -204,13 +220,15 @@ def _video_create_payload(
     resolution_name: str,
     video_length: int,
     preset: str,
-    reference_content_url: str | None = None,
+    reference_content_urls: list[str] | None = None,
     file_attachments: list[str] | None = None,
 ) -> dict[str, Any]:
     payload = {
         "temporary": True,
         "modelName": _VIDEO_MODEL_NAME,
-        "message": _build_message(prompt, preset, reference_content_url=reference_content_url),
+        "message": _build_message(
+            prompt, preset, reference_content_urls=reference_content_urls
+        ),
         "toolOverrides": {"videoGen": True},
         "enableSideBySide": True,
         "responseMetadata": {
@@ -356,25 +374,41 @@ def _is_upstream_asset_content_url(value: str) -> bool:
     )
 
 
-async def _prepare_video_reference(token: str, input_reference: dict[str, Any]) -> _VideoReference:
+async def _prepare_video_reference(
+    token: str, input_reference: dict[str, Any]
+) -> _VideoReference:
     file_id = str(input_reference.get("file_id") or "").strip()
     image_input = str(input_reference.get("image_url") or "").strip()
 
     if file_id and image_input:
-        raise ValidationError("input_reference accepts only one of file_id or image_url", param="input_reference")
+        raise ValidationError(
+            "input_reference accepts only one of file_id or image_url",
+            param="input_reference",
+        )
     if file_id:
-        raise ValidationError("input_reference.file_id is not supported yet", param="input_reference.file_id")
+        raise ValidationError(
+            "input_reference.file_id is not supported yet",
+            param="input_reference.file_id",
+        )
     if not image_input:
-        raise ValidationError("input_reference.image_url is required", param="input_reference.image_url")
+        raise ValidationError(
+            "input_reference.image_url is required", param="input_reference.image_url"
+        )
 
     if _is_upstream_asset_content_url(image_input):
         content_url = image_input
     else:
         try:
-            uploaded_file_id, uploaded_file_uri = await upload_from_input(token, image_input)
-            content_url = resolve_uploaded_asset_reference(token, uploaded_file_id, uploaded_file_uri)
+            uploaded_file_id, uploaded_file_uri = await upload_from_input(
+                token, image_input
+            )
+            content_url = resolve_uploaded_asset_reference(
+                token, uploaded_file_id, uploaded_file_uri
+            )
         except ValidationError as exc:
-            raise ValidationError(exc.message, param="input_reference.image_url") from exc
+            raise ValidationError(
+                exc.message, param="input_reference.image_url"
+            ) from exc
         except UpstreamError as exc:
             raise UpstreamError(
                 f"Video input reference upload failed: {exc.message}",
@@ -393,11 +427,30 @@ async def _prepare_video_reference(token: str, input_reference: dict[str, Any]) 
     )
     post_data = post.get("post")
     if not isinstance(post_data, dict):
-        raise UpstreamError("Video image reference create-post returned no post payload")
+        raise UpstreamError(
+            "Video image reference create-post returned no post payload"
+        )
     post_id = str(post_data.get("id") or "").strip()
     if not post_id:
         raise UpstreamError("Video image reference create-post returned no post id")
     return _VideoReference(content_url=content_url, post_id=post_id)
+
+
+async def _prepare_video_references(
+    token: str,
+    input_references: list[dict[str, Any]],
+) -> list[_VideoReference]:
+    """Upload multiple video references concurrently and preserve order."""
+    results: list[_VideoReference | None] = [None] * len(input_references)
+
+    async def _runner(index: int, ref: dict[str, Any]) -> None:
+        results[index] = await _prepare_video_reference(token, ref)
+
+    async with asyncio.TaskGroup() as tg:
+        for index, ref in enumerate(input_references):
+            tg.create_task(_runner(index, ref), name=f"video-ref-{index}")
+
+    return [r for r in results if r is not None]
 
 
 async def _collect_video_segment(
@@ -464,7 +517,9 @@ async def _collect_video_segment(
         final_url = resolve_asset_reference(final_asset_id, "", user_id=None) or ""
 
     if not final_url and final_asset_id:
-        raise UpstreamError("Video segment returned only assetId without a resolvable URL")
+        raise UpstreamError(
+            "Video segment returned only assetId without a resolvable URL"
+        )
     if not final_url:
         raise UpstreamError("Video generation returned no final video URL")
 
@@ -499,7 +554,11 @@ def _save_video_bytes(raw: bytes, file_id: str) -> Path:
 
 def _local_video_url(file_id: str) -> str:
     app_url = get_config().get_str("app.app_url", "").rstrip("/")
-    return f"{app_url}/v1/files/video?id={file_id}" if app_url else f"/v1/files/video?id={file_id}"
+    return (
+        f"{app_url}/v1/files/video?id={file_id}"
+        if app_url
+        else f"/v1/files/video?id={file_id}"
+    )
 
 
 def _normalize_video_format(value: str | None) -> str:
@@ -518,7 +577,9 @@ def _render_video_html(url: str) -> str:
 
 
 async def _resolve_video_output(*, token: str, url: str, file_id: str) -> str:
-    fmt = _normalize_video_format(get_config().get_str("features.video_format", "grok_url"))
+    fmt = _normalize_video_format(
+        get_config().get_str("features.video_format", "grok_url")
+    )
     if fmt == "grok_url":
         return url
     if fmt == "grok_html":
@@ -544,13 +605,13 @@ async def _generate_video_with_token(
     seconds: int,
     preset: str,
     timeout_s: float,
-    input_reference: dict[str, Any] | None = None,
+    input_references: list[dict[str, Any]] | None = None,
     progress_cb: Callable[[int], Awaitable[None]] | None = None,
 ) -> _VideoArtifact:
-    reference: _VideoReference | None = None
-    if input_reference:
-        reference = await _prepare_video_reference(token, input_reference)
-        parent_post_id = reference.post_id
+    references: list[_VideoReference] = []
+    if input_references:
+        references = await _prepare_video_references(token, input_references)
+        parent_post_id = references[0].post_id
     else:
         post = await create_media_post(
             token,
@@ -580,8 +641,12 @@ async def _generate_video_with_token(
                 resolution_name=resolution_name,
                 video_length=segment_length,
                 preset=preset,
-                reference_content_url=reference.content_url if reference is not None else None,
-                file_attachments=[reference.post_id] if reference is not None else None,
+                reference_content_urls=[r.content_url for r in references]
+                if references
+                else None,
+                file_attachments=[r.post_id for r in references]
+                if references
+                else None,
             )
             referer = "https://grok.com/imagine"
         else:
@@ -600,7 +665,9 @@ async def _generate_video_with_token(
         async def _segment_progress(progress: int) -> None:
             if progress_cb is None:
                 return
-            scaled = int(((index + (max(0, min(100, progress)) / 100.0)) / total_segments) * 100)
+            scaled = int(
+                ((index + (max(0, min(100, progress)) / 100.0)) / total_segments) * 100
+            )
             await progress_cb(scaled)
 
         artifact = await _collect_video_segment(
@@ -628,7 +695,7 @@ async def _run_video_generation(
     resolution_name: str,
     seconds: int,
     preset: str = "custom",
-    input_reference: dict[str, Any] | None = None,
+    input_references: list[dict[str, Any]] | None = None,
     progress_cb: Callable[[int], Awaitable[None]] | None = None,
 ) -> _VideoArtifact:
     async def _runner(token: str, timeout_s: float) -> _VideoArtifact:
@@ -640,7 +707,7 @@ async def _run_video_generation(
             seconds=seconds,
             preset=preset,
             timeout_s=timeout_s,
-            input_reference=input_reference,
+            input_references=input_references,
             progress_cb=progress_cb,
         )
 
@@ -659,6 +726,7 @@ async def _run_video_with_account(
         raise ValidationError(f"Model {model!r} is not a video model", param="model")
 
     from app.dataplane.account import _directory as _acct_dir
+
     if _acct_dir is None:
         raise RateLimitError("Account directory not initialised")
 
@@ -682,7 +750,13 @@ async def _run_video_with_account(
         raise
     finally:
         await _acct_dir.release(acct)
-        kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
+        kind = (
+            FeedbackKind.SUCCESS
+            if success
+            else _feedback_kind(fail_exc)
+            if fail_exc
+            else FeedbackKind.SERVER_ERROR
+        )
         await _acct_dir.feedback(token, kind, int(spec.mode_id))
         if success:
             asyncio.create_task(_quota_sync(token, int(spec.mode_id)))
@@ -706,7 +780,9 @@ async def _expire_video_job(video_id: str, ttl_s: int = _VIDEO_JOB_TTL_S) -> Non
         _VIDEO_JOBS.pop(video_id, None)
 
 
-async def _set_job_status(job: _VideoJob, *, status: str, progress: int | None = None) -> None:
+async def _set_job_status(
+    job: _VideoJob, *, status: str, progress: int | None = None
+) -> None:
     async with _VIDEO_JOBS_LOCK:
         job.status = status
         if progress is not None:
@@ -725,7 +801,7 @@ async def _run_video_job(
     prompt: str,
     seconds: int,
     preset: str | None,
-    input_reference: dict[str, Any] | None = None,
+    input_references: list[dict[str, Any]] | None = None,
 ) -> None:
     try:
         await _set_job_status(job, status="in_progress", progress=1)
@@ -738,6 +814,7 @@ async def _run_video_job(
         spec = resolve_model(job.model)
 
         from app.dataplane.account import _directory as _acct_dir
+
         if _acct_dir is None:
             raise RateLimitError("Account directory not initialised")
 
@@ -757,7 +834,9 @@ async def _run_video_job(
             timeout_s = cfg.get_float("video.timeout", 180.0)
 
             async def _progress(progress: int) -> None:
-                await _set_job_status(job, status="in_progress", progress=max(1, progress))
+                await _set_job_status(
+                    job, status="in_progress", progress=max(1, progress)
+                )
 
             artifact = await _generate_video_with_token(
                 token=token,
@@ -767,7 +846,7 @@ async def _run_video_job(
                 seconds=seconds,
                 preset=resolved_preset,
                 timeout_s=timeout_s,
-                input_reference=input_reference,
+                input_references=input_references,
                 progress_cb=_progress,
             )
             raw, _mime = await _download_video_bytes(token, artifact.video_url)
@@ -777,7 +856,13 @@ async def _run_video_job(
             raise
         finally:
             await _acct_dir.release(acct)
-            kind = FeedbackKind.SUCCESS if success else _feedback_kind(fail_exc) if fail_exc else FeedbackKind.SERVER_ERROR
+            kind = (
+                FeedbackKind.SUCCESS
+                if success
+                else _feedback_kind(fail_exc)
+                if fail_exc
+                else FeedbackKind.SERVER_ERROR
+            )
             await _acct_dir.feedback(token, kind, int(spec.mode_id))
             if success:
                 asyncio.create_task(_quota_sync(token, int(spec.mode_id)))
@@ -807,7 +892,7 @@ async def create_video(
     size: str | None = None,
     resolution_name: str | None = None,
     preset: str | None = None,
-    input_reference: dict[str, Any] | None = None,
+    input_references: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     spec = model_registry.get(model)
     if spec is None or not spec.enabled or not spec.is_video():
@@ -842,7 +927,7 @@ async def create_video(
             prompt=cleaned_prompt,
             seconds=normalized_seconds,
             preset=preset,
-            input_reference=input_reference,
+            input_references=input_references,
         )
     )
     asyncio.create_task(_expire_video_job(job.id))
@@ -869,13 +954,17 @@ async def content_path(video_id: str) -> Path:
         )
     path = Path(job.content_path)
     if not path.exists():
-        raise ValidationError(f"Video content for {video_id!r} not found", param="video_id")
+        raise ValidationError(
+            f"Video content for {video_id!r} not found", param="video_id"
+        )
     return path
 
 
-def _extract_video_prompt_and_reference(messages: list[dict]) -> tuple[str, dict[str, Any] | None]:
+def _extract_video_prompt_and_reference(
+    messages: list[dict],
+) -> tuple[str, list[dict[str, Any]] | None]:
     prompt = ""
-    reference_url = ""
+    reference_urls: list[str] = []
 
     for msg in reversed(messages):
         content = msg.get("content", "")
@@ -888,7 +977,7 @@ def _extract_video_prompt_and_reference(messages: list[dict]) -> tuple[str, dict
             continue
 
         text_parts: list[str] = []
-        block_reference = ""
+        block_references: list[str] = []
         for item in content:
             if not isinstance(item, dict):
                 continue
@@ -900,24 +989,26 @@ def _extract_video_prompt_and_reference(messages: list[dict]) -> tuple[str, dict
             elif item_type == "image_url":
                 image_url = item.get("image_url")
                 if isinstance(image_url, dict):
-                    block_reference = str(image_url.get("url") or "").strip() or block_reference
-                elif isinstance(image_url, str):
-                    block_reference = image_url.strip() or block_reference
+                    url = str(image_url.get("url") or "").strip()
+                    if url:
+                        block_references.append(url)
+                elif isinstance(image_url, str) and image_url.strip():
+                    block_references.append(image_url.strip())
 
         if text_parts:
             prompt = " ".join(text_parts)
-        if block_reference and not reference_url:
-            reference_url = block_reference
+        if block_references and not reference_urls:
+            reference_urls = block_references
         if prompt:
             break
 
     if not prompt:
         raise ValidationError("Video prompt cannot be empty", param="messages")
 
-    input_reference: dict[str, Any] | None = None
-    if reference_url:
-        input_reference = {"image_url": reference_url}
-    return prompt, input_reference
+    input_references: list[dict[str, Any]] | None = None
+    if reference_urls:
+        input_references = [{"image_url": url} for url in reference_urls[:5]]
+    return prompt, input_references
 
 
 async def completions(
@@ -938,7 +1029,7 @@ async def completions(
         default=default_resolution_name,
     )
     resolved_preset = _resolve_video_preset(preset)
-    prompt, input_reference = _extract_video_prompt_and_reference(messages)
+    prompt, input_references = _extract_video_prompt_and_reference(messages)
 
     cfg = get_config()
     is_stream = stream if stream is not None else cfg.get_bool("features.stream", False)
@@ -954,7 +1045,7 @@ async def completions(
                 seconds=seconds,
                 preset=resolved_preset,
                 timeout_s=timeout_s,
-                input_reference=input_reference,
+                input_references=input_references,
                 progress_cb=progress_cb,
             )
             file_id = hashlib.sha1(artifact.video_url.encode("utf-8")).hexdigest()[:32]
@@ -967,6 +1058,7 @@ async def completions(
         return await _run_video_with_account(model=model, runner=_runner)
 
     if is_stream:
+
         async def _sse() -> AsyncGenerator[str, None]:
             queue: asyncio.Queue[int] = asyncio.Queue()
             last_progress = -1
@@ -982,7 +1074,9 @@ async def completions(
                     continue
                 if progress > last_progress:
                     last_progress = progress
-                    chunk = make_thinking_chunk(response_id, model, _progress_reason(progress))
+                    chunk = make_thinking_chunk(
+                        response_id, model, _progress_reason(progress)
+                    )
                     yield f"data: {orjson.dumps(chunk).decode()}\n\n"
 
             content = await task


### PR DESCRIPTION
## Summary

- 修复 #470：WebSocket 画图不再检查 chat 配额，auto 额度耗尽后仍可正常生图
- 修复 #478：视频参考图支持最多 5 张，并发上传，chat completions 和文件上传两个入口均支持

## Testing

- `grok-4.3-beta`：用 super 账号发起请求，确认能命中该模型；将 auto 额度清空后确认仍可调用（走独立 grok_4_3 配额）；用 basic 账号请求确认返回无可用账号
- #470：将 super 账号的 auto 额度手动置为 0，在 WebUI 开启瀑布流生图，确认不再提示"No available accounts"
- #478：`/v1/videos` 发送 `multipart/form-data` 含多个 `input_reference[]` 文件（测试 1、3、5、6 张），确认 6 张时只处理前 5 张；chat completions 消息内含多个 image_url block，确认均被识别并传给上游

## Related

- Closes #470
- Closes #478
