### PR TITLE
fix: preserve statsig config while using x1 prefix

### DIFF
--- a/app/dataplane/proxy/adapters/headers.py
+++ b/app/dataplane/proxy/adapters/headers.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 
 from app.platform.logging.logger import logger
+from app.platform.config.snapshot import get_config
 from app.control.proxy.models import ProxyLease
 from app.dataplane.proxy.adapters.profile import ProxyProfile, resolve_proxy_profile
 
@@ -64,24 +65,19 @@ def _sanitize(value: Optional[str], *, field: str, strip_spaces: bool = False) -
 
 
 def _statsig_id() -> str:
-    """Generate a Statsig evaluation fallback ID.
-
-    The real browser's fetch interceptor tries to evaluate Statsig gates for
-    each request.  When the Statsig SDK is not yet initialised (headless,
-    first paint, etc.) it catches the error and falls back to::
-
-        btoa("x1:" + error.toString())
-
-    The server accepts this fallback.  We reproduce the exact format with
-    varied error messages to avoid a static fingerprint.
-    """
-    if random.choice((True, False)):
-        rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
-        msg = f"x1:TypeError: Cannot read properties of null (reading 'children[\\'{rand}\\']')"
-    else:
-        rand = "".join(random.choices(string.ascii_lowercase, k=10))
-        msg = f"x1:TypeError: Cannot read properties of undefined (reading '{rand}')"
-    return base64.b64encode(msg.encode()).decode()
+    cfg = get_config()
+    if cfg.get_bool("features.dynamic_statsig", False):
+        if random.choice((True, False)):
+            rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+            msg = f"x1:TypeError: Cannot read properties of null (reading 'children['{rand}']')"
+        else:
+            rand = "".join(random.choices(string.ascii_lowercase, k=10))
+            msg = f"x1:TypeError: Cannot read properties of undefined (reading '{rand}')"
+        return base64.b64encode(msg.encode()).decode()
+    return (
+        "ZTpUeXBlRXJyb3I6IENhbm5vdCByZWFkIHByb3BlcnRpZXMgb2YgdW5kZWZpbmVkIChyZWFkaW5nICdjaGls"
+        "ZE5vZGVzJyk="
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- follows the minimal fix: only changes dynamic Statsig fallback IDs from `e:` to `x1:`
- restores the `features.dynamic_statsig` config gate and existing static fallback value
- removes the accidental literal backslashes in the null/children fallback string

## Test Plan
- `python3 -m py_compile app/dataplane/proxy/adapters/headers.py`
- targeted decode/assertion script validating dynamic `x1:` outputs and retained static fallback
- `uv run ruff check app/dataplane/proxy/adapters/headers.py`