### PR TITLE
fix: correct x-statsig-id format to bypass anti-bot rules

### DIFF
--- a/app/dataplane/proxy/adapters/headers.py
+++ b/app/dataplane/proxy/adapters/headers.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 
 
 from app.platform.logging.logger import logger
-from app.platform.config.snapshot import get_config
 from app.control.proxy.models import ProxyLease
 from app.dataplane.proxy.adapters.profile import ProxyProfile, resolve_proxy_profile
 
@@ -65,19 +64,24 @@ def _sanitize(value: Optional[str], *, field: str, strip_spaces: bool = False) -
 
 
 def _statsig_id() -> str:
-    cfg = get_config()
-    if cfg.get_bool("features.dynamic_statsig", False):
-        if random.choice((True, False)):
-            rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
-            msg = f"e:TypeError: Cannot read properties of null (reading 'children['{rand}']')"
-        else:
-            rand = "".join(random.choices(string.ascii_lowercase, k=10))
-            msg = f"e:TypeError: Cannot read properties of undefined (reading '{rand}')"
-        return base64.b64encode(msg.encode()).decode()
-    return (
-        "ZTpUeXBlRXJyb3I6IENhbm5vdCByZWFkIHByb3BlcnRpZXMgb2YgdW5kZWZpbmVkIChyZWFkaW5nICdjaGls"
-        "ZE5vZGVzJyk="
-    )
+    """Generate a Statsig evaluation fallback ID.
+
+    The real browser's fetch interceptor tries to evaluate Statsig gates for
+    each request.  When the Statsig SDK is not yet initialised (headless,
+    first paint, etc.) it catches the error and falls back to::
+
+        btoa("x1:" + error.toString())
+
+    The server accepts this fallback.  We reproduce the exact format with
+    varied error messages to avoid a static fingerprint.
+    """
+    if random.choice((True, False)):
+        rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+        msg = f"x1:TypeError: Cannot read properties of null (reading 'children[\\'{rand}\\']')"
+    else:
+        rand = "".join(random.choices(string.ascii_lowercase, k=10))
+        msg = f"x1:TypeError: Cannot read properties of undefined (reading '{rand}')"
+    return base64.b64encode(msg.encode()).decode()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Grok's website added new anti-bot controls (issue #562). All HTTP API endpoints except WebSocket `imagine` return:

```
{"error":{"code":7,"message":"Request rejected by anti-bot rules.","details":[]}}
```

## Root Cause

Grok's frontend JavaScript intercepts every `fetch` call and computes the `x-statsig-id` header via a Statsig SDK evaluation. When that evaluation fails (headless, first paint, etc.), it falls back to:

```
catch(e) { t = btoa("x1:" + e) }
```

The old code generated values with the prefix `e:` (e.g. `e:TypeError: Cannot read properties of undefined...`), but the real browser uses the prefix `x1:` (e.g. `x1:TypeError: ...`). Grok's server validates this prefix and rejects anything else.

## Fix

Changed the prefix in `_statsig_id()` from `e:` to `x1:`, matching exactly what the real browser's fetch interceptor produces as a Statsig evaluation fallback. The `dynamic_statsig` config toggle is now effectively always-on (each request gets a randomized error variable name).

## Validation

Tested directly against `grok.com/rest/app-chat/conversations/new` with 3 different SSO tokens — all returned **200** where they previously returned **403**. Also deployed to local Docker and confirmed the service works end-to-end.

Fixes #562