### PR TITLE
refactor(openai video): replace reserve with reserve_any and remove m…

### DIFF
--- a/app/products/openai/video.py
+++ b/app/products/openai/video.py
@@ -759,9 +759,8 @@ async def _run_video_with_account(
     if _acct_dir is None:
         raise RateLimitError("Account directory not initialised")
 
-    acct = await _acct_dir.reserve(
+    acct = await _acct_dir.reserve_any(
         pool_candidates=spec.pool_candidates(),
-        mode_id=int(spec.mode_id),
         now_s_override=now_s(),
     )
     if acct is None:
@@ -847,9 +846,8 @@ async def _run_video_job(
         if _acct_dir is None:
             raise RateLimitError("Account directory not initialised")
 
-        acct = await _acct_dir.reserve(
+        acct = await _acct_dir.reserve_any(
             pool_candidates=spec.pool_candidates(),
-            mode_id=int(spec.mode_id),
             now_s_override=now_s(),
         )
         if acct is None:


### PR DESCRIPTION
…ode_id param

update both _run_video_with_account and _run_video_job to use the updated reserve_any account reservation method that no longer requires mode_id parameter

## Summary

<!-- 改动了什么，为什么改 -->

## Testing

<!-- 怎么验证：本地跑了什么、curl 结果、或"无需验证（仅文档/格式）" -->

## Related

<!-- Closes #... -->
