### PR TITLE
feat: Increase image-to-video reference image limit from 5 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ curl -L http://localhost:8000/v1/videos/<video_id>/content \
 | `size` | 支持 `720x1280`, `1280x720`, `1024x1024`, `1024x1792`, `1792x1024` |
 | `resolution_name` | `480p` 或 `720p` |
 | `preset` | `fun`, `normal`, `spicy`, `custom` |
-| `input_reference[]` | 可选图生视频参考图，multipart 文件字段；最多使用前 5 张 |
+| `input_reference[]` | 可选图生视频参考图，multipart 文件字段；最多使用前 7 张 |
 | `video_id` | `POST /v1/videos` 返回的视频任务 ID，用于查询任务或下载成片 |
 
 <br>

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -478,7 +478,7 @@ async def videos_create(
     if input_reference:
         references_payload = [
             {"image_url": await _upload_to_data_uri(f, param="input_reference")}
-            for f in input_reference[:5]
+            for f in input_reference[:7]
         ]
 
     result = await create_video(

--- a/app/products/openai/video.py
+++ b/app/products/openai/video.py
@@ -993,7 +993,7 @@ def _extract_video_prompt_and_reference(
 
     input_references: list[dict[str, Any]] | None = None
     if reference_urls:
-        input_references = [{"image_url": url} for url in reference_urls[:5]]
+        input_references = [{"image_url": url} for url in reference_urls[:7]]
     return prompt, input_references
 
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -591,7 +591,7 @@ curl -L http://localhost:8000/v1/videos/<video_id>/content \
 | `size` | Supports `720x1280`, `1280x720`, `1024x1024`, `1024x1792`, `1792x1024` |
 | `resolution_name` | `480p` or `720p` |
 | `preset` | `fun`, `normal`, `spicy`, `custom` |
-| `input_reference[]` | Optional image-to-video reference multipart file field; at most the first 5 images are used |
+| `input_reference[]` | Optional image-to-video reference multipart file field; at most the first 7 images are used |
 | `video_id` | Video job ID returned by `POST /v1/videos`; used to retrieve the job or download the final video |
 
 <br>


### PR DESCRIPTION
- update /v1/videos multipart input_reference[] handling
- update chat-based video reference extraction
- sync Chinese and English docs

## Summary

将图生视频参考图上限从 5 张调整为 7 张，对其官方的多参考最多7张。

本次改动同时更新了 /v1/videos 的 multipart input_reference[] 处理逻辑，以及聊天消息里的图生视频参考图提取逻辑，保证两条入口行为一致，并同步更新中英文文档说明。

## Testing
未运行自动化测试。

已人工检查以下内容：

/v1/videos 中 input_reference[] 的截断上限已从 5 改为 7
聊天消息中的图生视频参考图提取上限已从 5 改为 7
中英文文档中的参数说明已同步更新为 7 张
## Related
无
<!-- Closes #... -->
