### PR TITLE
fix: 修复用户资源 URL 请求泄露 Grok 认证头的问题

### DIFF
--- a/app/dataplane/reverse/transport/asset_upload.py
+++ b/app/dataplane/reverse/transport/asset_upload.py
@@ -27,11 +27,6 @@ _UPLOAD_URL = "https://grok.com/rest/app-chat/upload-file"
 _X_USER_ID_RE = re.compile(r"(?:^|;\s*)x-userid=([^;]+)")
 _URL_FETCH_HEADERS = {
     "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/124.0.0.0 Safari/537.36"
-    ),
 }
 
 # Global semaphore — limits concurrent upload_file() calls across all requests.

--- a/app/dataplane/reverse/transport/asset_upload.py
+++ b/app/dataplane/reverse/transport/asset_upload.py
@@ -25,6 +25,14 @@ from app.control.proxy.models import ProxyFeedback, ProxyFeedbackKind
 
 _UPLOAD_URL = "https://grok.com/rest/app-chat/upload-file"
 _X_USER_ID_RE = re.compile(r"(?:^|;\s*)x-userid=([^;]+)")
+_URL_FETCH_HEADERS = {
+    "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+}
 
 # Global semaphore — limits concurrent upload_file() calls across all requests.
 # Initialised lazily on first call so the event loop is guaranteed to be running.
@@ -186,10 +194,13 @@ async def upload_from_input(token: str, file_input: str) -> tuple[str, str]:
         proxy = await get_proxy_runtime()
         lease = await proxy.acquire()
         try:
-            headers = build_http_headers(token, lease=lease)
             kwargs  = build_session_kwargs(lease=lease)
             async with ResettableSession(**kwargs) as session:
-                resp = await session.get(file_input, headers=headers, timeout=30.0)
+                resp = await session.get(
+                    file_input,
+                    headers=_URL_FETCH_HEADERS,
+                    timeout=30.0,
+                )
             raw  = resp.content
             if resp.status_code != 200:
                 await proxy.feedback(


### PR DESCRIPTION
## Summary

修复 `upload_from_input` 在下载用户提供的资源 URL 时复用 Grok 请求头的问题。

此前该逻辑使用 `build_http_headers(token, lease=lease)` 构造请求头访问用户输入的 URL。该请求头用于访问 `grok.com`，会包含 Grok 认证相关的 Cookie 等信息，存在将用户 Grok token 派生凭据泄露给任意外部 URL 的风险。

本次修改后，用户资源 URL 下载仅使用通用图片下载请求头：

- `Accept`
- `User-Agent`

不再向用户提供的 URL 发送 `Cookie`、`Authorization`、`Origin`、`Referer`、`x-xai-request-id`、`Baggage` 等 Grok 专用或敏感请求头。上传文件到 Grok 的请求逻辑保持不变，仍继续使用 `build_http_headers`。

## Testing

- 执行 `python -m py_compile app/dataplane/reverse/transport/asset_upload.py`，通过。

- 使用图片 URL 验证多模态图片输入仍可正常工作：
  - `https://picx.zhimg.com/....jpg`
  - 返回 `HTTP 200 OK`
  - Grok 成功描述图片内容
- 使用 webhook 风格 URL 验证外部 URL 请求行为：
  - `https://webhook.site/.../test.png`
  - 在 webhook.site 后台确认请求头不再携带 Grok 认证相关字段

## Related

N/A
