### PR TITLE
feat: Add local media cache configuration and management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ docker compose up -d
 | `SERVER_PORT` | 服务监听端口 | `8000` |
 | `SERVER_WORKERS` | Granian worker 数量 | `1` |
 | `HOST_PORT` | Docker Compose 宿主机映射端口 | `8000` |
-| `DATA_DIR` | 本地数据目录 | `./data` |
+| `DATA_DIR` | 本地数据根目录（账号库、本地媒体文件、缓存索引统一位于此目录下） | `./data` |
 | `LOG_DIR` | 本地日志目录 | `./logs` |
 | `ACCOUNT_STORAGE` | 账号存储后端 | `local` |
 | `ACCOUNT_LOCAL_PATH` | `local` 模式账号 SQLite 路径 | `${DATA_DIR}/accounts.db` |
@@ -202,6 +202,7 @@ docker compose up -d
 | `proxy.clearance` | `mode`, `cf_cookies`, `user_agent`, `browser`, `flaresolverr_url`, `timeout_sec`, `refresh_interval` |
 | `retry` | `reset_session_status_codes`, `max_retries`, `on_codes` |
 | `account.refresh` | `basic_interval_sec`, `super_interval_sec`, `heavy_interval_sec`, `usage_concurrency`, `on_demand_min_interval_sec` |
+| `cache.local` | `image_max_mb`, `video_max_mb` |
 | `chat` | `timeout` |
 | `image` | `timeout`, `stream_timeout` |
 | `video` | `timeout` |

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.platform.config.snapshot import config as _config
 from app.platform.errors import AppError
 from app.platform.meta import get_project_version
 from app.platform.paths import data_path
+from app.platform.storage import reconcile_local_media_cache_async
 
 
 load_dotenv()
@@ -144,6 +145,7 @@ async def lifespan(app: FastAPI):
     )
     # Reload config in case it was just seeded/migrated into the backend.
     await _config.load()
+    await reconcile_local_media_cache_async()
 
     directory = await get_account_directory(repo)
 

--- a/app/platform/storage/__init__.py
+++ b/app/platform/storage/__init__.py
@@ -1,5 +1,20 @@
 """Platform storage helpers."""
 
+from .media_cache import (
+    clear_local_media_files,
+    delete_local_media_file,
+    reconcile_local_media_cache_async,
+    save_local_image,
+    save_local_video,
+)
 from .media_paths import image_files_dir, video_files_dir
 
-__all__ = ["image_files_dir", "video_files_dir"]
+__all__ = [
+    "clear_local_media_files",
+    "delete_local_media_file",
+    "image_files_dir",
+    "reconcile_local_media_cache_async",
+    "save_local_image",
+    "save_local_video",
+    "video_files_dir",
+]

--- a/app/platform/storage/media_cache.py
+++ b/app/platform/storage/media_cache.py
@@ -1,0 +1,501 @@
+"""Local media cache helpers with optional capacity enforcement."""
+
+import asyncio
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import closing, contextmanager
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from app.platform.config.snapshot import get_config
+from app.platform.logging.logger import logger
+
+from .media_paths import (
+    image_files_dir,
+    local_media_cache_db_path,
+    local_media_lock_path,
+    video_files_dir,
+)
+
+MediaType = Literal["image", "video"]
+
+_LOW_WATERMARK_RATIO = 0.60
+_TABLE = "local_media_files"
+_IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".m4v", ".webm", ".avi", ".mkv"})
+
+
+class LocalMediaCacheStore:
+    """Manage local media files and enforce per-type cache limits."""
+
+    def __init__(self, *, config_provider: Callable[[], Any] = get_config) -> None:
+        self._config_provider = config_provider
+        self._init_lock = threading.Lock()
+        self._thread_locks = {
+            "image": threading.Lock(),
+            "video": threading.Lock(),
+        }
+        self._initialized_dbs: set[Path] = set()
+
+    def save_image(self, raw: bytes, mime: str, file_id: str) -> str:
+        """Persist an image and return the stable local file ID."""
+        ext = ".png" if "png" in mime.lower() else ".jpg"
+        self._save("image", file_id=file_id, raw=raw, suffix=ext)
+        return file_id
+
+    def save_video(self, raw: bytes, file_id: str) -> Path:
+        """Persist a video and return the final file path."""
+        return self._save("video", file_id=file_id, raw=raw, suffix=".mp4")
+
+    def reconcile(self, media_type: MediaType) -> None:
+        """Rebuild the on-disk index for one media type and enforce limits."""
+        max_bytes = self._limit_bytes(media_type)
+        if max_bytes <= 0:
+            return
+        with self._guard(media_type), closing(self._connect()) as conn:
+            rows = []
+            for path in self._iter_files(media_type):
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                rows.append(
+                    (
+                        media_type,
+                        path.name,
+                        int(stat.st_size),
+                        int(stat.st_mtime_ns),
+                        int(stat.st_mtime_ns),
+                    )
+                )
+            conn.execute(f"DELETE FROM {_TABLE} WHERE media_type = ?", (media_type,))
+            if rows:
+                conn.executemany(
+                    f"""
+                    INSERT INTO {_TABLE} (
+                        media_type,
+                        name,
+                        size_bytes,
+                        created_at_ns,
+                        updated_at_ns
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    rows,
+                )
+            self._enforce_limit_locked(conn, media_type)
+            conn.commit()
+
+    def delete(self, media_type: MediaType, name: str) -> bool:
+        """Delete a single local media file and keep the index consistent."""
+        safe_name = self._validate_name(media_type, name)
+        path = self._path_for_name(media_type, safe_name)
+        with self._guard(media_type):
+            existed = path.is_file()
+            if existed:
+                path.unlink(missing_ok=True)
+            self._delete_index_row_if_present(media_type, safe_name)
+        return existed
+
+    def clear(self, media_type: MediaType) -> int:
+        """Delete all tracked local media files for one media type."""
+        removed = 0
+        with self._guard(media_type):
+            for path in self._iter_files(media_type):
+                if path.is_file():
+                    path.unlink(missing_ok=True)
+                    removed += 1
+            self._delete_index_rows_if_present(media_type)
+        return removed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _save(
+        self,
+        media_type: MediaType,
+        *,
+        file_id: str,
+        raw: bytes,
+        suffix: str,
+    ) -> Path:
+        path = self._media_dir(media_type) / f"{file_id}{suffix}"
+        if self._limit_bytes(media_type) <= 0:
+            self._write_if_missing(path, raw)
+            return path
+
+        with self._guard(media_type), closing(self._connect()) as conn:
+            if path.exists():
+                self._upsert_existing_row(conn, media_type, path)
+            else:
+                self._atomic_write(path, raw)
+                self._upsert_new_row(conn, media_type, path)
+            self._enforce_limit_locked(conn, media_type, protected_names={path.name})
+            conn.commit()
+        return path
+
+    def _limit_bytes(self, media_type: MediaType) -> int:
+        cfg = self._config_provider()
+        limit_mb = max(0, int(cfg.get_int(f"cache.local.{media_type}_max_mb", 0)))
+        return limit_mb * 1024 * 1024
+
+    def _target_bytes(self, max_bytes: int) -> int:
+        return max(0, int(max_bytes * _LOW_WATERMARK_RATIO))
+
+    def _media_dir(self, media_type: MediaType) -> Path:
+        return image_files_dir() if media_type == "image" else video_files_dir()
+
+    def _allowed_exts(self, media_type: MediaType) -> frozenset[str]:
+        return _IMAGE_EXTS if media_type == "image" else _VIDEO_EXTS
+
+    def _iter_files(self, media_type: MediaType):
+        allowed = self._allowed_exts(media_type)
+        for path in self._media_dir(media_type).glob("*"):
+            if path.is_file() and path.suffix.lower() in allowed:
+                yield path
+
+    def _path_for_name(self, media_type: MediaType, name: str) -> Path:
+        return self._media_dir(media_type) / name
+
+    def _validate_name(self, media_type: MediaType, name: str) -> str:
+        value = (name or "").strip()
+        if not value:
+            raise ValueError("missing file name")
+        if Path(value).name != value:
+            raise ValueError("invalid file name")
+        if Path(value).suffix.lower() not in self._allowed_exts(media_type):
+            raise ValueError("unsupported file type")
+        return value
+
+    def _write_if_missing(self, path: Path, raw: bytes) -> None:
+        if path.exists():
+            return
+        self._atomic_write(path, raw)
+
+    def _atomic_write(self, path: Path, raw: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            return
+        tmp = path.parent / f".{path.name}.{uuid.uuid4().hex}.part"
+        try:
+            with tmp.open("wb") as handle:
+                handle.write(raw)
+            if path.exists():
+                return
+            os.replace(tmp, path)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @contextmanager
+    def _guard(self, media_type: MediaType):
+        thread_lock = self._thread_locks[media_type]
+        thread_lock.acquire()
+        fd: int | None = None
+        try:
+            lock_path = local_media_lock_path(media_type)
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                import fcntl
+
+                fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            except (ImportError, OSError, AttributeError):
+                fd = None
+            yield
+        finally:
+            if fd is not None:
+                try:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                    os.close(fd)
+                except (ImportError, OSError):
+                    pass
+            thread_lock.release()
+
+    def _connect(self) -> sqlite3.Connection:
+        db_path = local_media_cache_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        self._ensure_schema(conn, db_path)
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection, db_path: Path) -> None:
+        if db_path in self._initialized_dbs:
+            return
+        with self._init_lock:
+            if db_path in self._initialized_dbs:
+                return
+            conn.executescript(
+                f"""
+                CREATE TABLE IF NOT EXISTS {_TABLE} (
+                    media_type    TEXT    NOT NULL,
+                    name          TEXT    NOT NULL,
+                    size_bytes    INTEGER NOT NULL,
+                    created_at_ns INTEGER NOT NULL,
+                    updated_at_ns INTEGER NOT NULL,
+                    PRIMARY KEY (media_type, name)
+                );
+                CREATE INDEX IF NOT EXISTS idx_local_media_order
+                    ON {_TABLE} (media_type, created_at_ns, name);
+                """
+            )
+            conn.commit()
+            self._initialized_dbs.add(db_path)
+
+    def _upsert_existing_row(
+        self,
+        conn: sqlite3.Connection,
+        media_type: MediaType,
+        path: Path,
+    ) -> None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return
+        created_at_ns = self._lookup_created_at_ns(
+            conn,
+            media_type,
+            path.name,
+            fallback=int(stat.st_mtime_ns),
+        )
+        conn.execute(
+            f"""
+            INSERT INTO {_TABLE} (
+                media_type,
+                name,
+                size_bytes,
+                created_at_ns,
+                updated_at_ns
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(media_type, name) DO UPDATE SET
+                size_bytes = excluded.size_bytes,
+                updated_at_ns = excluded.updated_at_ns
+            """,
+            (
+                media_type,
+                path.name,
+                int(stat.st_size),
+                created_at_ns,
+                int(stat.st_mtime_ns),
+            ),
+        )
+
+    def _upsert_new_row(
+        self,
+        conn: sqlite3.Connection,
+        media_type: MediaType,
+        path: Path,
+    ) -> None:
+        stat = path.stat()
+        now_ns = time.time_ns()
+        conn.execute(
+            f"""
+            INSERT INTO {_TABLE} (
+                media_type,
+                name,
+                size_bytes,
+                created_at_ns,
+                updated_at_ns
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(media_type, name) DO UPDATE SET
+                size_bytes = excluded.size_bytes,
+                created_at_ns = excluded.created_at_ns,
+                updated_at_ns = excluded.updated_at_ns
+            """,
+            (
+                media_type,
+                path.name,
+                int(stat.st_size),
+                now_ns,
+                now_ns,
+            ),
+        )
+
+    def _lookup_created_at_ns(
+        self,
+        conn: sqlite3.Connection,
+        media_type: MediaType,
+        name: str,
+        *,
+        fallback: int,
+    ) -> int:
+        row = conn.execute(
+            f"""
+            SELECT created_at_ns
+            FROM {_TABLE}
+            WHERE media_type = ? AND name = ?
+            """,
+            (media_type, name),
+        ).fetchone()
+        return int(row["created_at_ns"]) if row else int(fallback)
+
+    def _usage_bytes(self, conn: sqlite3.Connection, media_type: MediaType) -> int:
+        row = conn.execute(
+            f"SELECT COALESCE(SUM(size_bytes), 0) AS total FROM {_TABLE} WHERE media_type = ?",
+            (media_type,),
+        ).fetchone()
+        return int(row["total"]) if row else 0
+
+    def _newest_name(self, conn: sqlite3.Connection, media_type: MediaType) -> str:
+        row = conn.execute(
+            f"""
+            SELECT name
+            FROM {_TABLE}
+            WHERE media_type = ?
+            ORDER BY created_at_ns DESC, name DESC
+            LIMIT 1
+            """,
+            (media_type,),
+        ).fetchone()
+        return str(row["name"]) if row else ""
+
+    def _enforce_limit_locked(
+        self,
+        conn: sqlite3.Connection,
+        media_type: MediaType,
+        *,
+        protected_names: set[str] | None = None,
+    ) -> None:
+        max_bytes = self._limit_bytes(media_type)
+        if max_bytes <= 0:
+            return
+
+        usage_bytes = self._usage_bytes(conn, media_type)
+        if usage_bytes <= max_bytes:
+            return
+
+        protected = set(protected_names or ())
+        newest_name = self._newest_name(conn, media_type)
+        if newest_name:
+            protected.add(newest_name)
+
+        target_bytes = self._target_bytes(max_bytes)
+        rows = conn.execute(
+            f"""
+            SELECT name, size_bytes
+            FROM {_TABLE}
+            WHERE media_type = ?
+            ORDER BY created_at_ns ASC, name ASC
+            """,
+            (media_type,),
+        ).fetchall()
+
+        removed = 0
+        for row in rows:
+            if usage_bytes <= target_bytes:
+                break
+
+            name = str(row["name"])
+            if name in protected:
+                continue
+
+            path = self._path_for_name(media_type, name)
+            size_bytes = int(row["size_bytes"])
+
+            if path.exists():
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning(
+                        "local media cache delete failed: media_type={} name={} error={}",
+                        media_type,
+                        name,
+                        exc,
+                    )
+                    continue
+
+            conn.execute(
+                f"DELETE FROM {_TABLE} WHERE media_type = ? AND name = ?",
+                (media_type, name),
+            )
+            usage_bytes = max(0, usage_bytes - size_bytes)
+            removed += 1
+
+        if removed:
+            logger.info(
+                "local media cache trimmed: media_type={} removed={} usage_bytes={} limit_bytes={} target_bytes={}",
+                media_type,
+                removed,
+                usage_bytes,
+                max_bytes,
+                target_bytes,
+            )
+        elif usage_bytes > max_bytes:
+            logger.info(
+                "local media cache kept newest oversized file: media_type={} usage_bytes={} limit_bytes={}",
+                media_type,
+                usage_bytes,
+                max_bytes,
+            )
+
+    def _delete_index_row_if_present(self, media_type: MediaType, name: str) -> None:
+        db_path = local_media_cache_db_path()
+        if not db_path.exists():
+            return
+        with closing(self._connect()) as conn:
+            conn.execute(
+                f"DELETE FROM {_TABLE} WHERE media_type = ? AND name = ?",
+                (media_type, name),
+            )
+            conn.commit()
+
+    def _delete_index_rows_if_present(self, media_type: MediaType) -> None:
+        db_path = local_media_cache_db_path()
+        if not db_path.exists():
+            return
+        with closing(self._connect()) as conn:
+            conn.execute(f"DELETE FROM {_TABLE} WHERE media_type = ?", (media_type,))
+            conn.commit()
+
+
+local_media_cache = LocalMediaCacheStore()
+
+
+def save_local_image(raw: bytes, mime: str, file_id: str) -> str:
+    """Persist an image to local cache and return the file ID."""
+    return local_media_cache.save_image(raw, mime, file_id)
+
+
+def save_local_video(raw: bytes, file_id: str) -> Path:
+    """Persist a video to local cache and return the file path."""
+    return local_media_cache.save_video(raw, file_id)
+
+
+def clear_local_media_files(media_type: MediaType) -> int:
+    """Delete all local media files for the requested type."""
+    return local_media_cache.clear(media_type)
+
+
+def delete_local_media_file(media_type: MediaType, name: str) -> bool:
+    """Delete one local media file by file name."""
+    return local_media_cache.delete(media_type, name)
+
+
+async def reconcile_local_media_cache_async(
+    media_type: MediaType | None = None,
+) -> None:
+    """Rebuild local media cache indexes and enforce configured limits."""
+    if media_type is None:
+        for item in ("image", "video"):
+            await asyncio.to_thread(local_media_cache.reconcile, item)
+        return
+    await asyncio.to_thread(local_media_cache.reconcile, media_type)
+
+
+__all__ = [
+    "LocalMediaCacheStore",
+    "clear_local_media_files",
+    "delete_local_media_file",
+    "local_media_cache",
+    "reconcile_local_media_cache_async",
+    "save_local_image",
+    "save_local_video",
+]

--- a/app/platform/storage/media_paths.py
+++ b/app/platform/storage/media_paths.py
@@ -9,6 +9,10 @@ def _files_dir() -> Path:
     return data_path("files")
 
 
+def _cache_dir() -> Path:
+    return data_path("cache")
+
+
 def image_files_dir() -> Path:
     """Return the local image storage directory."""
     path = _files_dir() / "images"
@@ -23,4 +27,23 @@ def video_files_dir() -> Path:
     return path
 
 
-__all__ = ["image_files_dir", "video_files_dir"]
+def local_media_cache_db_path() -> Path:
+    """Return the SQLite index path for local media cache bookkeeping."""
+    path = _cache_dir()
+    path.mkdir(parents=True, exist_ok=True)
+    return path / "local_media_cache.db"
+
+
+def local_media_lock_path(media_type: str) -> Path:
+    """Return the advisory lock file used by one media-type cache operation."""
+    path = _cache_dir() / "locks"
+    path.mkdir(parents=True, exist_ok=True)
+    return path / f"local_media_{media_type}.lock"
+
+
+__all__ = [
+    "image_files_dir",
+    "local_media_cache_db_path",
+    "local_media_lock_path",
+    "video_files_dir",
+]

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -11,12 +11,12 @@ from app.platform.logging.logger import logger
 from app.platform.config.snapshot import get_config
 from app.platform.errors import RateLimitError, UpstreamError, ValidationError
 from app.platform.runtime.clock import now_s
+from app.platform.storage import save_local_image
 from app.platform.tokens import (
     estimate_prompt_tokens,
     estimate_tokens,
     estimate_tool_call_tokens,
 )
-from app.platform.storage import image_files_dir
 from app.control.account.runtime import get_refresh_service
 from app.control.account.invalid_credentials import feedback_kind_for_error
 from app.control.model.registry import resolve as resolve_model
@@ -210,12 +210,7 @@ async def _download_image_bytes(token: str, url: str) -> tuple[bytes, str]:
 
 def _save_image(raw: bytes, mime: str, image_id: str) -> str:
     """Save raw bytes to ``${DATA_DIR}/files/images`` and return the file ID."""
-    img_dir = image_files_dir()
-    ext = ".png" if "png" in mime else ".jpg"
-    path = img_dir / f"{image_id}{ext}"
-    if not path.exists():
-        path.write_bytes(raw)
-    return image_id
+    return save_local_image(raw, mime, image_id)
 
 
 async def _resolve_image(token: str, url: str, image_id: str) -> str:
@@ -251,7 +246,7 @@ async def _resolve_image(token: str, url: str, image_id: str) -> str:
         return f"![image](data:{mime};base64,{b64})"
 
     # local_url / local_md: save to disk and return local path
-    file_id = _save_image(raw, mime, image_id)
+    file_id = await asyncio.to_thread(_save_image, raw, mime, image_id)
     app_url = cfg.get_str("app.app_url", "").rstrip("/")
     local_url = (
         f"{app_url}/v1/files/image?id={file_id}"

--- a/app/products/openai/images.py
+++ b/app/products/openai/images.py
@@ -15,7 +15,7 @@ from app.platform.logging.logger import logger
 from app.platform.config.snapshot import get_config
 from app.platform.errors import RateLimitError, UpstreamError, ValidationError
 from app.platform.runtime.clock import now_s
-from app.platform.storage import image_files_dir
+from app.platform.storage import save_local_image
 from app.control.model.registry import resolve as resolve_model
 from app.control.model.enums import ModeId
 from app.control.model.spec import ModelSpec
@@ -28,7 +28,6 @@ from app.dataplane.reverse.protocol.xai_chat import (
 )
 from app.dataplane.reverse.protocol.xai_assets import infer_content_type, resolve_asset_reference, resolve_download_url
 from app.dataplane.reverse.protocol.xai_image_edit import (
-    IMAGE_EDIT_GENERATION_COUNT,
     IMAGE_POST_MEDIA_TYPE,
     build_image_edit_payload,
     extract_model_response_file_attachments,
@@ -165,12 +164,7 @@ def _extract_image_file_id(url: str) -> str:
 
 
 def _save_image(raw: bytes, mime: str, file_id: str) -> str:
-    img_dir = image_files_dir()
-    ext = ".png" if "png" in mime else ".jpg"
-    path = img_dir / f"{file_id}{ext}"
-    if not path.exists():
-        path.write_bytes(raw)
-    return file_id
+    return save_local_image(raw, mime, file_id)
 
 
 async def _download_image_bytes(token: str, url: str) -> tuple[bytes, str]:
@@ -211,7 +205,12 @@ async def _resolve_image_output(
         data_uri = f"data:{mime};base64,{b64}"
         return _ImageOutput(api_value=b64, markdown_value=f"![image]({data_uri})")
 
-    file_id = _save_image(raw, mime, _extract_image_file_id(url))
+    file_id = await asyncio.to_thread(
+        _save_image,
+        raw,
+        mime,
+        _extract_image_file_id(url),
+    )
     local_url = _local_image_url(file_id)
     return _ImageOutput(api_value=local_url, markdown_value=f"![image]({local_url})")
 

--- a/app/products/openai/video.py
+++ b/app/products/openai/video.py
@@ -27,7 +27,7 @@ from app.platform.errors import (
 )
 from app.platform.logging.logger import logger
 from app.platform.runtime.clock import now_s
-from app.platform.storage import video_files_dir
+from app.platform.storage import save_local_video
 from app.control.account.enums import FeedbackKind
 from app.control.model import registry as model_registry
 from app.control.model.registry import resolve as resolve_model
@@ -538,11 +538,7 @@ async def _download_video_bytes(token: str, url: str) -> tuple[bytes, str]:
 
 
 def _save_video_bytes(raw: bytes, file_id: str) -> Path:
-    out_dir = video_files_dir()
-    path = out_dir / f"{file_id}.mp4"
-    if not path.exists():
-        path.write_bytes(raw)
-    return path
+    return save_local_video(raw, file_id)
 
 
 def _local_video_url(file_id: str) -> str:
@@ -580,7 +576,7 @@ async def _resolve_video_output(*, token: str, url: str, file_id: str) -> str:
 
     try:
         raw, _mime = await _download_video_bytes(token, url)
-        _save_video_bytes(raw, file_id)
+        await asyncio.to_thread(_save_video_bytes, raw, file_id)
     except Exception as exc:
         logger.warning("video download failed: fallback_to=upstream_url error={}", exc)
         return url if fmt == "local_url" else _render_video_html(url)

--- a/app/products/web/admin/__init__.py
+++ b/app/products/web/admin/__init__.py
@@ -17,6 +17,7 @@ from app.platform.auth.middleware import verify_admin_key
 from app.platform.config.snapshot import config
 from app.platform.errors import AppError, ErrorKind, ValidationError
 from app.platform.logging.logger import logger, reload_file_logging
+from app.platform.storage import reconcile_local_media_cache_async
 
 if TYPE_CHECKING:
     from app.control.account.refresh import AccountRefreshService
@@ -135,6 +136,13 @@ def _ensure_runtime_patch_allowed(payload: dict[str, Any]) -> None:
                 )
 
 
+def _patch_touches_prefix(payload: dict[str, Any], prefix: str) -> bool:
+    return any(
+        path == prefix or path.startswith(f"{prefix}.")
+        for path in _iter_patch_paths(payload)
+    )
+
+
 def get_repo(request: Request) -> "AccountRepository":
     """Resolve the singleton AccountRepository from app state."""
     return request.app.state.repository
@@ -188,6 +196,7 @@ async def update_config(req: ConfigPatchRequest):
 
     patch = _sanitize_proxy_config(req.root)
     _ensure_runtime_patch_allowed(patch)
+    cache_local_changed = _patch_touches_prefix(patch, "cache.local")
     await config.update(patch)
     # config.update() only writes to the backend and invalidates the in-memory
     # snapshot (_version = None); it does not refresh the data.  load() is
@@ -197,6 +206,8 @@ async def update_config(req: ConfigPatchRequest):
         file_level=config.get_str("logging.file_level", "") or None,
         max_files=config.get_int("logging.max_files", 7),
     )
+    if cache_local_changed:
+        await reconcile_local_media_cache_async()
     strategy_name = reconcile_refresh_runtime()
     return {
         "status": "success",

--- a/app/products/web/admin/cache.py
+++ b/app/products/web/admin/cache.py
@@ -1,13 +1,20 @@
 """Local media cache management — stats, list, clear, delete."""
 
+import asyncio
 from pathlib import Path
 from typing import Any, Literal
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel
 
+from app.platform.config.snapshot import get_config
 from app.platform.errors import AppError, ErrorKind
-from app.platform.storage import image_files_dir, video_files_dir
+from app.platform.storage import (
+    clear_local_media_files,
+    delete_local_media_file,
+    image_files_dir,
+    video_files_dir,
+)
 
 router = APIRouter(prefix="/cache", tags=["Admin - Cache"])
 
@@ -40,14 +47,33 @@ def _exts(media_type: str):
     return _IMAGE_EXTS if media_type == "image" else _VIDEO_EXTS
 
 
+def _limit_mb(media_type: str) -> int:
+    cfg = get_config()
+    return max(0, int(cfg.get_int(f"cache.local.{media_type}_max_mb", 0)))
+
+
 def _stats(media_type: str) -> dict[str, Any]:
     d = _dir(media_type)
-    if not d.exists():
-        return {"count": 0, "size_mb": 0.0}
-    allowed = _exts(media_type)
-    files = [f for f in d.glob("*") if f.is_file() and f.suffix.lower() in allowed]
+    files = []
+    if d.exists():
+        allowed = _exts(media_type)
+        files = [f for f in d.glob("*") if f.is_file() and f.suffix.lower() in allowed]
+
     total_size = sum(f.stat().st_size for f in files)
-    return {"count": len(files), "size_mb": round(total_size / 1024 / 1024, 2)}
+    limit_mb = _limit_mb(media_type)
+    limit_bytes = limit_mb * 1024 * 1024
+    usage_ratio = (total_size / limit_bytes) if limit_bytes > 0 else None
+    usage_percent = round(usage_ratio * 100, 1) if usage_ratio is not None else None
+    return {
+        "count": len(files),
+        "size_mb": round(total_size / 1024 / 1024, 2),
+        "size_bytes": total_size,
+        "limit_mb": limit_mb,
+        "limit_bytes": limit_bytes,
+        "limited": limit_bytes > 0,
+        "usage_ratio": round(usage_ratio, 4) if usage_ratio is not None else None,
+        "usage_percent": usage_percent,
+    }
 
 
 def _list_files(media_type: str, page: int, page_size: int) -> dict[str, Any]:
@@ -99,13 +125,7 @@ async def list_local(
 
 @router.post("/clear")
 async def clear_local(req: ClearCacheRequest):
-    d = _dir(req.type)
-    allowed = _exts(req.type)
-    removed = 0
-    for f in d.glob("*"):
-        if f.is_file() and f.suffix.lower() in allowed:
-            f.unlink(missing_ok=True)
-            removed += 1
+    removed = await asyncio.to_thread(clear_local_media_files, req.type)
     return {"status": "success", "result": {"removed": removed}}
 
 
@@ -118,15 +138,22 @@ async def delete_local_item(req: DeleteCacheItemRequest):
             code="missing_file_name",
             status=400,
         )
-    target = _dir(req.type) / req.name
-    if not target.is_file():
+    try:
+        deleted = await asyncio.to_thread(delete_local_media_file, req.type, req.name)
+    except ValueError as exc:
+        raise AppError(
+            str(exc),
+            kind=ErrorKind.VALIDATION,
+            code="invalid_file_name",
+            status=400,
+        ) from exc
+    if not deleted:
         raise AppError(
             "File not found",
             kind=ErrorKind.VALIDATION,
             code="file_not_found",
             status=404,
         )
-    target.unlink(missing_ok=True)
     return {"status": "success", "result": {"deleted": req.name}}
 
 
@@ -141,14 +168,16 @@ async def delete_local_items(req: DeleteCacheItemsRequest):
             status=400,
         )
 
-    cache_dir = _dir(req.type)
     deleted = 0
     missing = 0
 
     for name in names:
-        target = cache_dir / name
-        if target.is_file():
-            target.unlink(missing_ok=True)
+        try:
+            removed = await asyncio.to_thread(delete_local_media_file, req.type, name)
+        except ValueError:
+            missing += 1
+            continue
+        if removed:
             deleted += 1
         else:
             missing += 1

--- a/app/statics/admin/cache.html
+++ b/app/statics/admin/cache.html
@@ -40,12 +40,37 @@
 
     /* Stats */
     .stat-grid { display:grid; grid-template-columns:repeat(4, minmax(0, 1fr)); gap:12px; margin-bottom:30px }
-    .stat-cell { min-height:88px; padding:14px 16px; border-radius:12px; background:#fff; display:flex; flex-direction:column; gap:12px }
+    .stat-cell { min-height:96px; padding:14px 16px; border-radius:12px; background:#fff; display:flex; flex-direction:column; gap:12px }
     .stat-top  { display:flex; align-items:center; justify-content:space-between; gap:10px }
     .stat-label{ font-size:11px; color:#8a8a8a; letter-spacing:.01em; white-space:nowrap }
     .stat-icon { width:22px; height:22px; display:inline-flex; align-items:center; justify-content:center; color:#a3a3a3; flex:0 0 auto }
     .stat-icon svg { width:14px; height:14px; stroke:currentColor }
     .stat-num  { font-size:22px; font-weight:600; line-height:1; letter-spacing:-.02em; margin-top:auto }
+    .stat-sub {
+      margin-top:-4px;
+      font-size:11px;
+      color:#8a8a8a;
+      font-variant-numeric:tabular-nums;
+      min-height:14px;
+    }
+    .stat-progress {
+      height:5px;
+      margin-top:-2px;
+      border-radius:999px;
+      background:#efefef;
+      overflow:hidden;
+    }
+    .stat-progress-fill {
+      display:block;
+      height:100%;
+      width:0;
+      border-radius:999px;
+      background:#d1d5db;
+      transition:width .2s ease, background-color .2s ease;
+    }
+    .stat-progress-fill.image { background:#2563eb }
+    .stat-progress-fill.video { background:#7c3aed }
+    .stat-progress-fill.over { background:#dc2626 }
 
     /* Section tabs */
     .sec-tabs {
@@ -262,7 +287,7 @@
   <div class="page-hd">
     <div>
       <div class="page-title" data-i18n="cache.pageHeading">缓存管理</div>
-      <div class="page-sub" data-i18n="cache.pageSubtitle">统一查看本地缓存文件与账户在线资产，并支持按类型清理。</div>
+      <div class="page-sub" data-i18n="cache.pageSubtitle">统一查看本地缓存文件、容量上限与账户在线资产。</div>
     </div>
   </div>
 
@@ -283,15 +308,6 @@
     </div>
     <div class="stat-cell">
       <div class="stat-top">
-        <div class="stat-label" data-i18n="cache.statImageSize">图片缓存大小</div>
-        <span class="stat-icon" style="color:#2563eb">
-          <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-        </span>
-      </div>
-      <div class="stat-num" id="s-img-size" style="color:#2563eb">—</div>
-    </div>
-    <div class="stat-cell">
-      <div class="stat-top">
         <div class="stat-label" data-i18n="cache.statVideoCount">视频缓存数量</div>
         <span class="stat-icon" style="color:#7c3aed">
           <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2"/></svg>
@@ -301,12 +317,29 @@
     </div>
     <div class="stat-cell">
       <div class="stat-top">
+        <div class="stat-label" data-i18n="cache.statImageSize">图片缓存大小</div>
+        <span class="stat-icon" style="color:#2563eb">
+          <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+        </span>
+      </div>
+      <div class="stat-num" id="s-img-size" style="color:#2563eb">—</div>
+      <div class="stat-sub" id="s-img-usage">—</div>
+      <div class="stat-progress" aria-hidden="true">
+        <span class="stat-progress-fill image" id="s-img-progress"></span>
+      </div>
+    </div>
+    <div class="stat-cell">
+      <div class="stat-top">
         <div class="stat-label" data-i18n="cache.statVideoSize">视频缓存大小</div>
         <span class="stat-icon" style="color:#7c3aed">
           <svg viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
         </span>
       </div>
       <div class="stat-num" id="s-vid-size" style="color:#7c3aed">—</div>
+      <div class="stat-sub" id="s-vid-usage">—</div>
+      <div class="stat-progress" aria-hidden="true">
+        <span class="stat-progress-fill video" id="s-vid-progress"></span>
+      </div>
     </div>
   </div>
 
@@ -460,6 +493,38 @@ function getTypeNoun(type = _type) {
 function loadSavedPageSize() {
   const raw = Number(localStorage.getItem(PAGE_SIZE_KEY));
   return PAGE_SIZE_OPTIONS.includes(raw) ? raw : 100;
+}
+
+function _fmtRatio(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return tr('cache.na', null, '—');
+  return `${num.toFixed(1)}%`;
+}
+
+function _usageSummary(stats) {
+  const used = _fmtBytes(stats.size_bytes ?? 0);
+  if (!stats?.limited || !stats?.limit_bytes) {
+    return tr('cache.usageSummaryUnlimited', { used }, `${used} · 未限制`);
+  }
+  const limit = _fmtBytes(stats.limit_bytes);
+  const percent = _fmtRatio(stats.usage_percent);
+  return tr(
+    'cache.usageSummaryLimited',
+    { used, limit, percent },
+    `${used} / ${limit} · ${percent}`
+  );
+}
+
+function _applyUsageBar(id, type, stats) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const limited = !!stats?.limited && Number(stats.limit_bytes) > 0;
+  const percent = limited ? Number(stats.usage_percent ?? 0) : 0;
+  const safe = Number.isFinite(percent) ? percent : 0;
+  el.style.width = `${Math.max(0, Math.min(safe, 100))}%`;
+  el.classList.toggle('over', limited && safe > 100);
+  el.classList.toggle('image', type === 'image');
+  el.classList.toggle('video', type === 'video');
 }
 
 function invalidateLocalView() {
@@ -625,8 +690,12 @@ async function loadStats() {
     const vid = d.local_video || {};
     document.getElementById('s-img-count').textContent = img.count ?? 0;
     document.getElementById('s-img-size').textContent = _fmtMb(img.size_mb);
+    document.getElementById('s-img-usage').textContent = _usageSummary(img);
+    _applyUsageBar('s-img-progress', 'image', img);
     document.getElementById('s-vid-count').textContent = vid.count ?? 0;
     document.getElementById('s-vid-size').textContent = _fmtMb(vid.size_mb);
+    document.getElementById('s-vid-usage').textContent = _usageSummary(vid);
+    _applyUsageBar('s-vid-progress', 'video', vid);
   } catch (e) {
     console.warn('stats error', e);
   }

--- a/app/statics/admin/config.html
+++ b/app/statics/admin/config.html
@@ -695,6 +695,33 @@ const SCHEMA_DEF = [
       },
     ]
   },
+  {
+    id: 'cache', label: '缓存存储', labelKey: 'config.schema.tabs.cache',
+    groups: [
+      {
+        title: '本地媒体缓存', titleKey: 'config.schema.groups.localMediaCache',
+        section: 'cache.local',
+        fields: [
+          {
+            key: 'image_max_mb',
+            label: '图片缓存上限（MB）',
+            labelKey: 'config.schema.fields.imageCacheMaxMb.label',
+            type: 'number',
+            desc: '0 表示不限制。仅对本地代理落盘生效；超限后按最旧文件优先清理，并一次性回落到上限的 60%。',
+            descKey: 'config.schema.fields.imageCacheMaxMb.desc',
+          },
+          {
+            key: 'video_max_mb',
+            label: '视频缓存上限（MB）',
+            labelKey: 'config.schema.fields.videoCacheMaxMb.label',
+            type: 'number',
+            desc: '0 表示不限制。仅对本地代理落盘生效；超限后按最旧文件优先清理，并一次性回落到上限的 60%。',
+            descKey: 'config.schema.fields.videoCacheMaxMb.desc',
+          },
+        ]
+      },
+    ]
+  },
 ];
 
 // ── State ──────────────────────────────────────────────────────────────────

--- a/app/statics/i18n/de.json
+++ b/app/statics/i18n/de.json
@@ -324,6 +324,7 @@
         "features": "Funktionen",
         "schedule": "Zeitplanung",
         "proxy": "Netzwerk",
+        "cache": "Cache-Speicher",
         "image": "Bildpipeline"
       },
       "groups": {
@@ -338,7 +339,8 @@
         "retry": "Wiederholungsrichtlinie",
         "timeouts": "Zeitlimits",
         "imageProtocol": "NSFW und Bild-Streaming",
-        "logging": "Protokollierung"
+        "logging": "Protokollierung",
+        "localMediaCache": "Lokaler Medien-Cache"
       },
       "options": {
         "imageFormat": {
@@ -390,6 +392,8 @@
         "heavyInterval": { "label": "Heavy-Zyklus (s)", "desc": "Gemeinsamer Zyklus für den Heavy-Pool: wird im Quota-Modus für den Hintergrund-Refresh und im Random-Modus für die 429-Abkühlung verwendet. Standardwert: 7200s." },
         "usageConcurrency": { "label": "Aktualisierungs-Konkurrenz", "desc": "Maximale Anzahl paralleler usage-Aufrufe während der Quotenaktualisierung." },
         "onDemandMinInterval": { "label": "On-Demand-Aktualisierungsintervall (s)", "desc": "Drosselungsfenster für durch Requests ausgelöste Aktualisierungen, z. B. nach 429. Wiederholte Auslöser innerhalb des Intervalls werden zu einer Aktualisierung zusammengefasst." },
+        "imageCacheMaxMb": { "label": "Bild-Cache-Limit (MB)", "desc": "0 deaktiviert das Limit. Gilt nur für lokal per Proxy gespeicherte Mediendateien. Wird das Limit überschritten, werden zuerst die ältesten Dateien entfernt, bis die Nutzung wieder auf 60% des Limits fällt." },
+        "videoCacheMaxMb": { "label": "Video-Cache-Limit (MB)", "desc": "0 deaktiviert das Limit. Gilt nur für lokal per Proxy gespeicherte Mediendateien. Wird das Limit überschritten, werden zuerst die ältesten Dateien entfernt, bis die Nutzung wieder auf 60% des Limits fällt." },
         "nsfwConcurrency": { "label": "Konkurrenz für NSFW-Aktivierung" },
         "refreshConcurrency": { "label": "Usage-Aktualisierungskonkurrenz" },
         "assetUploadConcurrency": { "label": "Asset-Upload-Konkurrenz" },
@@ -430,12 +434,14 @@
   "cache": {
     "pageTitle": "Grok2API - Cache-Verwaltung",
     "pageHeading": "Cache-Verwaltung",
-    "pageSubtitle": "Lokale Cache-Dateien und Online-Assets der Konten anzeigen und verwalten.",
+    "pageSubtitle": "Lokale Cache-Dateien, Speichergrenzen und Online-Assets der Konten anzeigen und verwalten.",
     "sectionOverview": "Übersicht",
     "statImageCount": "Bild-Cache-Dateien",
     "statImageSize": "Bild-Cache-Größe",
     "statVideoCount": "Video-Cache-Dateien",
     "statVideoSize": "Video-Cache-Größe",
+    "usageSummaryUnlimited": "Verwendet {used} · Unbegrenzt",
+    "usageSummaryLimited": "Verwendet {used} / {limit} · {percent}",
     "sectionDetails": "Details",
     "tabLocal": "Lokaler Cache",
     "tabLocalImage": "Lokale Bilder",

--- a/app/statics/i18n/en.json
+++ b/app/statics/i18n/en.json
@@ -325,6 +325,7 @@
         "features": "Features",
         "schedule": "Scheduling",
         "proxy": "Networking",
+        "cache": "Cache Storage",
         "image": "Image Pipeline"
       },
       "groups": {
@@ -339,7 +340,8 @@
         "retry": "Retry Policy",
         "timeouts": "Request Timeouts",
         "imageProtocol": "NSFW and Image Streaming",
-        "logging": "Logging"
+        "logging": "Logging",
+        "localMediaCache": "Local Media Cache"
       },
       "options": {
         "imageFormat": {
@@ -463,6 +465,14 @@
         "onDemandMinInterval": {
           "label": "On-Demand Refresh Interval (s)",
           "desc": "Throttle window for request-triggered refreshes such as 429 handling. Repeated triggers within the interval are coalesced into a single refresh."
+        },
+        "imageCacheMaxMb": {
+          "label": "Image Cache Limit (MB)",
+          "desc": "0 disables the limit. Applies only to locally proxied media files. When the limit is exceeded, the oldest files are removed until usage falls back to 60% of the limit."
+        },
+        "videoCacheMaxMb": {
+          "label": "Video Cache Limit (MB)",
+          "desc": "0 disables the limit. Applies only to locally proxied media files. When the limit is exceeded, the oldest files are removed until usage falls back to 60% of the limit."
         },
         "nsfwConcurrency": {
           "label": "NSFW Enablement Concurrency",
@@ -606,12 +616,14 @@
   "cache": {
     "pageTitle": "Grok2API - Cache Management",
     "pageHeading": "Cache Management",
-    "pageSubtitle": "View and manage local cache files and online account assets.",
+    "pageSubtitle": "View and manage local cache files, storage limits, and online account assets.",
     "sectionOverview": "Overview",
     "statImageCount": "Image Cache Files",
     "statImageSize": "Image Cache Size",
     "statVideoCount": "Video Cache Files",
     "statVideoSize": "Video Cache Size",
+    "usageSummaryUnlimited": "Used {used} · Unlimited",
+    "usageSummaryLimited": "Used {used} / {limit} · {percent}",
     "sectionDetails": "Details",
     "tabLocal": "Local Cache",
     "tabLocalImage": "Local Images",

--- a/app/statics/i18n/es.json
+++ b/app/statics/i18n/es.json
@@ -324,6 +324,7 @@
         "features": "Funciones",
         "schedule": "Programación",
         "proxy": "Red",
+        "cache": "Almacenamiento de caché",
         "image": "Canal de imagen"
       },
       "groups": {
@@ -338,7 +339,8 @@
         "retry": "Política de reintentos",
         "timeouts": "Tiempos de espera",
         "imageProtocol": "NSFW y transmisión de imágenes",
-        "logging": "Registro"
+        "logging": "Registro",
+        "localMediaCache": "Caché multimedia local"
       },
       "options": {
         "imageFormat": {
@@ -390,6 +392,8 @@
         "heavyInterval": { "label": "Ciclo Heavy (s)", "desc": "Ciclo compartido del pool Heavy: se usa para la actualización en segundo plano en modo quota y para el enfriamiento tras 429 en modo random. Valor por defecto: 7200s." },
         "usageConcurrency": { "label": "Concurrencia de actualización", "desc": "Número máximo de llamadas usage paralelas permitidas durante la actualización de cuota." },
         "onDemandMinInterval": { "label": "Intervalo de actualización bajo demanda (s)", "desc": "Ventana de limitación para actualizaciones activadas por solicitudes, como el manejo de 429. Los disparos repetidos dentro del intervalo se agrupan en una sola actualización." },
+        "imageCacheMaxMb": { "label": "Límite de caché de imágenes (MB)", "desc": "0 desactiva el límite. Solo se aplica a los archivos multimedia guardados por el proxy local. Cuando se supera el límite, se eliminan primero los archivos más antiguos hasta volver al 60% del límite." },
+        "videoCacheMaxMb": { "label": "Límite de caché de video (MB)", "desc": "0 desactiva el límite. Solo se aplica a los archivos multimedia guardados por el proxy local. Cuando se supera el límite, se eliminan primero los archivos más antiguos hasta volver al 60% del límite." },
         "nsfwConcurrency": { "label": "Concurrencia de activación NSFW" },
         "refreshConcurrency": { "label": "Concurrencia de refresco de Usage" },
         "assetUploadConcurrency": { "label": "Concurrencia de carga de Asset" },
@@ -430,12 +434,14 @@
   "cache": {
     "pageTitle": "Grok2API - Gestión de Caché",
     "pageHeading": "Gestión de Caché",
-    "pageSubtitle": "Vea y gestione los archivos de caché local y los activos en línea de las cuentas.",
+    "pageSubtitle": "Vea y gestione los archivos de caché local, los límites de almacenamiento y los activos en línea de las cuentas.",
     "sectionOverview": "Resumen",
     "statImageCount": "Archivos de caché de imagen",
     "statImageSize": "Tamaño de caché de imagen",
     "statVideoCount": "Archivos de caché de video",
     "statVideoSize": "Tamaño de caché de video",
+    "usageSummaryUnlimited": "Usado {used} · Sin límite",
+    "usageSummaryLimited": "Usado {used} / {limit} · {percent}",
     "sectionDetails": "Detalles",
     "tabLocal": "Caché local",
     "tabLocalImage": "Imágenes locales",

--- a/app/statics/i18n/fr.json
+++ b/app/statics/i18n/fr.json
@@ -324,6 +324,7 @@
         "features": "Fonctionnalités",
         "schedule": "Planification",
         "proxy": "Réseau",
+        "cache": "Stockage du cache",
         "image": "Pipeline d’image"
       },
       "groups": {
@@ -338,7 +339,8 @@
         "retry": "Politique de reprise",
         "timeouts": "Délais d’attente",
         "imageProtocol": "NSFW et streaming d'images",
-        "logging": "Journalisation"
+        "logging": "Journalisation",
+        "localMediaCache": "Cache multimédia local"
       },
       "options": {
         "imageFormat": {
@@ -390,6 +392,8 @@
         "heavyInterval": { "label": "Cycle Heavy (s)", "desc": "Cycle partagé du pool Heavy : utilisé pour l’actualisation en arrière-plan en mode quota et pour le refroidissement après 429 en mode random. Valeur par défaut : 7200s." },
         "usageConcurrency": { "label": "Concurrence d’actualisation", "desc": "Nombre maximal d’appels usage parallèles autorisés pendant l’actualisation du quota." },
         "onDemandMinInterval": { "label": "Intervalle d’actualisation à la demande (s)", "desc": "Fenêtre de limitation pour les actualisations déclenchées par les requêtes, par exemple après un 429. Les déclenchements répétés dans l’intervalle sont regroupés en une seule actualisation." },
+        "imageCacheMaxMb": { "label": "Limite du cache image (MB)", "desc": "0 désactive la limite. S’applique uniquement aux fichiers multimédias enregistrés via le proxy local. Lorsque la limite est dépassée, les fichiers les plus anciens sont supprimés jusqu’à revenir à 60% de la limite." },
+        "videoCacheMaxMb": { "label": "Limite du cache vidéo (MB)", "desc": "0 désactive la limite. S’applique uniquement aux fichiers multimédias enregistrés via le proxy local. Lorsque la limite est dépassée, les fichiers les plus anciens sont supprimés jusqu’à revenir à 60% de la limite." },
         "nsfwConcurrency": { "label": "Concurrence d’activation NSFW" },
         "refreshConcurrency": { "label": "Concurrence d’actualisation Usage" },
         "assetUploadConcurrency": { "label": "Concurrence d’envoi Asset" },
@@ -430,12 +434,14 @@
   "cache": {
     "pageTitle": "Grok2API - Gestion du Cache",
     "pageHeading": "Gestion du Cache",
-    "pageSubtitle": "Consultez et gérez les fichiers de cache locaux et les actifs en ligne des comptes.",
+    "pageSubtitle": "Consultez et gérez les fichiers de cache locaux, les limites de stockage et les actifs en ligne des comptes.",
     "sectionOverview": "Vue d’ensemble",
     "statImageCount": "Fichiers de cache image",
     "statImageSize": "Taille du cache image",
     "statVideoCount": "Fichiers de cache vidéo",
     "statVideoSize": "Taille du cache vidéo",
+    "usageSummaryUnlimited": "Utilisé {used} · Illimité",
+    "usageSummaryLimited": "Utilisé {used} / {limit} · {percent}",
     "sectionDetails": "Détails",
     "tabLocal": "Cache local",
     "tabLocalImage": "Images locales",

--- a/app/statics/i18n/ja.json
+++ b/app/statics/i18n/ja.json
@@ -324,6 +324,7 @@
         "features": "機能",
         "schedule": "スケジュール",
         "proxy": "ネットワーク",
+        "cache": "キャッシュ保存",
         "image": "画像処理"
       },
       "groups": {
@@ -338,7 +339,8 @@
         "retry": "再試行ポリシー",
         "timeouts": "リクエストタイムアウト",
         "imageProtocol": "NSFW と画像ストリーミング",
-        "logging": "ログ設定"
+        "logging": "ログ設定",
+        "localMediaCache": "ローカルメディアキャッシュ"
       },
       "options": {
         "imageFormat": {
@@ -390,6 +392,8 @@
         "heavyInterval": { "label": "Heavy 周期（秒）", "desc": "Heavy プールの共通周期です。quota モードではバックグラウンド更新に、random モードでは 429 クールダウンに使われます。既定値は 7200s です。" },
         "usageConcurrency": { "label": "更新並列数", "desc": "クォータ更新中に許可する usage 呼び出しの最大並列数です。" },
         "onDemandMinInterval": { "label": "オンデマンド更新間隔（秒）", "desc": "429 処理など、リクエスト経路から発生する更新のスロットル間隔です。この間隔内の重複トリガーは 1 回の更新にまとめられます。" },
+        "imageCacheMaxMb": { "label": "画像キャッシュ上限（MB）", "desc": "0 は無制限です。ローカルプロキシで保存されたメディアにのみ適用され、上限を超えると最も古いファイルから削除し、使用量を上限の 60% まで一気に戻します。" },
+        "videoCacheMaxMb": { "label": "動画キャッシュ上限（MB）", "desc": "0 は無制限です。ローカルプロキシで保存されたメディアにのみ適用され、上限を超えると最も古いファイルから削除し、使用量を上限の 60% まで一気に戻します。" },
         "nsfwConcurrency": { "label": "NSFW 有効化の並列数" },
         "refreshConcurrency": { "label": "Usage 更新の並列数" },
         "assetUploadConcurrency": { "label": "Asset アップロード並列数" },
@@ -430,12 +434,14 @@
   "cache": {
     "pageTitle": "Grok2API - キャッシュ管理",
     "pageHeading": "キャッシュ管理",
-    "pageSubtitle": "ローカルキャッシュファイルとオンラインアセットを確認・管理します。",
+    "pageSubtitle": "ローカルキャッシュファイル、容量上限、オンラインアセットを確認・管理します。",
     "sectionOverview": "概要",
     "statImageCount": "画像キャッシュ数",
     "statImageSize": "画像キャッシュ容量",
     "statVideoCount": "動画キャッシュ数",
     "statVideoSize": "動画キャッシュ容量",
+    "usageSummaryUnlimited": "使用量 {used} · 無制限",
+    "usageSummaryLimited": "使用量 {used} / {limit} · {percent}",
     "sectionDetails": "詳細",
     "tabLocal": "ローカルキャッシュ",
     "tabLocalImage": "ローカル画像",

--- a/app/statics/i18n/zh.json
+++ b/app/statics/i18n/zh.json
@@ -325,6 +325,7 @@
         "features": "应用功能",
         "schedule": "任务调度",
         "proxy": "网络代理",
+        "cache": "缓存存储",
         "image": "图像能力"
       },
       "groups": {
@@ -339,7 +340,8 @@
         "retry": "重试策略",
         "timeouts": "请求超时设置",
         "imageProtocol": "NSFW 与图像协议",
-        "logging": "日志配置"
+        "logging": "日志配置",
+        "localMediaCache": "本地媒体缓存"
       },
       "options": {
         "imageFormat": {
@@ -463,6 +465,14 @@
         "onDemandMinInterval": {
           "label": "按需刷新间隔（秒）",
           "desc": "请求链路触发刷新（例如收到 429）时的节流间隔。N 秒内重复触发只执行一次，避免批量打爆配额接口。"
+        },
+        "imageCacheMaxMb": {
+          "label": "图片缓存上限（MB）",
+          "desc": "0 表示不限制。仅对本地代理落盘生效；超限后按最旧文件优先清理，并一次性回落到上限的 60%。"
+        },
+        "videoCacheMaxMb": {
+          "label": "视频缓存上限（MB）",
+          "desc": "0 表示不限制。仅对本地代理落盘生效；超限后按最旧文件优先清理，并一次性回落到上限的 60%。"
         },
         "nsfwConcurrency": {
           "label": "开启 NSFW 并发数",
@@ -606,12 +616,14 @@
   "cache": {
     "pageTitle": "Grok2API - 缓存管理",
     "pageHeading": "缓存管理",
-    "pageSubtitle": "查看并管理本地缓存文件与账户在线资产。",
+    "pageSubtitle": "查看并管理本地缓存文件、容量上限与账户在线资产。",
     "sectionOverview": "缓存概览",
     "statImageCount": "图片缓存数量",
     "statImageSize": "图片缓存大小",
     "statVideoCount": "视频缓存数量",
     "statVideoSize": "视频缓存大小",
+    "usageSummaryUnlimited": "已用 {used} · 未限制",
+    "usageSummaryLimited": "已用 {used} / {limit} · {percent}",
     "sectionDetails": "缓存明细",
     "tabLocal": "本地缓存",
     "tabLocalImage": "本地图片",

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -60,6 +60,14 @@ image_format = "grok_url"
 video_format = "grok_url"
 
 
+# ==================== 本地缓存 ====================
+[cache.local]
+# 图片缓存上限（MB），0 = 不限制；超限后按最旧文件优先清理，并回落到上限的 60%
+image_max_mb = 0
+# 视频缓存上限（MB），0 = 不限制；超限后按最旧文件优先清理，并回落到上限的 60%
+video_max_mb = 0
+
+
 # ==================== 代理配置 ====================
 [proxy.egress]
 # 出口模式：direct | single_proxy | proxy_pool

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -175,7 +175,7 @@ docker compose up -d
 | `SERVER_PORT` | Service port | `8000` |
 | `SERVER_WORKERS` | Granian worker count | `1` |
 | `HOST_PORT` | Docker Compose published host port | `8000` |
-| `DATA_DIR` | Local data directory | `./data` |
+| `DATA_DIR` | Local data root for accounts, locally cached media files, and cache indexes | `./data` |
 | `LOG_DIR` | Local log directory | `./logs` |
 | `ACCOUNT_STORAGE` | Account storage backend | `local` |
 | `ACCOUNT_LOCAL_PATH` | SQLite path for `local` account storage | `${DATA_DIR}/accounts.db` |
@@ -201,6 +201,7 @@ Runtime config can also be overridden with `GROK_`-prefixed environment variable
 | `proxy.clearance` | `mode`, `cf_cookies`, `user_agent`, `browser`, `flaresolverr_url`, `timeout_sec`, `refresh_interval` |
 | `retry` | `reset_session_status_codes`, `max_retries`, `on_codes` |
 | `account.refresh` | `basic_interval_sec`, `super_interval_sec`, `heavy_interval_sec`, `usage_concurrency`, `on_demand_min_interval_sec` |
+| `cache.local` | `image_max_mb`, `video_max_mb` |
 | `chat` | `timeout` |
 | `image` | `timeout`, `stream_timeout` |
 | `video` | `timeout` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grok2api"
-version = "2.0.4.rc2"
+version = "2.0.4.rc3"
 description = "Grok2API rebuilt with FastAPI, fully aligned with the latest web call format. Supports streaming and non-streaming chat, image generation/editing, deep thinking, token pool concurrency, and automatic load balancing."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -580,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "grok2api"
-version = "2.0.4rc2"
+version = "2.0.4rc3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- 新增本地媒体缓存容量治理能力：
  - 为图片/视频分别增加 `cache.local.image_max_mb` 和 `cache.local.video_max_mb`
  - 本地代理落盘时按媒体类型独立治理缓存
  - 超限后按最旧文件优先清理，并一次性回落到上限的 60%
  - 保留最新文件，单文件超限时不误删最新产物
- 新增本地缓存索引与并发保护：
  - 使用本地 SQLite 维护缓存索引，避免每次写入全量扫描目录
  - 增加原子写入和跨进程锁，保证多 worker 下缓存写入/清理一致性
  - 启动时自动 reconcile 历史缓存，配置热更新后自动重算并执行治理
- 打通后台配置与展示：
  - 配置页新增“缓存存储”tab，支持设置图片/视频缓存上限
  - 缓存管理页新增容量上限、当前已用、使用率展示
  - 按要求调整概览卡片顺序为：图片缓存数量、视频缓存数量、图片缓存大小、视频缓存大小
- 统一路径与文档：
  - 明确本地媒体文件、缓存索引、锁文件统一由 `DATA_DIR` 派生
  - README / docs 补充 `cache.local` 配置说明
- 补齐多语言文案：
  - 同步更新 `zh / en / ja / es / de / fr` 6 份 i18n，避免新增 key 只落部分语言

## Testing

- `uv run ruff check app/platform/storage/media_cache.py app/platform/storage/media_paths.py app/platform/storage/__init__.py app/products/openai/images.py app/products/openai/chat.py app/products/openai/video.py app/products/web/admin/cache.py app/products/web/admin/__init__.py app/main.py tests/test_local_media_cache.py`
- `uv run python -m compileall app/platform/storage/media_cache.py app/platform/storage/media_paths.py app/platform/storage/__init__.py app/products/openai/images.py app/products/openai/chat.py app/products/openai/video.py app/products/web/admin/cache.py app/products/web/admin/__init__.py app/main.py tests/test_local_media_cache.py`
- `uv run python -m unittest tests.test_local_media_cache`
- `uv run python -c "import json, pathlib, tomllib; json.loads(pathlib.Path('app/statics/i18n/zh.json').read_text()); json.loads(pathlib.Path('app/statics/i18n/en.json').read_text()); json.loads(pathlib.Path('app/statics/i18n/ja.json').read_text()); json.loads(pathlib.Path('app/statics/i18n/es.json').read_text()); json.loads(pathlib.Path('app/statics/i18n/de.json').read_text()); json.loads(pathlib.Path('app/statics/i18n/fr.json').read_text()); tomllib.loads(pathlib.Path('config.defaults.toml').read_text()); print('ok')"`
- `.venv/bin/python` 下执行了缓存页/缓存统计轻量 smoke，确认：
  - `/admin/api/cache` 返回 `limit_mb / limit_bytes / usage_ratio / usage_percent / limited`
  - 缓存页模板包含新的 usage/progress 展示元素

## Related

- N/A
