### PR TITLE
feat: 增加 lite 账户类型，解决 25 次限额账号被刷新自动识别为 basic 的问题

### DIFF
--- a/app/control/account/backends/local.py
+++ b/app/control/account/backends/local.py
@@ -169,7 +169,7 @@ class LocalAccountRepository:
                 token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
             except ValueError:
                 continue
-            pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+            pool = item.pool if item.pool in ("basic", "lite", "super", "heavy") else "basic"
             qs   = default_quota_set(pool)
             conn.execute(
                 f"""

--- a/app/control/account/backends/redis.py
+++ b/app/control/account/backends/redis.py
@@ -204,7 +204,7 @@ class RedisAccountRepository:
                 token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
             except ValueError:
                 continue
-            pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+            pool = item.pool if item.pool in ("basic", "lite", "super", "heavy") else "basic"
             qs   = default_quota_set(pool)
             ts   = now_ms()
             record = AccountRecord(

--- a/app/control/account/backends/sql.py
+++ b/app/control/account/backends/sql.py
@@ -627,7 +627,7 @@ class SqlAccountRepository:
                     token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
                 except Exception:
                     continue
-                pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+                pool = item.pool if item.pool in ("basic", "lite", "super", "heavy") else "basic"
                 qs   = default_quota_set(pool)
                 row  = {
                     "token":            token,

--- a/app/control/account/models.py
+++ b/app/control/account/models.py
@@ -205,6 +205,10 @@ class AccountRecord(BaseModel):
         return "nsfw" in self.tags
 
     @property
+    def is_lite(self) -> bool:
+        return self.pool == "lite"
+
+    @property
     def is_super(self) -> bool:
         return self.pool == "super"
 
@@ -263,7 +267,9 @@ class AccountRecord(BaseModel):
     @classmethod
     def _normalize_pool(cls, v: Any) -> str:
         val = str(v or "").strip().lower()
-        if val in ("super"):
+        if val in ("lite",):
+            return "lite"
+        if val in ("super",):
             return "super"
         if val in ("heavy",):
             return "heavy"

--- a/app/control/account/quota_defaults.py
+++ b/app/control/account/quota_defaults.py
@@ -49,6 +49,13 @@ BASIC_QUOTA_DEFAULTS = AccountQuotaSet(
     expert=_w(0, 0, 0),  # unsupported on basic accounts
 )
 
+LITE_QUOTA_DEFAULTS = AccountQuotaSet(
+    auto=_w(25, 25, 7_200),  # 25  queries / 2 h
+    fast=_w(70, 70, 7_200),  # 70  queries / 2 h
+    expert=_w(12, 12, 7_200),  # 12  queries / 2 h
+    grok_4_3=_w(12, 12, 7_200),  # 12  queries / 2 h
+)
+
 SUPER_QUOTA_DEFAULTS = AccountQuotaSet(
     auto=_w(50, 50, 7_200),  # 50  queries / 2 h
     fast=_w(140, 140, 7_200),  # 140 queries / 2 h
@@ -67,24 +74,16 @@ HEAVY_QUOTA_DEFAULTS = AccountQuotaSet(
 # Map pool name → defaults object (used by backends on upsert).
 _POOL_DEFAULTS: dict[str, AccountQuotaSet] = {
     "basic": BASIC_QUOTA_DEFAULTS,
+    "lite": LITE_QUOTA_DEFAULTS,
     "super": SUPER_QUOTA_DEFAULTS,
     "heavy": HEAVY_QUOTA_DEFAULTS,
 }
 
 _SUPPORTED_MODE_IDS_BY_POOL: dict[str, frozenset[int]] = {
     "basic": frozenset((1,)),
+    "lite": frozenset((0, 1, 2, 4)),
     "super": frozenset((0, 1, 2, 4)),
     "heavy": frozenset((0, 1, 2, 3, 4)),
-}
-
-# ---------------------------------------------------------------------------
-# Pool inference — keyed on auto.total (unique across pool types)
-# ---------------------------------------------------------------------------
-
-_AUTO_TOTAL_TO_POOL: dict[int, str] = {
-    20: "basic",
-    50: "super",
-    150: "heavy",
 }
 
 
@@ -162,17 +161,30 @@ def normalize_quota_set(pool: str, quota_set: AccountQuotaSet) -> AccountQuotaSe
 def infer_pool(windows: dict[int, QuotaWindow]) -> str:
     """Infer pool type from live quota windows returned by the rate-limits API.
 
-    Uses ``auto.total`` (mode_id=0) as the discriminating signal.
+    Uses ``auto.total`` (mode_id=0) as the discriminating signal:
+      - 25 -> lite
+      - 50 -> super
+      - 150 -> heavy
+      - otherwise -> basic
     Falls back to ``"basic"`` when the value is absent or unrecognised.
     """
     auto_win = windows.get(0)
     if auto_win is None:
         return "basic"
-    return _AUTO_TOTAL_TO_POOL.get(auto_win.total, "basic")
+    total = auto_win.total
+    if total == 25:
+        return "lite"
+    elif total == 50:
+        return "super"
+    elif total >= 150:
+        return "heavy"
+    else:
+        return "basic"
 
 
 __all__ = [
     "BASIC_QUOTA_DEFAULTS",
+    "LITE_QUOTA_DEFAULTS",
     "SUPER_QUOTA_DEFAULTS",
     "HEAVY_QUOTA_DEFAULTS",
     "default_quota_set",

--- a/app/control/account/scheduler.py
+++ b/app/control/account/scheduler.py
@@ -17,6 +17,7 @@ from .refresh import AccountRefreshService
 # Pool → (config key, built-in default seconds)
 _POOL_CONFIG: dict[str, tuple[str, int]] = {
     "basic": ("account.refresh.basic_interval_sec", 86_400),
+    "lite": ("account.refresh.super_interval_sec",  7_200),
     "super": ("account.refresh.super_interval_sec",  7_200),
     "heavy": ("account.refresh.heavy_interval_sec",  7_200),
 }

--- a/app/control/model/enums.py
+++ b/app/control/model/enums.py
@@ -26,8 +26,9 @@ class Tier(IntEnum):
     """Account tier — determines which pool is selected."""
 
     BASIC = 0  # pool="basic"
-    SUPER = 1  # pool="super"
-    HEAVY = 2  # pool="heavy"
+    LITE = 1  # pool="lite"
+    SUPER = 2  # pool="super"
+    HEAVY = 3  # pool="heavy"
 
 
 class Capability(IntFlag):

--- a/app/control/model/spec.py
+++ b/app/control/model/spec.py
@@ -49,6 +49,8 @@ class ModelSpec:
 
     def pool_name(self) -> str:
         """Return the canonical pool string for this tier."""
+        if self.tier == Tier.LITE:
+            return "lite"
         if self.tier == Tier.SUPER:
             return "super"
         if self.tier == Tier.HEAVY:
@@ -69,26 +71,32 @@ class ModelSpec:
         when all accounts in higher pools are exhausted).
 
         Default (prefer_best=False):
-          BASIC tier  → try basic first, then super, then heavy
+          BASIC tier  → try basic first, then lite, then super, then heavy
+          LITE tier   → try lite first, then super, then heavy
           SUPER tier  → try super first, then heavy
           HEAVY tier  → heavy only
 
         Reversed (prefer_best=True):
-          BASIC tier  → try heavy first, then super, then basic
+          BASIC tier  → try heavy first, then super, then lite, then basic
+          LITE tier   → try heavy first, then super, then lite
           SUPER tier  → try heavy first, then super
           HEAVY tier  → heavy only
         """
         if self.prefer_best:
             if self.tier == Tier.HEAVY:
-                return (2,)  # heavy only
+                return (3,)  # heavy only
             if self.tier == Tier.SUPER:
-                return (2, 1)  # heavy, super
-            return (2, 1, 0)  # heavy, super, basic
+                return (3, 2, 1)  # heavy, super, lite
+            if self.tier == Tier.LITE:
+                return (3, 2, 1)  # heavy, super, lite
+            return (3, 2, 1, 0)  # heavy, super, lite, basic
         if self.tier == Tier.BASIC:
-            return (0, 1, 2)  # basic, super, heavy
+            return (0, 1, 2, 3)  # basic, lite, super, heavy
+        if self.tier == Tier.LITE:
+            return (1, 2, 3)  # lite, super, heavy
         if self.tier == Tier.SUPER:
-            return (1, 2)  # super, heavy
-        return (2,)  # heavy only
+            return (2, 1, 3)  # super, lite, heavy
+        return (3,)  # heavy only
 
 
 __all__ = ["ModelSpec"]

--- a/app/dataplane/account/__init__.py
+++ b/app/dataplane/account/__init__.py
@@ -308,6 +308,7 @@ class AccountDirectory:
 
 _POOL_INTERVAL_CONFIG: dict[str, tuple[str, int]] = {
     "basic": ("account.refresh.basic_interval_sec", 86_400),
+    "lite": ("account.refresh.super_interval_sec", 7_200),
     "super": ("account.refresh.super_interval_sec", 7_200),
     "heavy": ("account.refresh.heavy_interval_sec", 7_200),
 }

--- a/app/dataplane/shared/enums.py
+++ b/app/dataplane/shared/enums.py
@@ -17,8 +17,9 @@ class ModeId(IntEnum):
 
 class PoolId(IntEnum):
     BASIC = 0
-    SUPER = 1
-    HEAVY = 2
+    LITE = 1
+    SUPER = 2
+    HEAVY = 3
 
 
 class StatusId(IntEnum):
@@ -32,6 +33,7 @@ class StatusId(IntEnum):
 # Map pool string → PoolId integer (used during sync from control plane).
 POOL_STR_TO_ID: dict[str, int] = {
     "basic": int(PoolId.BASIC),
+    "lite": int(PoolId.LITE),
     "super": int(PoolId.SUPER),
     "heavy": int(PoolId.HEAVY),
 }

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -27,7 +27,7 @@ from .schemas import (
 from .chat import completions as chat_completions
 
 router = APIRouter(prefix="/v1")
-_POOL_ID_TO_NAME = {0: "basic", 1: "super", 2: "heavy"}
+_POOL_ID_TO_NAME = {0: "basic", 1: "lite", 2: "super", 3: "heavy"}
 _TAG_MODELS = "OpenAI - Models"
 _TAG_CHAT = "OpenAI - Chat"
 _TAG_RESPONSES = "OpenAI - Responses"


### PR DESCRIPTION
## Summary

我是 Grok Lite 账号（官方接口返回的 `auto.total` 限制是 25 次）。

**痛点**：
之前系统里没有 `lite` 这个 pool 档位，所以每次我手动在数据库里把账号改成 `super` 勉强能用。但是只要系统后台一刷新，系统读到 25 次配额之后，由于不认识这个额度，就会把账号自动降级判定回 `basic`，导致高级模型直接用不了（也就是一刷新就和 basic 一桌了）。

为了解决这个问题，本次 PR 增加了 `lite` 账户类型，并在刷新、判定、路由上使其表现和 `super` 账户完全一致。

**改动内容**：
1. **配额自动推断**：在 `quota_defaults.py` 的 `infer_pool()` 中增加 `auto.total == 25` 的判定，将其正确推断为 `lite` 账户。
2. **对齐支持的模式与模型**：
   - 将 `_SUPPORTED_MODE_IDS_BY_POOL["lite"]` 配置为 `(0, 1, 2, 4)`，跟 `super` 完全一样（增加了对 `grok-4.3-beta` 的 Mode 4 的支持，移除了不支持的 `heavy`）。
   - 将 `LITE_QUOTA_DEFAULTS` 里的 `heavy` 去除，增加 `grok_4_3` 配额。
   - `Tier.SUPER` 的模型的候选池列表里包含了 `lite`（即 `1`），使得 `lite` 可以作为 `super` 模型的可选路由。
3. **各组件兼容**：
   - 在 `enums.py` 中增加了 `LITE` 的 Tier / PoolId。
   - 兼容了 SQLite / SQL / Redis 后端的 `pool` 写入白名单（支持写入 `"lite"`，解决 500 报错）。
   - 在 `scheduler.py` 中配置了和 `super` 相同的同步刷新和冷却机制（7200秒）。

## Testing

在本地进行了实际接口调用验证。
当数据库里只有 `lite` 账号时，调用 `http://127.0.0.1:8000/v1/models` 接口，可以正常加载所有原属于 `super` 的高级模型列表（包括 `grok-4.3-beta` ），未再出现降级为 basic 或 Pydantic 校验的 500 报错。

## Related

暂无
