### PR TITLE
fix: prefer raw image-edit final url before asset fallback

### DIFF
--- a/app/products/openai/images.py
+++ b/app/products/openai/images.py
@@ -738,13 +738,13 @@ def _resolve_edit_final_url(
     asset_id: str | None,
     user_id: str | None,
 ) -> str | None:
-    """Prefer stable asset content URLs over generated image paths for image-edit finals."""
+    """Prefer the upstream final URL and only fall back to asset-derived URLs."""
+    if raw_url:
+        return _absolutize_asset_url(raw_url)
     if asset_id and user_id:
         resolved = resolve_asset_reference(asset_id, "", user_id=user_id)
         if resolved:
             return resolved
-    if raw_url:
-        return _absolutize_asset_url(raw_url)
     return None
 
 


### PR DESCRIPTION
## Summary

Prefer the upstream raw final image URL for image-edit results and only fall back to asset-derived URLs when `raw_url` is missing.

This avoids proxy download 404s in `local_url` mode when the asset-derived content URL is no longer valid.

## Testing

- Ran `python3 -m py_compile app/products/openai/images.py`
- Verified the change is limited to image-edit final URL resolution order

## Related

- N/A