### PR TITLE
fix: 移除 PR #473 夹带的未审查代码（3 项已确认缺陷）

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,6 @@ curl http://localhost:8000/v1/chat/completions \
     "model": "grok-4.20-auto",
     "stream": true,
     "reasoning_effort": "high",
-    "deepsearch": "default",
     "messages": [
       {"role":"user","content":"你好"}
     ]
@@ -382,7 +381,6 @@ curl http://localhost:8000/v1/chat/completions \
 | `messages` | 支持文本与多模态内容块 |
 | `stream` | 是否流式输出；不传时使用 `features.stream` 默认值 |
 | `reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`；`none` 会关闭思考输出 |
-| `deepsearch` | 深度搜索预设：`default`, `deeper` |
 | `temperature` / `top_p` | 采样参数，默认 `0.8` / `0.95` |
 | `tools` | OpenAI function tools 结构 |
 | `tool_choice` | `auto`, `required` 或指定函数工具 |

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -269,8 +269,6 @@ def _normalize_image_format(value: str | None) -> str:
     return fmt
 
 
-_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>")
-_INLINE_BASE64_IMG_RE = re.compile(r"!\[image\]\(data:[^)]*?base64,[^)]*?\)")
 # 精确匹配 grok2api 注入的 Sources 段落（含标记行），用于多轮对话剥离
 _SOURCES_STRIP_RE = re.compile(
     r"(?:^|\r?\n\r?\n)## Sources\r?\n\[grok2api-sources\]: #\r?\n[\s\S]*$"
@@ -283,8 +281,7 @@ def _strip_generated_artifacts(text: str, *, strip_sources: bool = False) -> str
         return text
     if strip_sources:
         text = _SOURCES_STRIP_RE.sub("", text)
-    text = _THINK_TAG_RE.sub("", text).strip()
-    return _INLINE_BASE64_IMG_RE.sub("[图片]", text)
+    return text.strip()
 
 
 def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -1,6 +1,5 @@
 """OpenAI-compatible API router (/v1/*)."""
 
-import asyncio
 import base64
 import binascii
 import mimetypes
@@ -128,36 +127,7 @@ async def _safe_sse(stream: AsyncIterable[str]) -> AsyncGenerator[str, None]:
         yield "data: [DONE]\n\n"
 
 
-_SSE_HEADERS = {
-    "Cache-Control": "no-cache",
-    "Connection": "keep-alive",
-    "X-Accel-Buffering": "no",
-}
-
-_HEARTBEAT_INTERVAL_S = 30
-
-
-async def _sse_with_heartbeat(
-    stream: AsyncIterable[str], interval: int = _HEARTBEAT_INTERVAL_S
-) -> AsyncGenerator[str, None]:
-    """Keep SSE connections alive through reverse proxies / CDNs.
-
-    - Initial 2KB padding forces intermediate buffers (nginx, Cloudflare) to flush.
-    - `: ping` comments sent every `interval` seconds of silence.
-    """
-    yield ": heartbeat stream connected\n" + " " * 2048 + "\n\n"
-
-    aiter = stream.__aiter__()
-    while True:
-        try:
-            chunk = await asyncio.wait_for(aiter.__anext__(), timeout=interval)
-            yield chunk
-        except asyncio.TimeoutError:
-            yield ": ping\n\n"
-        except StopAsyncIteration:
-            break
-        except asyncio.CancelledError:
-            break
+_SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
 
 
 # ---------------------------------------------------------------------------
@@ -321,9 +291,6 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
             )
 
         else:
-            request_overrides: dict | None = None
-            if req.deepsearch:
-                request_overrides = {"deepsearchPreset": req.deepsearch}
             # reasoning_effort=None → config default; "none" → off; otherwise → on.
             if req.reasoning_effort is None:
                 emit_think: bool | None = None
@@ -338,7 +305,6 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
                 tool_choice=req.tool_choice,
                 temperature=req.temperature or 0.8,
                 top_p=req.top_p or 0.95,
-                request_overrides=request_overrides,
             )
 
     except AppError:
@@ -350,11 +316,6 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
             is_stream,
             exc,
         )
-        # Video failures must surface their real HTTP status code so downstream
-        # billing gateways (e.g. New API) don't misread an SSE-wrapped error as a
-        # successful 200 response.
-        if spec.is_video():
-            raise
         if is_stream:
             _err_msg = str(
                 exc
@@ -375,9 +336,7 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
     if isinstance(result, dict):
         return JSONResponse(result)
     return StreamingResponse(
-        _sse_with_heartbeat(_safe_sse(result)),
-        media_type="text/event-stream",
-        headers=_SSE_HEADERS,
+        _safe_sse(result), media_type="text/event-stream", headers=_SSE_HEADERS
     )
 
 
@@ -456,9 +415,9 @@ async def responses_endpoint(req: ResponsesCreateRequest):
     if isinstance(result, dict):
         return JSONResponse(result)
     return StreamingResponse(
-        _sse_with_heartbeat(_safe_sse_responses(result)),
-        media_type="text/event-stream",
-        headers=_SSE_HEADERS,
+        _safe_sse_responses(result),
+        media_type = "text/event-stream",
+        headers    = _SSE_HEADERS,
     )
 
 

--- a/app/products/openai/schemas.py
+++ b/app/products/openai/schemas.py
@@ -39,9 +39,6 @@ class ChatCompletionRequest(BaseModel):
     tool_choice:         str | dict[str, Any] | None = None
     parallel_tool_calls: bool | None                = True
     max_tokens:          int | None                 = None
-    deepsearch:          Literal["default", "deeper"] | None = Field(
-        None, description="深度搜索预设: default/deeper"
-    )
 
 
 class ImageGenerationRequest(BaseModel):

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -324,7 +324,6 @@ curl http://localhost:8000/v1/chat/completions \
     "model": "grok-4.20-auto",
     "stream": true,
     "reasoning_effort": "high",
-    "deepsearch": "default",
     "messages": [
       {"role":"user","content":"Hello"}
     ]
@@ -381,7 +380,6 @@ curl http://localhost:8000/v1/chat/completions \
 | `messages` | Supports text and multimodal content blocks |
 | `stream` | Whether to stream output; falls back to `features.stream` when omitted |
 | `reasoning_effort` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; `none` disables reasoning output |
-| `deepsearch` | Deep search preset: `default`, `deeper` |
 | `temperature` / `top_p` | Sampling parameters, default `0.8` / `0.95` |
 | `tools` | OpenAI function tools structure |
 | `tool_choice` | `auto`, `required`, or a specific function tool |


### PR DESCRIPTION
## 概述

PR #473（`fix(cf): cf_clearance 403`）包含 30 个提交，其中仅 2 个与声明的 CF 修复相关。
提交 `44a50d3`（"port 本地自定义补丁到新架构"）夹带了 4 项未经审查的功能代码。
经代码审计，确认其中 3 项存在代码缺陷。

## 已确认的缺陷

### 1. SSE 心跳 — `asyncio.wait_for` 会截断上游流
- `_sse_with_heartbeat()` 使用 `asyncio.wait_for(aiter.__anext__(), timeout=30)`
- 超时时 `wait_for` 会 **cancel** 正在等待的 `__anext__()`，而非无害地发送 ping
- 深度思考模型（expert/heavy）的长静默期可能导致流被提前终止
- 参考：[Python 官方文档 — asyncio.wait_for 超时会取消被等待任务](https://docs.python.org/3.12/library/asyncio-task.html)

### 2. Think/Base64 清洗 — 篡改所有角色消息
- `_strip_generated_artifacts()` 注释写"Remove generated **assistant** artifacts"
- 但实际通过 `_extract_message()` 作用于 **所有角色**（user/system/developer/assistant）
- 用户 prompt 中的 `<think>` 标签会被静默删除，`![image](data:...)` 会被替换为 `[图片]`
- 原有的 `_SOURCES_STRIP_RE` 正确限定在 `role == "assistant"` — 此变更破坏了该约定

### 3. Video 错误码 raise — 放错 except 层
- `if spec.is_video(): raise` 位于 `except AppError: raise` **之后**
- `ValidationError` / `UpstreamError` 等主要错误类型在前面已被 raise，永远到不了 video 分支
- `stream=true` 的 video 请求有时返回 JSON 非 200，破坏流式接口契约

### 4. Deepsearch 透传 — 未经审查
- 无明显 bug，但从未经过 PR 审查流程
- 一并移除，如需保留建议以独立 PR 正式引入

## 变更范围

| 文件 | 改动 |
|:--|:--|
| `app/products/openai/router.py` | 删除心跳机制、deepsearch 透传、video raise |
| `app/products/openai/schemas.py` | 删除 deepsearch 字段 |
| `app/products/openai/chat.py` | 删除 think/base64 正则，简化 `_strip_generated_artifacts` |
| `README.md` | 删除 deepsearch 文档 |
| `docs/README.en.md` | 删除 deepsearch 文档 |

## 不动的文件

- `headers.py` / `profile.py` / `proxy/*` — CF 修复重构（`21adf6b`），合法代码
- `sync-upstream.yml` — 已在 `73d2bf6` 中删除

## 测试

- `ruff check` — lint 通过
- `python -m compileall` — 编译通过
- 全端点集成冒烟（models / chat / responses / messages / images / admin）— 全部正常
- 流式响应不再包含心跳 padding — 已验证
- 用户 prompt 中的 `<think>` 标签不再被清洗 — 已验证