### PR TITLE
fix: accept video job ids in local file route

### DIFF
--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -579,7 +579,7 @@ async def serve_video(id: str = Query(..., description="Video file ID")):
     """Serve a locally cached video by file ID."""
     import re
 
-    if not re.fullmatch(r"[0-9a-f\-]{16,36}", id):
+    if not re.fullmatch(r"(?:video_)?[0-9a-f\-]{16,36}", id):
         raise ValidationError("Invalid file ID", param="id")
 
     path = video_files_dir() / f"{id}.mp4"


### PR DESCRIPTION
## Summary

Allow `/v1/files/video` to accept local video job ids with the `video_` prefix in addition to plain hex file ids.

This fixes local cached video access for jobs created by `/v1/videos`, which are stored on disk using the `video_<uuid>` naming format.

## Testing

- Ran `python3 -m py_compile app/products/openai/router.py`
- Verified the route change is limited to the local video file id validation regex

## Related

- N/A