### PR TITLE
修复 Grok app-chat 请求兼容性

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ docker compose up -d
 | `app` | `app_key`, `app_url`, `api_key`, `webui_enabled`, `webui_key` |
 | `logging` | `file_level`, `max_files` |
 | `features` | `temporary`, `memory`, `stream`, `thinking`, `auto_chat_mode_fallback`, `thinking_summary`, `dynamic_statsig`, `enable_nsfw`, `show_search_sources`, `custom_instruction`, `image_format`, `imagine_public_image_proxy`, `video_format` |
+| `proxy` | `statsig_id` |
 | `proxy.egress` | `mode`, `proxy_url`, `proxy_pool`, `resource_proxy_url`, `resource_proxy_pool`, `skip_ssl_verify` |
 | `proxy.clearance` | `mode`, `cf_cookies`, `user_agent`, `browser`, `flaresolverr_url`, `timeout_sec`, `refresh_interval` |
 | `retry` | `reset_session_status_codes`, `max_retries`, `on_codes` |
@@ -210,6 +211,58 @@ docker compose up -d
 | `asset` | `upload_timeout`, `download_timeout`, `list_timeout`, `delete_timeout` |
 | `nsfw` | `timeout` |
 | `batch` | `nsfw_concurrency`, `refresh_concurrency`, `asset_upload_concurrency`, `asset_list_concurrency`, `asset_delete_concurrency` |
+
+### Grok App-Chat 兼容性
+
+如果聊天请求出现如下上游错误：
+
+```text
+Chat upstream returned 403
+Request rejected by anti-bot rules.
+```
+
+可以检查当前 Grok 网页端请求是否需要额外的浏览器会话 header。`x-statsig-id` 不是 Cloudflare Cookie，FlareSolverr 不会自动提供；如有需要，可以从自己的浏览器会话中复制该请求头并写入运行时配置：
+
+```toml
+[proxy]
+statsig_id = "your-browser-x-statsig-id"
+```
+
+不需要时保持为空：
+
+```toml
+[proxy]
+statsig_id = ""
+```
+
+获取方式：
+
+1. 在浏览器打开 `https://grok.com`
+2. 打开开发者工具的 Network 面板
+3. 正常发送一条 Grok 消息
+4. 找到 `https://grok.com/rest/app-chat/conversations/new`
+5. 在 Request Headers 中复制 `x-statsig-id`
+6. 写入本地 `config.toml`，保存后重试
+
+Cloudflare 放行凭证仍由 `proxy.clearance` 负责。例如使用 FlareSolverr 时：
+
+```toml
+[proxy.clearance]
+mode = "flaresolverr"
+flaresolverr_url = "http://flaresolverr:8191"
+timeout_sec = 120
+refresh_interval = 3600
+```
+
+请勿提交或公开真实的登录态、Cookie、请求头或密钥，包括：
+
+- `sso`
+- `sso-rw`
+- `cf_clearance`
+- `__cf_bm`
+- `x-statsig-id`
+- API Key
+- 管理后台密码
 
 ### 图片、视频格式
 

--- a/app/dataplane/proxy/adapters/headers.py
+++ b/app/dataplane/proxy/adapters/headers.py
@@ -66,6 +66,9 @@ def _sanitize(value: Optional[str], *, field: str, strip_spaces: bool = False) -
 
 def _statsig_id() -> str:
     cfg = get_config()
+    configured = cfg.get_str("proxy.statsig_id", "").strip()
+    if configured:
+        return configured
     if cfg.get_bool("features.dynamic_statsig", False):
         if random.choice((True, False)):
             rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
@@ -86,8 +89,12 @@ def _statsig_id() -> str:
 
 
 def _major_version(browser: Optional[str], ua: Optional[str]) -> Optional[str]:
-    for src in (browser or "", ua or ""):
-        m = re.search(r"(\d{2,3})", src)
+    for src in (browser or "",):
+        m = re.search(r"(?:chrome|chromium|edge|firefox|safari)(\d{2,3})", src.lower())
+        if m:
+            return m.group(1)
+    for src in (ua or "",):
+        m = re.search(r"(?:Chrome|Chromium|CriOS|Edg|Firefox)/(\d{2,3})", src)
         if m:
             return m.group(1)
     return None
@@ -105,15 +112,6 @@ def _platform(ua: str) -> Optional[str]:
         return "iOS"
     if "linux" in u:
         return "Linux"
-    return None
-
-
-def _arch(ua: str) -> Optional[str]:
-    u = ua.lower()
-    if "aarch64" in u or "arm" in u:
-        return "arm"
-    if "x86_64" in u or "x64" in u or "win64" in u or "intel" in u:
-        return "x86"
     return None
 
 
@@ -137,21 +135,19 @@ def _client_hints(browser: Optional[str], ua: Optional[str]) -> dict[str, str]:
     else:
         brand = "Google Chrome"
 
-    sec_ch_ua = f'"{brand}";v="{ver}", "Chromium";v="{ver}", "Not(A:Brand";v="24"'
+    if brand == "Google Chrome":
+        sec_ch_ua = f'"Chromium";v="{ver}", "Google Chrome";v="{ver}", "Not/A)Brand";v="99"'
+    else:
+        sec_ch_ua = f'"{brand}";v="{ver}", "Chromium";v="{ver}", "Not/A)Brand";v="99"'
     plat = _platform(ua or "")
-    arch = _arch(ua or "")
     mobile = "?1" if ("mobile" in u or plat in ("Android", "iOS")) else "?0"
 
     hints: dict[str, str] = {
         "Sec-Ch-Ua": sec_ch_ua,
         "Sec-Ch-Ua-Mobile": mobile,
-        "Sec-Ch-Ua-Model": "",
     }
     if plat:
         hints["Sec-Ch-Ua-Platform"] = f'"{plat}"'
-    if arch:
-        hints["Sec-Ch-Ua-Arch"] = arch
-        hints["Sec-Ch-Ua-Bitness"] = "64"
     return hints
 
 
@@ -252,27 +248,21 @@ def build_http_headers(
     site = "same-origin" if org_host and org_host == ref_host else "same-site"
 
     headers: dict[str, str] = {
-        "Accept": accept,
-        "Accept-Encoding": "gzip, deflate, br, zstd",
-        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
-        "Baggage": (
-            "sentry-environment=production,"
-            "sentry-release=d6add6fb0460641fd482d767a335ef72b9b6abb8,"
-            "sentry-public_key=b311e0f2690c81f25e2c4cf6d4f7ce1c"
-        ),
-        "Content-Type": ct,
-        "Origin": org,
-        "Priority": "u=1, i",
-        "Referer": ref,
-        "Sec-Fetch-Dest": fd,
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": site,
-        "User-Agent": ua,
+        "accept": accept,
+        "accept-language": "zh-CN,zh;q=0.9",
+        "content-type": ct,
+        "origin": org,
+        "priority": "u=1, i",
+        "referer": ref,
+        "sec-fetch-dest": fd,
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": site,
+        "user-agent": ua,
         "x-statsig-id": _statsig_id(),
         "x-xai-request-id": str(uuid.uuid4()),
     }
-    headers.update(_client_hints(browser, raw_ua))
-    headers["Cookie"] = build_sso_cookie(cookie_token, lease=lease)
+    headers.update({k.lower(): v for k, v in _client_hints(browser, raw_ua).items()})
+    headers["cookie"] = build_sso_cookie(cookie_token, lease=lease)
 
     logger.debug("http headers built: header_count={}", len(headers))
     return headers

--- a/app/dataplane/reverse/protocol/xai_chat.py
+++ b/app/dataplane/reverse/protocol/xai_chat.py
@@ -27,16 +27,16 @@ def build_chat_payload(
 
     payload: dict[str, Any] = {
         "collectionIds":               [],
-        "connectors":                  [],
+        "disabledConnectorIds":         [],
         "deviceEnvInfo": {
-            "darkModeEnabled":  False,
-            "devicePixelRatio": 2,
-            "screenHeight":     1329,
-            "screenWidth":      2056,
-            "viewportHeight":   1083,
-            "viewportWidth":    2056,
+            "darkModeEnabled":  True,
+            "devicePixelRatio": 1.75,
+            "screenHeight":     1440,
+            "screenWidth":      2560,
+            "viewportHeight":   726,
+            "viewportWidth":    899,
         },
-        "disableMemory":               not cfg.get_bool("features.memory", False),
+        "disableMemory":               False,
         "disableSearch":               False,
         "disableSelfHarmShortCircuit": False,
         "disableTextFollowUps":        False,
@@ -49,22 +49,18 @@ def build_chat_payload(
         "imageAttachments":            [],
         "imageGenerationCount":        2,
         "isAsyncChat":                 False,
+        "linkQuery":                   False,
         "message":                     message,
         "modeId":                      mode_id.to_api_str(),
         "responseMetadata":            {},
         "returnImageBytes":            False,
         "returnRawGrokInXaiRequest":   False,
-        "searchAllConnectors":         False,
         "sendFinalMetadata":           True,
-        "temporary":                   cfg.get_bool("features.temporary", True),
-        "toolOverrides": tool_overrides or {
-            "gmailSearch":           False,
-            "googleCalendarSearch":  False,
-            "outlookSearch":         False,
-            "outlookCalendarSearch": False,
-            "googleDriveSearch":     False,
-        },
+        "temporary":                   False,
     }
+
+    if tool_overrides:
+        payload["toolOverrides"] = tool_overrides
 
     custom = cfg.get_str("features.custom_instruction", "").strip()
     if custom:

--- a/app/products/openai/chat.py
+++ b/app/products/openai/chat.py
@@ -338,7 +338,7 @@ def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:
         if isinstance(content, str):
             cleaned = _strip_generated_artifacts(content.strip())
             if cleaned:
-                parts.append(f"[{role}]: {cleaned}")
+                parts.append(cleaned if role == "user" else f"[{role}]: {cleaned}")
         elif isinstance(content, list):
             for block in content:
                 if not isinstance(block, dict):
@@ -351,7 +351,7 @@ def _extract_message(messages: list[dict]) -> tuple[str, list[str]]:
                         strip_sources=(role == "assistant"),
                     )
                     if text:
-                        parts.append(f"[{role}]: {text}")
+                        parts.append(text if role == "user" else f"[{role}]: {text}")
                 elif btype == "image_url":
                     url = (block.get("image_url") or {}).get("url", "")
                     if url:

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -71,6 +71,10 @@ video_max_mb = 0
 
 
 # ==================== 代理配置 ====================
+[proxy]
+# 可选：从浏览器 app-chat 请求中抓取的 x-statsig-id。留空时使用内置生成逻辑。
+statsig_id = ""
+
 [proxy.egress]
 # 出口模式：direct | single_proxy | proxy_pool
 mode = "direct"


### PR DESCRIPTION
## 说明

  本次更新主要修复 Grok app-chat 网页端接口在部分环境下返回 upstream 403 的问题：

  ```text
  Chat upstream returned 403
  Request rejected by anti-bot rules.

  ## 主要改动

  - 新增可选配置 proxy.statsig_id，允许用户在本地配置浏览器请求中的 x-statsig-id。
  - 调整 app-chat 请求 headers，使其更接近当前 Grok 网页端请求格式。
  - 修正 sec-ch-ua 和 Chrome 版本号解析逻辑。
  - 调整 app-chat payload，匹配当前 Grok 网页端请求结构。
  - 用户消息不再额外添加 [user]: 前缀，避免和网页端真实输入格式不一致。
  - README 增加 x-statsig-id 配置说明、FlareSolverr clearance 说明和隐私提醒。

  ## 隐私说明

  本次提交不包含任何私人凭据或真实会话值，包括：

  - SSO / sso-rw
  - cf_clearance
  - __cf_bm
  - 真实 x-statsig-id
  - API Key
  - 管理后台密码

  proxy.statsig_id 默认值为空，用户需要时可自行从自己的浏览器请求中复制并配置。