### PR TITLE
feat(xai): Grok Build OAuth (loopback PKCE) + pool-scoped models

### DIFF
--- a/app/control/account/backends/local.py
+++ b/app/control/account/backends/local.py
@@ -166,10 +166,13 @@ class LocalAccountRepository:
         count = 0
         for item in items:
             try:
-                token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
+                _validated = AccountRecord.model_validate({"token": item.token, "pool": item.pool})
             except ValueError:
                 continue
-            pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+            token = _validated.token
+            # Use the validator-normalised pool (accepts non-grok pools such as
+            # "xai" / "_xai_oauth_pending"); only grok pools get real defaults.
+            pool = _validated.pool
             qs   = default_quota_set(pool)
             conn.execute(
                 f"""

--- a/app/control/account/backends/redis.py
+++ b/app/control/account/backends/redis.py
@@ -201,10 +201,13 @@ class RedisAccountRepository:
         count = 0
         for item in items:
             try:
-                token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
+                _validated = AccountRecord.model_validate({"token": item.token, "pool": item.pool})
             except ValueError:
                 continue
-            pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+            token = _validated.token
+            # Use the validator-normalised pool (accepts non-grok pools such as
+            # "xai" / "_xai_oauth_pending").
+            pool = _validated.pool
             qs   = default_quota_set(pool)
             ts   = now_ms()
             record = AccountRecord(

--- a/app/control/account/backends/sql.py
+++ b/app/control/account/backends/sql.py
@@ -624,10 +624,13 @@ class SqlAccountRepository:
             count = 0
             for item in items:
                 try:
-                    token = AccountRecord.model_validate({"token": item.token, "pool": item.pool}).token
+                    _validated = AccountRecord.model_validate({"token": item.token, "pool": item.pool})
                 except Exception:
                     continue
-                pool = item.pool if item.pool in ("basic", "super", "heavy") else "basic"
+                token = _validated.token
+                # Use the validator-normalised pool (accepts non-grok pools such
+                # as "xai" / "_xai_oauth_pending").
+                pool = _validated.pool
                 qs   = default_quota_set(pool)
                 row  = {
                     "token":            token,

--- a/app/control/account/models.py
+++ b/app/control/account/models.py
@@ -267,6 +267,13 @@ class AccountRecord(BaseModel):
             return "super"
         if val in ("heavy",):
             return "heavy"
+        if val == "xai":
+            # Official api.x.ai OAuth provider pool — excluded from grok.com
+            # selection / quota machinery (see dataplane GROK_POOLS).
+            return "xai"
+        if val == "_xai_oauth_pending":
+            # Reserved transient pool for in-flight xAI OAuth state (non-grok).
+            return "_xai_oauth_pending"
         if val in ("ssobasic", "basic", "", "auto"):
             # "auto" is a UI alias meaning "let quota sync decide";
             # save as basic for now — refresh will correct to the real type.

--- a/app/control/account/refresh.py
+++ b/app/control/account/refresh.py
@@ -20,9 +20,19 @@ from .quota_defaults import (
     supports_mode,
 )
 from .state_machine import is_manageable
+from app.dataplane.shared.enums import GROK_POOLS
 
 if TYPE_CHECKING:
     from .repository import AccountRepository
+
+
+def _is_grok_pool(record: AccountRecord) -> bool:
+    """Return True if *record* uses the grok.com quota/usage machinery.
+
+    Accounts in non-grok pools (e.g. ``"xai"`` for the official api.x.ai OAuth
+    provider) must not be probed against grok.com's usage API.
+    """
+    return record.pool in GROK_POOLS
 
 
 @dataclass
@@ -151,7 +161,7 @@ class AccountRefreshService:
     async def refresh_call_async(self, token: str, mode_id: int) -> None:
         """Fire-and-forget single-mode quota sync after a successful call."""
         record = (await self._repo.get_accounts([token]) or [None])[0]
-        if record is None or record.is_deleted():
+        if record is None or record.is_deleted() or not _is_grok_pool(record):
             return
         try:
             window = await self._fetch_mode_quota(token, record.pool, mode_id)
@@ -233,7 +243,7 @@ class AccountRefreshService:
         apply_fallback=False — used by manual/on-demand paths: if API fails, return
                                failed=1 immediately without touching stored data.
         """
-        if record.is_deleted():
+        if record.is_deleted() or not _is_grok_pool(record):
             return RefreshResult()
 
         try:

--- a/app/control/model/registry.py
+++ b/app/control/model/registry.py
@@ -36,6 +36,13 @@ MODELS: tuple[ModelSpec, ...] = (
     # Super+（basic 池不支持此模式）
     ModelSpec("grok-4.3-beta",                          ModeId.GROK_4_3, Tier.SUPER, Capability.CHAT,       True, "Grok 4.3 Beta"),
 
+    # === xAI Grok Build OAuth (grok-cli / SuperGrok subscription) ==========
+    # OAuth tokens from auth.x.ai only cover Grok Build + Composer 2.5 Fast —
+    # not the full api.x.ai API-key catalog (grok-4, grok-3, etc.).
+    # grok-build-0.1 → api.x.ai /chat/completions ; composer → api.x.ai /responses.
+    ModelSpec("grok-build-0.1",         ModeId.AUTO, Tier.BASIC, Capability.CHAT, True, "Grok Build 0.1",         provider="xai"),
+    ModelSpec("grok-composer-2.5-fast", ModeId.AUTO, Tier.BASIC, Capability.CHAT, True, "Composer 2.5 Fast",      provider="xai"),
+
     # === Image ==============================================================
 
     # Basic fast

--- a/app/control/model/spec.py
+++ b/app/control/model/spec.py
@@ -20,6 +20,11 @@ class ModelSpec:
     ``public_name`` is the human-readable display name.
     ``prefer_best`` when True, reverses pool priority to try higher-tier
                     pools first (hard priority, not soft preference).
+    ``provider``    selects the upstream backend:
+                      "grok" — grok.com web reverse-proxy (SSO cookie tokens);
+                      "xai"  — official api.x.ai API (OAuth Bearer token).
+                    For ``provider="xai"`` the ``mode_id`` / ``tier`` fields are
+                    inert placeholders (xAI routing does not use grok pools).
     """
 
     model_name: str
@@ -29,11 +34,16 @@ class ModelSpec:
     enabled: bool
     public_name: str
     prefer_best: bool = False
+    provider: str = "grok"
 
     # --- convenience predicates ---
 
     def is_chat(self) -> bool:
         return bool(self.capability & Capability.CHAT)
+
+    def is_xai(self) -> bool:
+        """Return True if this model is served via the official api.x.ai API."""
+        return self.provider == "xai"
 
     def is_image(self) -> bool:
         return bool(self.capability & Capability.IMAGE)

--- a/app/control/xai/__init__.py
+++ b/app/control/xai/__init__.py
@@ -1,0 +1,11 @@
+"""xAI official-API OAuth provider.
+
+This package implements the "grok-cli / Grok Build" OAuth2 + PKCE flow against
+``auth.x.ai`` and the credential lifecycle for subscription models
+(``grok-build-0.1`` via ``/chat/completions``,
+``grok-composer-2.5-fast`` via ``/responses`` on api.x.ai).
+
+It is fully separate from the grok.com web reverse-proxy path: xAI accounts are
+stored with ``pool="xai"`` and excluded from grok selection / quota machinery
+(see ``app.dataplane.shared.enums.GROK_POOLS``).
+"""

--- a/app/control/xai/_http.py
+++ b/app/control/xai/_http.py
@@ -1,0 +1,142 @@
+"""Minimal curl_cffi HTTP helper for the xAI official API + OAuth endpoints.
+
+Unlike ``app.dataplane.reverse.transport.http`` (which injects grok.com headers
+and SSO cookies), these helpers send clean requests suitable for ``auth.x.ai``
+and ``api.x.ai`` with only the headers the caller provides.  An optional proxy
+lease is honoured via the shared ``build_session_kwargs`` builder.
+"""
+
+from typing import Any, AsyncGenerator
+
+import orjson
+
+from app.platform.errors import UpstreamError
+from app.control.proxy.models import ProxyLease
+from app.dataplane.proxy.adapters.session import build_session_kwargs
+
+
+def _session(lease: ProxyLease | None):
+    """Create a curl_cffi AsyncSession with proxy support (no grok headers)."""
+    from curl_cffi.requests import AsyncSession
+
+    kwargs = build_session_kwargs(lease=lease)
+    return AsyncSession(**kwargs)
+
+
+async def get_json(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    lease: ProxyLease | None = None,
+    timeout_s: float = 30.0,
+) -> dict[str, Any]:
+    """GET a URL and return parsed JSON, raising UpstreamError on non-2xx."""
+    async with _session(lease) as session:
+        try:
+            resp = await session.get(url, headers=headers, timeout=timeout_s)
+        except Exception as exc:  # noqa: BLE001 — wrap transport errors uniformly
+            raise UpstreamError(f"xAI GET failed: {exc}", status=502) from exc
+    if resp.status_code // 100 != 2:
+        body = _excerpt(resp)
+        raise UpstreamError(
+            f"xAI GET {url} returned {resp.status_code}",
+            status=resp.status_code,
+            body=body,
+        )
+    return orjson.loads(resp.content)
+
+
+async def post_form_json(
+    url: str,
+    form: dict[str, str],
+    *,
+    headers: dict[str, str] | None = None,
+    lease: ProxyLease | None = None,
+    timeout_s: float = 30.0,
+) -> dict[str, Any]:
+    """POST application/x-www-form-urlencoded data and return parsed JSON."""
+    hdrs = {"Content-Type": "application/x-www-form-urlencoded", **(headers or {})}
+    async with _session(lease) as session:
+        try:
+            resp = await session.post(url, data=form, headers=hdrs, timeout=timeout_s)
+        except Exception as exc:  # noqa: BLE001
+            raise UpstreamError(f"xAI POST failed: {exc}", status=502) from exc
+    if resp.status_code // 100 != 2:
+        body = _excerpt(resp)
+        raise UpstreamError(
+            f"xAI POST {url} returned {resp.status_code}",
+            status=resp.status_code,
+            body=body,
+        )
+    return orjson.loads(resp.content)
+
+
+async def post_json_raw(
+    url: str,
+    payload: bytes,
+    *,
+    headers: dict[str, str],
+    lease: ProxyLease | None = None,
+    timeout_s: float = 120.0,
+) -> dict[str, Any]:
+    """POST a raw JSON body and return parsed JSON (non-streaming)."""
+    async with _session(lease) as session:
+        try:
+            resp = await session.post(
+                url, data=payload, headers=headers, timeout=timeout_s
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise UpstreamError(f"xAI POST failed: {exc}", status=502) from exc
+        if resp.status_code // 100 != 2:
+            body = _excerpt(resp)
+            raise UpstreamError(
+                f"xAI POST {url} returned {resp.status_code}",
+                status=resp.status_code,
+                body=body,
+            )
+        return orjson.loads(resp.content)
+
+
+async def post_stream_raw(
+    url: str,
+    payload: bytes,
+    *,
+    headers: dict[str, str],
+    lease: ProxyLease | None = None,
+    timeout_s: float = 120.0,
+) -> AsyncGenerator[str, None]:
+    """POST a raw JSON body and yield SSE lines from the upstream response."""
+    async with _session(lease) as session:
+        try:
+            resp = await session.post(
+                url, data=payload, headers=headers, timeout=timeout_s, stream=True
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise UpstreamError(f"xAI POST failed: {exc}", status=502) from exc
+
+        if resp.status_code // 100 != 2:
+            try:
+                body = (await resp.acontent()).decode("utf-8", "replace")[:400]
+            except Exception:  # noqa: BLE001
+                body = ""
+            raise UpstreamError(
+                f"xAI stream {url} returned {resp.status_code}",
+                status=resp.status_code,
+                body=body,
+            )
+
+        try:
+            async for line in resp.aiter_lines():
+                yield line
+        except Exception as exc:  # noqa: BLE001
+            raise UpstreamError(f"xAI stream read failed: {exc}", status=502) from exc
+
+
+def _excerpt(resp, *, limit: int = 400) -> str:
+    try:
+        return resp.content.decode("utf-8", "replace")[:limit]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+__all__ = ["get_json", "post_form_json", "post_json_raw", "post_stream_raw"]

--- a/app/control/xai/account.py
+++ b/app/control/xai/account.py
@@ -1,0 +1,178 @@
+"""xAI account credential storage + single-account selection and refresh.
+
+xAI accounts are stored as ordinary ``AccountRecord`` rows with ``pool="xai"``
+and an ``ext`` dict carrying the OAuth payload.  They are excluded from the
+grok.com hot path (see ``app.dataplane.shared.enums.GROK_POOLS``).
+
+Per current scope only a SINGLE xAI account is used; selection just returns the
+first active xAI account.  Token refresh is lazy (before each request, with a
+5-minute lead) and guarded by a per-token lock to avoid duplicate refreshes.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from app.platform.logging.logger import logger
+from app.platform.runtime.clock import now_ms
+from app.control.account.commands import AccountPatch, AccountUpsert, ListAccountsQuery
+from app.control.account.enums import AccountStatus
+from app.control.account.models import AccountRecord
+from app.dataplane.proxy import get_proxy_runtime
+from . import oauth
+
+if TYPE_CHECKING:
+    from app.control.account.repository import AccountRepository
+
+XAI_POOL = "xai"
+XAI_TAG = "xai"
+
+# Per-token refresh locks (avoid concurrent refresh of the same account).
+_refresh_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(token: str) -> asyncio.Lock:
+    lock = _refresh_locks.get(token)
+    if lock is None:
+        lock = asyncio.Lock()
+        _refresh_locks[token] = lock
+    return lock
+
+
+def _synthetic_token(email: str | None, sub: str | None) -> str:
+    """Build the stable primary-key token for an xAI account.
+
+    Prefers ``xai:<sub>`` (stable across refreshes); falls back to email, then
+    a timestamp.  Never the access_token (which rotates on refresh).
+    """
+    if sub:
+        return f"xai:{sub}"
+    if email:
+        return f"xai:{email}"
+    return f"xai:{now_ms()}"
+
+
+def build_ext_from_token_response(
+    resp: dict,
+    *,
+    token_endpoint: str,
+    base_url: str,
+    email: str | None,
+    sub: str | None,
+    previous: dict | None = None,
+) -> dict:
+    """Build/merge the ``ext`` OAuth payload from a token-endpoint response."""
+    prev = dict(previous or {})
+    now = now_ms()
+    expires_in = int(resp.get("expires_in") or 0)
+    ext = {
+        **prev,
+        "provider": "xai",
+        "access_token": resp.get("access_token") or prev.get("access_token", ""),
+        "refresh_token": resp.get("refresh_token") or prev.get("refresh_token", ""),
+        "id_token": resp.get("id_token") or prev.get("id_token", ""),
+        "token_type": resp.get("token_type") or prev.get("token_type", "Bearer"),
+        "expires_at": now + expires_in * 1000 if expires_in else prev.get("expires_at"),
+        "base_url": base_url,
+        "token_endpoint": token_endpoint,
+        "last_refresh": now,
+    }
+    if email:
+        ext["email"] = email
+    if sub:
+        ext["sub"] = sub
+    return ext
+
+
+async def upsert_xai_account(
+    repo: "AccountRepository",
+    *,
+    ext: dict,
+    email: str | None,
+    sub: str | None,
+) -> str:
+    """Create or replace the xAI account; return its primary-key token."""
+    token = _synthetic_token(email, sub)
+    await repo.upsert_accounts(
+        [AccountUpsert(token=token, pool=XAI_POOL, tags=[XAI_TAG], ext=ext)]
+    )
+    logger.info("xai account saved: token={} email={}", token, email or "-")
+    return token
+
+
+async def list_xai_accounts(repo: "AccountRepository") -> list[AccountRecord]:
+    """Return all non-deleted xAI accounts."""
+    page = await repo.list_accounts(
+        ListAccountsQuery(pool=XAI_POOL, page=1, page_size=200)
+    )
+    return [r for r in page.items if not r.is_deleted()]
+
+
+async def get_xai_account(repo: "AccountRepository") -> AccountRecord | None:
+    """Return the active xAI account to use (single-account scope)."""
+    for record in await list_xai_accounts(repo):
+        if record.status == AccountStatus.ACTIVE:
+            return record
+    return None
+
+
+def _needs_refresh(ext: dict) -> bool:
+    expires_at = ext.get("expires_at")
+    if not expires_at:
+        return False  # unknown expiry — assume valid, let upstream 401 drive refresh
+    return now_ms() >= int(expires_at) - oauth.REFRESH_LEAD_MS
+
+
+async def ensure_fresh(
+    repo: "AccountRepository", account: AccountRecord
+) -> str:
+    """Return a valid access token, refreshing it first if near/after expiry."""
+    ext = dict(account.ext or {})
+    access_token = ext.get("access_token", "")
+
+    if not _needs_refresh(ext):
+        return access_token
+
+    refresh_token = ext.get("refresh_token", "")
+    token_endpoint = ext.get("token_endpoint") or oauth.DEFAULT_TOKEN_ENDPOINT
+    base_url = ext.get("base_url") or oauth.DEFAULT_API_BASE
+    if not refresh_token:
+        return access_token  # nothing to refresh with; let upstream reject
+
+    async with _lock_for(account.token):
+        # Re-read inside the lock: another coroutine may have refreshed already.
+        records = await repo.get_accounts([account.token])
+        cur_ext = dict(records[0].ext) if records else ext
+        if not _needs_refresh(cur_ext):
+            return cur_ext.get("access_token", access_token)
+
+        proxy = await get_proxy_runtime()
+        lease = await proxy.acquire()
+        resp = await oauth.refresh_tokens(
+            token_endpoint, cur_ext.get("refresh_token", refresh_token), lease=lease
+        )
+        email = cur_ext.get("email")
+        sub = cur_ext.get("sub")
+        new_ext = build_ext_from_token_response(
+            resp,
+            token_endpoint=token_endpoint,
+            base_url=base_url,
+            email=email,
+            sub=sub,
+            previous=cur_ext,
+        )
+        await repo.patch_accounts(
+            [AccountPatch(token=account.token, ext_merge=new_ext)]
+        )
+        logger.info("xai token refreshed: token={}", account.token)
+        return new_ext.get("access_token", access_token)
+
+
+__all__ = [
+    "XAI_POOL",
+    "XAI_TAG",
+    "build_ext_from_token_response",
+    "upsert_xai_account",
+    "list_xai_accounts",
+    "get_xai_account",
+    "ensure_fresh",
+]

--- a/app/control/xai/callback_parse.py
+++ b/app/control/xai/callback_parse.py
@@ -1,0 +1,43 @@
+"""Parse authorization codes from loopback callbacks or manual paste."""
+
+from urllib.parse import parse_qs, urlparse
+
+
+def parse_oauth_callback(
+    raw: str,
+    *,
+    expected_state: str | None = None,
+) -> tuple[str, str]:
+    """Return ``(code, state)`` from a callback URL, query string, or bare code.
+
+    Accepts:
+    - full URL: ``http://127.0.0.1:56121/callback?code=...&state=...``
+    - query fragment: ``?code=...&state=...`` or ``code=...&state=...``
+    - bare authorization code (requires *expected_state*)
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("回调内容为空")
+
+    if "://" in text:
+        parsed = urlparse(text)
+        qs = parse_qs(parsed.query, keep_blank_values=False)
+    elif text.startswith("?") or "code=" in text:
+        qs = parse_qs(text.lstrip("?"), keep_blank_values=False)
+    else:
+        if not expected_state:
+            raise ValueError("仅粘贴授权码时需要有效的登录会话，请先点击「登录 xAI」")
+        return text, expected_state
+
+    codes = qs.get("code") or []
+    states = qs.get("state") or []
+    if not codes or not str(codes[0]).strip():
+        raise ValueError("未找到 authorization code（code 参数）")
+    code = str(codes[0]).strip()
+    state = str(states[0]).strip() if states else (expected_state or "")
+    if not state:
+        raise ValueError("未找到 state 参数；请粘贴完整回调 URL")
+    return code, state
+
+
+__all__ = ["parse_oauth_callback"]

--- a/app/control/xai/constants.py
+++ b/app/control/xai/constants.py
@@ -1,0 +1,43 @@
+"""xAI OAuth constants (grok-cli / Grok Build public client)."""
+
+OAUTH_CALLBACK_HOST = "127.0.0.1"
+OAUTH_CALLBACK_PORT = 56121
+OAUTH_CALLBACK_PATH = "/callback"
+OAUTH_REDIRECT_URI = (
+    f"http://{OAUTH_CALLBACK_HOST}:{OAUTH_CALLBACK_PORT}{OAUTH_CALLBACK_PATH}"
+)
+
+# xAI's browser redirect may CORS-preflight the loopback URI; echo these origins.
+OAUTH_CORS_ORIGIN_ALLOWLIST = frozenset(
+    {"https://auth.x.ai", "https://accounts.x.ai"}
+)
+
+OAUTH_WAIT_TIMEOUT_S = 10 * 60
+
+# Grok-cli OAuth subscription models (not the full public api.x.ai catalog).
+GROK_BUILD_MODEL_IDS = frozenset({"grok-build-0.1"})
+GROK_COMPOSER_MODEL_IDS = frozenset({"grok-composer-2.5-fast"})
+XAI_OAUTH_MODEL_IDS = GROK_BUILD_MODEL_IDS | GROK_COMPOSER_MODEL_IDS
+
+DEFAULT_API_BASE = "https://api.x.ai/v1"
+
+
+def resolve_chat_base_url(model: str, *, api_base: str) -> str:
+    """Return the upstream base URL for an OAuth-entitled chat model."""
+    _ = model  # all OAuth models use api.x.ai (see CLIProxyAPI xai executor)
+    return api_base.rstrip("/")
+
+
+__all__ = [
+    "OAUTH_CALLBACK_HOST",
+    "OAUTH_CALLBACK_PORT",
+    "OAUTH_CALLBACK_PATH",
+    "OAUTH_REDIRECT_URI",
+    "OAUTH_CORS_ORIGIN_ALLOWLIST",
+    "OAUTH_WAIT_TIMEOUT_S",
+    "GROK_BUILD_MODEL_IDS",
+    "GROK_COMPOSER_MODEL_IDS",
+    "XAI_OAUTH_MODEL_IDS",
+    "DEFAULT_API_BASE",
+    "resolve_chat_base_url",
+]

--- a/app/control/xai/flow.py
+++ b/app/control/xai/flow.py
@@ -1,0 +1,70 @@
+"""Shared xAI OAuth completion (loopback + manual paste)."""
+
+from typing import TYPE_CHECKING
+
+from app.platform.errors import ValidationError
+from app.platform.logging.logger import logger
+from app.control.xai import account as xai_account
+from app.control.xai import oauth, pending
+from app.dataplane.proxy import get_proxy_runtime
+
+if TYPE_CHECKING:
+    from app.control.account.repository import AccountRepository
+
+
+async def finish_oauth(
+    repo: "AccountRepository",
+    *,
+    state: str,
+    code: str,
+) -> dict:
+    """Consume pending PKCE state, exchange the code, and persist the xAI account."""
+    pend = await pending.consume(repo, state)
+    if pend is None:
+        raise ValidationError(
+            "登录会话无效或已过期，请重新发起 xAI 登录。",
+            param="state",
+            code="oauth_state_invalid",
+        )
+
+    proxy = await get_proxy_runtime()
+    lease = await proxy.acquire()
+    try:
+        token_resp = await oauth.exchange_code(
+            pend["token_endpoint"],
+            code=code,
+            redirect_uri=pend["redirect_uri"],
+            code_verifier=pend["code_verifier"],
+            code_challenge=pend.get("code_challenge") or "",
+            lease=lease,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("xai oauth token exchange failed: error={}", exc)
+        raise ValidationError(
+            f"令牌交换失败：{exc}",
+            param="callback",
+            code="oauth_token_exchange_failed",
+        ) from exc
+
+    email, sub = oauth.parse_id_token(token_resp.get("id_token", ""))
+    ext = xai_account.build_ext_from_token_response(
+        token_resp,
+        token_endpoint=pend["token_endpoint"],
+        base_url=oauth.DEFAULT_API_BASE,
+        email=email,
+        sub=sub,
+    )
+    await xai_account.upsert_xai_account(repo, ext=ext, email=email, sub=sub)
+    removed = await pending.cleanup_all(repo)
+    if removed:
+        logger.debug("xai oauth cleared stale pending rows: count={}", removed)
+    logger.info("xai oauth completed: email={} sub={}", email or "-", sub or "-")
+    return {
+        "status": "ok",
+        "email": email,
+        "sub": sub,
+        "message": f"已成功登录并保存 xAI 账号：{email or sub or '(未知)'}",
+    }
+
+
+__all__ = ["finish_oauth"]

--- a/app/control/xai/loopback.py
+++ b/app/control/xai/loopback.py
@@ -1,0 +1,220 @@
+"""Local loopback OAuth callback server (127.0.0.1:56121/callback)."""
+
+import asyncio
+from urllib.parse import parse_qs, urlparse
+
+from app.platform.logging.logger import logger
+
+from .constants import (
+    OAUTH_CALLBACK_HOST,
+    OAUTH_CALLBACK_PATH,
+    OAUTH_CALLBACK_PORT,
+    OAUTH_CORS_ORIGIN_ALLOWLIST,
+    OAUTH_WAIT_TIMEOUT_S,
+)
+
+_SUCCESS_HTML = """<!doctype html><html lang="zh"><head><meta charset="utf-8">
+<title>xAI 登录成功</title><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{font-family:system-ui,sans-serif;background:#0b0f17;color:#e5e7eb;
+display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+.card{background:#111827;border:1px solid #1f2937;border-radius:14px;padding:32px 40px;
+max-width:440px;text-align:center}.t{color:#16a34a;font-size:20px;font-weight:600}
+.m{color:#9ca3af;font-size:14px;margin-top:8px;line-height:1.6}</style></head>
+<body><div class="card"><div class="t">xAI 授权成功</div>
+<div class="m">可以关闭此页面并返回 grok2api 管理后台。</div></div></body></html>"""
+
+_FAIL_HTML = """<!doctype html><html lang="zh"><head><meta charset="utf-8">
+<title>xAI 登录失败</title></head><body style="font-family:system-ui;background:#0b0f17;
+color:#e5e7eb;text-align:center;padding:40px"><h2 style="color:#dc2626">xAI 授权失败</h2>
+<p style="color:#9ca3af">{message}</p></body></html>"""
+
+
+class LoopbackOAuthServer:
+    """Singleton loopback listener for the grok-cli registered redirect URI."""
+
+    def __init__(self) -> None:
+        self._server: asyncio.Server | None = None
+        self._waiters: dict[str, asyncio.Future[str]] = {}
+        self._start_lock = asyncio.Lock()
+
+    def register(self, state: str) -> asyncio.Future[str]:
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[str] = loop.create_future()
+        self._waiters[state] = fut
+        return fut
+
+    def cancel_waiter(self, state: str) -> None:
+        fut = self._waiters.pop(state, None)
+        if fut is not None and not fut.done():
+            fut.cancel()
+
+    def _resolve(self, state: str, code: str) -> bool:
+        fut = self._waiters.pop(state, None)
+        if fut is None or fut.done():
+            return False
+        fut.set_result(code)
+        return True
+
+    async def ensure_started(self) -> bool:
+        async with self._start_lock:
+            if self._server is not None:
+                return True
+            try:
+                self._server = await asyncio.start_server(
+                    self._handle_connection,
+                    OAUTH_CALLBACK_HOST,
+                    OAUTH_CALLBACK_PORT,
+                )
+                logger.info(
+                    "xai oauth loopback listening: {}",
+                    f"http://{OAUTH_CALLBACK_HOST}:{OAUTH_CALLBACK_PORT}{OAUTH_CALLBACK_PATH}",
+                )
+                return True
+            except OSError as exc:
+                logger.warning("xai oauth loopback unavailable: error={}", exc)
+                return False
+
+    async def wait_for_code(self, state: str) -> str:
+        fut = self.register(state)
+        return await asyncio.wait_for(fut, timeout=OAUTH_WAIT_TIMEOUT_S)
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            request_line = (await reader.readline()).decode("utf-8", errors="replace").strip()
+            if not request_line:
+                return
+            parts = request_line.split()
+            if len(parts) < 2:
+                return
+            method, target = parts[0].upper(), parts[1]
+
+            headers: dict[str, str] = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                decoded = line.decode("utf-8", errors="replace").strip()
+                if ":" in decoded:
+                    key, value = decoded.split(":", 1)
+                    headers[key.strip().lower()] = value.strip()
+
+            parsed = urlparse(target)
+            path = parsed.path or "/"
+            origin = headers.get("origin", "")
+
+            if method == "OPTIONS" and path == OAUTH_CALLBACK_PATH:
+                await self._write_response(
+                    writer,
+                    status=204,
+                    headers=self._cors_headers(origin),
+                    body=b"",
+                )
+                return
+
+            if method != "GET" or path != OAUTH_CALLBACK_PATH:
+                await self._write_response(
+                    writer,
+                    status=404,
+                    headers={"Content-Type": "text/plain"},
+                    body=b"Not Found",
+                )
+                return
+
+            qs = parse_qs(parsed.query, keep_blank_values=False)
+            if qs.get("error"):
+                err = (qs.get("error_description") or qs.get("error") or ["unknown"])[0]
+                await self._write_response(
+                    writer,
+                    status=400,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
+                    body=_FAIL_HTML.format(message=err).encode("utf-8"),
+                )
+                return
+
+            codes = qs.get("code") or []
+            states = qs.get("state") or []
+            if not codes or not states:
+                await self._write_response(
+                    writer,
+                    status=400,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
+                    body=_FAIL_HTML.format(message="缺少 code 或 state 参数").encode("utf-8"),
+                )
+                return
+
+            code = str(codes[0]).strip()
+            state = str(states[0]).strip()
+            if not self._resolve(state, code):
+                await self._write_response(
+                    writer,
+                    status=400,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
+                    body=_FAIL_HTML.format(
+                        message="登录会话无效或已过期，请回到管理后台重新发起登录。"
+                    ).encode("utf-8"),
+                )
+                return
+
+            await self._write_response(
+                writer,
+                status=200,
+                headers={"Content-Type": "text/html; charset=utf-8"},
+                body=_SUCCESS_HTML.encode("utf-8"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("xai oauth loopback handler error: {}", exc)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _cors_headers(origin: str) -> dict[str, str]:
+        if origin in OAUTH_CORS_ORIGIN_ALLOWLIST:
+            return {
+                "Access-Control-Allow-Origin": origin,
+                "Access-Control-Allow-Methods": "GET, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Vary": "Origin",
+            }
+        return {}
+
+    @staticmethod
+    async def _write_response(
+        writer: asyncio.StreamWriter,
+        *,
+        status: int,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> None:
+        reason = {200: "OK", 204: "No Content", 400: "Bad Request", 404: "Not Found"}.get(
+            status, "OK"
+        )
+        lines = [f"HTTP/1.1 {status} {reason}"]
+        headers = dict(headers)
+        if body:
+            headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+            headers["Content-Length"] = str(len(body))
+        elif status == 204:
+            headers.pop("Content-Type", None)
+        for key, value in headers.items():
+            lines.append(f"{key}: {value}")
+        lines.append("")
+        writer.write("\r\n".join(lines).encode("utf-8") + body)
+        await writer.drain()
+
+
+_loopback = LoopbackOAuthServer()
+
+
+def get_loopback() -> LoopbackOAuthServer:
+    return _loopback
+
+
+__all__ = ["LoopbackOAuthServer", "get_loopback"]

--- a/app/control/xai/oauth.py
+++ b/app/control/xai/oauth.py
@@ -1,0 +1,194 @@
+"""xAI OAuth2 + PKCE core logic.
+
+Ports CLIProxyAPI's ``internal/auth/xai`` (discovery, authorize URL, token
+exchange, refresh, id_token parsing).  All outbound HTTP goes through
+``_http`` (curl_cffi, proxy-aware).  No FastAPI dependencies here.
+"""
+
+import base64
+import binascii
+from urllib.parse import urlencode, urlparse
+
+import orjson
+
+from app.platform.config.snapshot import get_config
+from app.platform.errors import UpstreamError
+from app.control.proxy.models import ProxyLease
+from . import _http
+from .constants import DEFAULT_API_BASE, OAUTH_REDIRECT_URI
+
+# ---------------------------------------------------------------------------
+# Constants (the public grok-cli OAuth client)
+# ---------------------------------------------------------------------------
+
+DEFAULT_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+SCOPE = "openid profile email offline_access grok-cli:access api:access"
+ISSUER = "https://auth.x.ai"
+DISCOVERY_URL = "https://auth.x.ai/.well-known/openid-configuration"
+DEFAULT_TOKEN_ENDPOINT = "https://auth.x.ai/oauth/token"
+
+# Refresh tokens this many milliseconds before the recorded expiry.
+REFRESH_LEAD_MS = 5 * 60 * 1000
+
+
+def client_id() -> str:
+    """Return the configured OAuth client id (falls back to the public id)."""
+    return get_config().get_str("xai.client_id", "") or DEFAULT_CLIENT_ID
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_xai_url(url: str, *, field: str) -> str:
+    """Ensure *url* is HTTPS and on the x.ai domain; return it unchanged."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise UpstreamError(f"xAI {field} must be HTTPS: {url!r}", status=502)
+    host = (parsed.hostname or "").lower()
+    if host != "x.ai" and not host.endswith(".x.ai"):
+        raise UpstreamError(
+            f"xAI {field} must be on the x.ai domain: {url!r}", status=502
+        )
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+async def discover(*, lease: ProxyLease | None = None) -> tuple[str, str]:
+    """Return ``(authorization_endpoint, token_endpoint)`` from discovery."""
+    doc = await _http.get_json(DISCOVERY_URL, lease=lease)
+    auth_ep = doc.get("authorization_endpoint")
+    token_ep = doc.get("token_endpoint")
+    if not auth_ep or not token_ep:
+        raise UpstreamError("xAI discovery missing endpoints", status=502)
+    return (
+        _validate_xai_url(auth_ep, field="authorization_endpoint"),
+        _validate_xai_url(token_ep, field="token_endpoint"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authorize URL
+# ---------------------------------------------------------------------------
+
+
+def build_authorize_url(
+    authorization_endpoint: str,
+    *,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    nonce: str,
+) -> str:
+    """Build the browser authorize URL with all required OAuth params."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id(),
+        "redirect_uri": redirect_uri,
+        "scope": SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "nonce": nonce,
+        "plan": "generic",
+        "referrer": "grok2api",
+    }
+    sep = "&" if "?" in authorization_endpoint else "?"
+    return f"{authorization_endpoint}{sep}{urlencode(params)}"
+
+
+# ---------------------------------------------------------------------------
+# Token exchange / refresh
+# ---------------------------------------------------------------------------
+
+
+async def exchange_code(
+    token_endpoint: str,
+    *,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    code_challenge: str = "",
+    lease: ProxyLease | None = None,
+) -> dict:
+    """Exchange an authorization code for tokens (authorization_code grant)."""
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": client_id(),
+        "code_verifier": code_verifier,
+    }
+    # xAI re-validates PKCE challenge fields for the grok-cli public client.
+    if code_challenge:
+        form["code_challenge"] = code_challenge
+        form["code_challenge_method"] = "S256"
+    return await _http.post_form_json(token_endpoint, form, lease=lease)
+
+
+async def refresh_tokens(
+    token_endpoint: str,
+    refresh_token: str,
+    *,
+    lease: ProxyLease | None = None,
+) -> dict:
+    """Exchange a refresh token for a new access token (refresh_token grant)."""
+    form = {
+        "grant_type": "refresh_token",
+        "client_id": client_id(),
+        "refresh_token": refresh_token,
+    }
+    return await _http.post_form_json(token_endpoint, form, lease=lease)
+
+
+# ---------------------------------------------------------------------------
+# id_token parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_id_token(id_token: str) -> tuple[str | None, str | None]:
+    """Return ``(email, sub)`` extracted from a JWT id_token payload.
+
+    Does NOT verify the signature (the token came directly from the trusted
+    token endpoint over TLS); only decodes the middle (payload) segment.
+    """
+    if not id_token:
+        return None, None
+    parts = id_token.split(".")
+    if len(parts) < 2:
+        return None, None
+    payload_seg = parts[1]
+    # Restore base64url padding.
+    padding = "=" * (-len(payload_seg) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(payload_seg + padding)
+        claims = orjson.loads(raw)
+    except (binascii.Error, ValueError, orjson.JSONDecodeError):
+        return None, None
+    email = claims.get("email")
+    sub = claims.get("sub")
+    return (email if isinstance(email, str) else None,
+            sub if isinstance(sub, str) else None)
+
+
+__all__ = [
+    "DEFAULT_CLIENT_ID",
+    "DEFAULT_API_BASE",
+    "DEFAULT_TOKEN_ENDPOINT",
+    "REFRESH_LEAD_MS",
+    "SCOPE",
+    "ISSUER",
+    "DISCOVERY_URL",
+    "OAUTH_REDIRECT_URI",
+    "client_id",
+    "discover",
+    "build_authorize_url",
+    "exchange_code",
+    "refresh_tokens",
+    "parse_id_token",
+]

--- a/app/control/xai/pending.py
+++ b/app/control/xai/pending.py
@@ -1,0 +1,135 @@
+"""Transient OAuth pending-state store, shared across workers.
+
+The start→callback round-trip must carry the PKCE ``code_verifier`` and the
+``state`` nonce.  Because the server may run multiple workers (the callback can
+land on a different worker than ``start``), the pending state is persisted in
+the account repository under a reserved non-grok pool so it is shared and
+single-use.  The reserved pool is excluded from grok selection / quota machinery
+by the ``GROK_POOLS`` guard.
+"""
+
+import secrets
+from typing import TYPE_CHECKING
+
+from app.platform.runtime.clock import now_ms
+from app.control.account.commands import AccountUpsert, ListAccountsQuery
+
+if TYPE_CHECKING:
+    from app.control.account.repository import AccountRepository
+
+PENDING_POOL = "_xai_oauth_pending"
+_TTL_MS = 10 * 60 * 1000  # pending states expire after 10 minutes
+_TOKEN_PREFIX = "oauthpending:"
+
+
+def is_internal_record(record) -> bool:
+    """Return True for transient OAuth rows that must not appear in admin lists."""
+    token = getattr(record, "token", "") or ""
+    pool = getattr(record, "pool", "") or ""
+    return pool == PENDING_POOL or token.startswith(_TOKEN_PREFIX)
+
+
+def new_state() -> str:
+    """Return a fresh URL-safe, ASCII-only state/nonce value."""
+    return secrets.token_urlsafe(32)
+
+
+def _token_for(state: str) -> str:
+    return f"{_TOKEN_PREFIX}{state}"
+
+
+async def save(
+    repo: "AccountRepository",
+    *,
+    state: str,
+    code_verifier: str,
+    code_challenge: str,
+    token_endpoint: str,
+    redirect_uri: str,
+) -> None:
+    """Persist a pending OAuth state (single-use, TTL-bounded)."""
+    await repo.upsert_accounts(
+        [
+            AccountUpsert(
+                token=_token_for(state),
+                pool=PENDING_POOL,
+                ext={
+                    "code_verifier": code_verifier,
+                    "code_challenge": code_challenge,
+                    "token_endpoint": token_endpoint,
+                    "redirect_uri": redirect_uri,
+                    "created_at": now_ms(),
+                },
+            )
+        ]
+    )
+
+
+async def exists(repo: "AccountRepository", state: str) -> bool:
+    """Return whether a non-expired pending OAuth state is still stored."""
+    if not state:
+        return False
+    records = await repo.get_accounts([_token_for(state)])
+    record = records[0] if records else None
+    if record is None or record.is_deleted():
+        return False
+    created = int((record.ext or {}).get("created_at") or 0)
+    return not created or now_ms() - created <= _TTL_MS
+
+
+async def consume(repo: "AccountRepository", state: str) -> dict | None:
+    """Validate and atomically consume a pending state; return its ext or None."""
+    if not state:
+        return None
+    token = _token_for(state)
+    records = await repo.get_accounts([token])
+    record = records[0] if records else None
+    if record is None or record.is_deleted():
+        return None
+    # Single-use: delete immediately regardless of validity.
+    await repo.delete_accounts([token])
+    ext = dict(record.ext or {})
+    created = int(ext.get("created_at") or 0)
+    if created and now_ms() - created > _TTL_MS:
+        return None
+    return ext
+
+
+async def cleanup_all(repo: "AccountRepository") -> int:
+    """Remove every in-flight OAuth pending row (e.g. after a successful login)."""
+    page = await repo.list_accounts(
+        ListAccountsQuery(pool=PENDING_POOL, page=1, page_size=200)
+    )
+    tokens = [r.token for r in page.items if not r.is_deleted()]
+    if tokens:
+        await repo.delete_accounts(tokens)
+    return len(tokens)
+
+
+async def cleanup_expired(repo: "AccountRepository") -> int:
+    """Best-effort sweep of expired pending states. Returns count removed."""
+    page = await repo.list_accounts(
+        ListAccountsQuery(pool=PENDING_POOL, page=1, page_size=200)
+    )
+    now = now_ms()
+    stale = [
+        r.token
+        for r in page.items
+        if not r.is_deleted()
+        and now - int((r.ext or {}).get("created_at") or 0) > _TTL_MS
+    ]
+    if stale:
+        await repo.delete_accounts(stale)
+    return len(stale)
+
+
+__all__ = [
+    "PENDING_POOL",
+    "new_state",
+    "save",
+    "exists",
+    "consume",
+    "is_internal_record",
+    "cleanup_all",
+    "cleanup_expired",
+]

--- a/app/control/xai/pkce.py
+++ b/app/control/xai/pkce.py
@@ -1,0 +1,26 @@
+"""PKCE (RFC 7636) code generation for the xAI OAuth flow.
+
+Mirrors CLIProxyAPI's ``internal/auth/xai/pkce.go``:
+  - verifier  = base64url(96 random bytes)
+  - challenge = base64url(SHA256(verifier))
+"""
+
+import base64
+import hashlib
+import os
+
+
+def _b64url(raw: bytes) -> str:
+    """Base64-URL encode without padding (per RFC 7636)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return a ``(code_verifier, code_challenge)`` pair using the S256 method."""
+    verifier = _b64url(os.urandom(96))
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = _b64url(digest)
+    return verifier, challenge
+
+
+__all__ = ["generate_pkce"]

--- a/app/control/xai/responses_chat.py
+++ b/app/control/xai/responses_chat.py
@@ -1,0 +1,279 @@
+"""OpenAI Chat Completions ↔ xAI Responses API conversions (OAuth)."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, AsyncGenerator
+
+import orjson
+
+from app.control.xai.constants import GROK_COMPOSER_MODEL_IDS
+
+
+def uses_responses_api(model: str) -> bool:
+    """Models that must call ``/responses`` on api.x.ai (not ``/chat/completions``)."""
+    return model in GROK_COMPOSER_MODEL_IDS
+
+
+def _content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            kind = part.get("type") or ""
+            if kind in ("text", "input_text", "output_text"):
+                parts.append(str(part.get("text") or ""))
+        return "\n".join(parts)
+    return str(content)
+
+
+def messages_to_responses_body(
+    *,
+    model: str,
+    messages: list[dict],
+    stream: bool,
+    temperature: float,
+    top_p: float,
+) -> dict[str, Any]:
+    """Build an xAI Responses request body from Chat Completions messages."""
+    instructions: str | None = None
+    input_items: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = str(msg.get("role") or "user")
+        text = _content_to_text(msg.get("content"))
+        if role == "system":
+            instructions = f"{instructions}\n\n{text}".strip() if instructions else text
+            continue
+        if role == "developer":
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": text}],
+                }
+            )
+        elif role == "user":
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                }
+            )
+        elif role == "assistant":
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": text}],
+                }
+            )
+        elif role == "tool":
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(msg.get("tool_call_id") or ""),
+                    "output": text,
+                }
+            )
+
+    body: dict[str, Any] = {
+        "model": model,
+        "stream": stream,
+        "temperature": temperature,
+        "top_p": top_p,
+        "store": False,
+        "parallel_tool_calls": True,
+    }
+    if instructions:
+        body["instructions"] = instructions
+
+    if len(input_items) == 1 and input_items[0].get("role") == "user":
+        body["input"] = input_items[0]["content"][0]["text"]
+    elif input_items:
+        body["input"] = input_items
+    else:
+        body["input"] = ""
+
+    return body
+
+
+def _extract_output_text(data: dict[str, Any]) -> tuple[str, str]:
+    content = ""
+    reasoning = ""
+    for item in data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("type")
+        if kind == "message":
+            for part in item.get("content") or []:
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    content += str(part.get("text") or "")
+        elif kind == "reasoning":
+            for part in item.get("summary") or []:
+                if isinstance(part, dict) and part.get("type") == "summary_text":
+                    reasoning += str(part.get("text") or "")
+
+    if not content.strip() and reasoning.strip():
+        head = reasoning.split("\n\n", 1)[0].strip()
+        content = head or reasoning
+    return content, reasoning
+
+
+def _map_usage(usage: dict[str, Any]) -> dict[str, Any]:
+    if not usage:
+        return {}
+    out: dict[str, Any] = {
+        "prompt_tokens": usage.get("input_tokens", 0),
+        "completion_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("total_tokens", 0),
+    }
+    in_details = usage.get("input_tokens_details") or {}
+    out_details = usage.get("output_tokens_details") or {}
+    if in_details or out_details:
+        out["prompt_tokens_details"] = {
+            "cached_tokens": in_details.get("cached_tokens", 0),
+        }
+        out["completion_tokens_details"] = {
+            "reasoning_tokens": out_details.get("reasoning_tokens", 0),
+        }
+    return out
+
+
+def responses_to_chat_completion(data: dict[str, Any], *, model: str) -> dict[str, Any]:
+    """Convert a completed xAI Responses payload to Chat Completions JSON."""
+    content, reasoning = _extract_output_text(data)
+    message: dict[str, Any] = {"role": "assistant", "content": content or None}
+    if reasoning.strip():
+        message["reasoning_content"] = reasoning
+
+    resp_id = str(data.get("id") or uuid.uuid4())
+    created = int(data.get("created_at") or time.time())
+    usage = _map_usage(data.get("usage") or {})
+    meta = data.get("metadata") or {}
+
+    return {
+        "id": resp_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": usage,
+        "system_fingerprint": meta.get("system_fingerprint"),
+        "service_tier": data.get("service_tier") or "default",
+    }
+
+
+def _chat_chunk(
+    *,
+    chunk_id: str,
+    model: str,
+    created: int,
+    delta: dict[str, Any],
+    finish_reason: str | None = None,
+    usage: dict[str, Any] | None = None,
+) -> str:
+    choice: dict[str, Any] = {"index": 0, "delta": delta}
+    if finish_reason is not None:
+        choice["finish_reason"] = finish_reason
+    payload: dict[str, Any] = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [choice],
+    }
+    if usage:
+        payload["usage"] = usage
+    return f"data: {orjson.dumps(payload).decode()}\n\n"
+
+
+async def translate_responses_stream_to_chat(
+    lines: AsyncGenerator[str, None],
+    *,
+    model: str,
+) -> AsyncGenerator[str, None]:
+    """Translate xAI Responses SSE into OpenAI Chat Completions SSE."""
+    chunk_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+    created = int(time.time())
+    role_sent = False
+
+    async for line in lines:
+        if isinstance(line, bytes):
+            raw = line.decode("utf-8", "replace").strip()
+        else:
+            raw = str(line).strip()
+        if not raw:
+            continue
+        if raw.startswith("event:"):
+            continue
+        if not raw.startswith("data:"):
+            continue
+        data_str = raw[5:].strip()
+        if data_str == "[DONE]":
+            yield "data: [DONE]\n\n"
+            continue
+        try:
+            event = orjson.loads(data_str)
+        except orjson.JSONDecodeError:
+            continue
+
+        etype = event.get("type")
+        delta: dict[str, Any] = {}
+        if etype == "response.created":
+            resp = event.get("response") or {}
+            if resp.get("id"):
+                chunk_id = str(resp["id"])
+            continue
+        if etype == "response.output_text.delta":
+            delta["content"] = event.get("delta") or ""
+        elif etype == "response.reasoning_text.delta":
+            delta["reasoning_content"] = event.get("delta") or ""
+        elif etype == "response.completed":
+            resp = event.get("response") or {}
+            usage = _map_usage(resp.get("usage") or {})
+            if not role_sent:
+                delta["role"] = "assistant"
+            yield _chat_chunk(
+                chunk_id=chunk_id,
+                model=model,
+                created=created,
+                delta=delta or {"role": "assistant"},
+                finish_reason="stop",
+                usage=usage or None,
+            )
+            yield "data: [DONE]\n\n"
+            return
+
+        if not delta:
+            continue
+        if not role_sent:
+            delta["role"] = "assistant"
+            role_sent = True
+        yield _chat_chunk(
+            chunk_id=chunk_id,
+            model=model,
+            created=created,
+            delta=delta,
+        )
+
+
+__all__ = [
+    "uses_responses_api",
+    "messages_to_responses_body",
+    "responses_to_chat_completion",
+    "translate_responses_stream_to_chat",
+]

--- a/app/control/xai/sessions.py
+++ b/app/control/xai/sessions.py
@@ -1,0 +1,28 @@
+"""In-memory OAuth session outcomes for admin UI polling (single-worker friendly)."""
+
+from typing import Any
+
+_outcomes: dict[str, dict[str, Any]] = {}
+
+
+def set_outcome(state: str, *, status: str, message: str = "", email: str | None = None) -> None:
+    _outcomes[state] = {
+        "status": status,
+        "message": message,
+        **({"email": email} if email else {}),
+    }
+
+
+def peek_outcome(state: str) -> dict[str, Any] | None:
+    return _outcomes.get(state)
+
+
+def pop_outcome(state: str) -> dict[str, Any] | None:
+    return _outcomes.pop(state, None)
+
+
+def clear_outcome(state: str) -> None:
+    _outcomes.pop(state, None)
+
+
+__all__ = ["set_outcome", "peek_outcome", "pop_outcome", "clear_outcome"]

--- a/app/dataplane/account/sync.py
+++ b/app/dataplane/account/sync.py
@@ -11,8 +11,18 @@ from app.control.account.models import AccountRecord
 from app.control.account.quota_defaults import normalize_quota_set
 from app.control.account.repository import AccountRepository
 from app.control.account.state_machine import derive_status
-from ..shared.enums import POOL_STR_TO_ID, STATUS_STR_TO_ID, StatusId
+from ..shared.enums import GROK_POOLS, POOL_STR_TO_ID, STATUS_STR_TO_ID, StatusId
 from .table import AccountRuntimeTable, make_empty_table
+
+
+def _is_grok_pool(record: AccountRecord) -> bool:
+    """Return True if *record* belongs to the grok.com reverse-proxy machinery.
+
+    Accounts in non-grok pools (e.g. ``"xai"`` for the official api.x.ai OAuth
+    provider) are excluded from the hot-path runtime table so they are never
+    selected for grok.com chat requests.
+    """
+    return record.pool in GROK_POOLS
 
 
 def _record_to_slot_args(record: AccountRecord) -> dict:
@@ -75,7 +85,7 @@ async def bootstrap(repository: AccountRepository) -> AccountRuntimeTable:
     _tags_by_token: dict[str, list[str]] = {}
 
     for record in snapshot.items:
-        if record.is_deleted():
+        if record.is_deleted() or not _is_grok_pool(record):
             continue
         args = _record_to_slot_args(record)
         tags = args.pop("tags")
@@ -116,8 +126,9 @@ async def apply_changes(
                 changed = True
 
         for record in changeset.items:
-            if record.is_deleted():
-                # Handle soft-delete from items list too.
+            if record.is_deleted() or not _is_grok_pool(record):
+                # Soft-deleted records, or records that moved to a non-grok pool
+                # (e.g. "xai"), are removed from the hot-path table.
                 idx = table.idx_by_token.get(record.token)
                 if idx is not None:
                     table._remove_from_indexes(idx)

--- a/app/dataplane/shared/enums.py
+++ b/app/dataplane/shared/enums.py
@@ -38,6 +38,11 @@ POOL_STR_TO_ID: dict[str, int] = {
 
 POOL_ID_TO_STR: dict[int, str] = {v: k for k, v in POOL_STR_TO_ID.items()}
 
+# Pools that participate in the grok.com reverse-proxy hot path (selection,
+# runtime table, quota probing).  Accounts in other pools (e.g. "xai", which
+# use the official api.x.ai OAuth provider) must be excluded from this machinery.
+GROK_POOLS: frozenset[str] = frozenset(POOL_STR_TO_ID.keys())
+
 STATUS_STR_TO_ID: dict[str, int] = {
     "active": int(StatusId.ACTIVE),
     "cooling": int(StatusId.COOLING),
@@ -59,6 +64,7 @@ __all__ = [
     "StatusId",
     "POOL_STR_TO_ID",
     "POOL_ID_TO_STR",
+    "GROK_POOLS",
     "STATUS_STR_TO_ID",
     "ALL_MODE_IDS",
 ]

--- a/app/products/openai/router.py
+++ b/app/products/openai/router.py
@@ -49,6 +49,10 @@ async def _available_pools(request: Request) -> frozenset[str]:
 def _model_available_for_pools(spec: ModelSpec, pools: frozenset[str]) -> bool:
     if not spec.enabled:
         return False
+    # xAI-provider models are available whenever an active xAI account exists
+    # (pool="xai"); they do not use grok pools / modes.
+    if spec.is_xai():
+        return "xai" in pools
     for pool_id in spec.pool_candidates():
         pool = _POOL_ID_TO_NAME[pool_id]
         if pool in pools and supports_mode(pool, int(spec.mode_id)):
@@ -213,7 +217,7 @@ async def _upload_to_data_uri(upload: UploadFile, *, param: str) -> str:
 @router.post(
     "/chat/completions", tags=[_TAG_CHAT], dependencies=[Depends(verify_api_key)]
 )
-async def chat_completions_endpoint(req: ChatCompletionRequest):
+async def chat_completions_endpoint(req: ChatCompletionRequest, request: Request):
     _validate_chat(req)
     from app.platform.config.snapshot import get_config
 
@@ -232,8 +236,23 @@ async def chat_completions_endpoint(req: ChatCompletionRequest):
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
 
     try:
-        # Dispatch by model capability.
-        if spec.is_image_edit():
+        # Dispatch by provider first: xAI models use the official api.x.ai API.
+        if spec.is_xai():
+            from .xai_chat import completions as xai_completions
+
+            result = await xai_completions(
+                request.app.state.repository,
+                model=req.model,
+                messages=messages,
+                stream=is_stream,
+                temperature=req.temperature or 0.8,
+                top_p=req.top_p or 0.95,
+                tools=req.tools,
+                tool_choice=req.tool_choice,
+            )
+
+        # Otherwise dispatch by model capability (grok.com reverse-proxy).
+        elif spec.is_image_edit():
             from .images import edit as img_edit
 
             cfg = req.image_config or ImageConfig()

--- a/app/products/openai/xai_chat.py
+++ b/app/products/openai/xai_chat.py
@@ -1,0 +1,163 @@
+"""Chat completions via Grok Build OAuth (api.x.ai + CLI proxy).
+
+Uses the grok-cli OAuth Bearer token.  Only subscription-entitled models are
+accepted (see ``app.control.xai.constants.XAI_OAUTH_MODEL_IDS``).
+"""
+
+from typing import Any, AsyncGenerator
+
+import orjson
+
+from app.platform.config.snapshot import get_config
+from app.platform.errors import RateLimitError, UpstreamError, ValidationError
+from app.platform.logging.logger import logger
+from app.control.account.repository import AccountRepository
+from app.control.xai import account as xai_account
+from app.control.xai.constants import (
+    DEFAULT_API_BASE,
+    XAI_OAUTH_MODEL_IDS,
+    resolve_chat_base_url,
+)
+from app.control.xai import _http
+from app.control.xai.responses_chat import (
+    messages_to_responses_body,
+    responses_to_chat_completion,
+    translate_responses_stream_to_chat,
+    uses_responses_api,
+)
+from app.dataplane.proxy import get_proxy_runtime
+
+
+def _validate_model(model: str) -> None:
+    if model not in XAI_OAUTH_MODEL_IDS:
+        allowed = ", ".join(sorted(XAI_OAUTH_MODEL_IDS))
+        raise ValidationError(
+            f"Model {model!r} is not available via Grok Build OAuth. "
+            f"Allowed models: {allowed}. "
+            "Use an API key (XAI_API_KEY) for other api.x.ai models.",
+            param="model",
+            code="xai_oauth_model_not_allowed",
+        )
+
+
+def _build_body(
+    *,
+    model: str,
+    messages: list[dict],
+    stream: bool,
+    temperature: float,
+    top_p: float,
+    tools: list[dict] | None,
+    tool_choice: Any,
+) -> dict:
+    """Build the chat-completions request body (OpenAI-compatible)."""
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "stream": stream,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if tools:
+        body["tools"] = tools
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    return body
+
+
+async def completions(
+    repo: AccountRepository,
+    *,
+    model: str,
+    messages: list[dict],
+    stream: bool,
+    temperature: float = 0.8,
+    top_p: float = 0.95,
+    tools: list[dict] | None = None,
+    tool_choice: Any = None,
+) -> dict | AsyncGenerator[str, None]:
+    """Forward a chat request using the Grok Build OAuth account."""
+    cfg = get_config()
+    if not cfg.get_bool("xai.enabled", True):
+        raise RateLimitError("xAI provider is disabled")
+
+    _validate_model(model)
+
+    account = await xai_account.get_xai_account(repo)
+    if account is None:
+        raise RateLimitError(
+            "No xAI account available — log in via the admin panel first"
+        )
+
+    access_token = await xai_account.ensure_fresh(repo, account)
+    if not access_token:
+        raise UpstreamError("xAI account has no usable access token", status=401)
+
+    api_base = cfg.get_str("xai.base_url", "") or DEFAULT_API_BASE
+    base_url = resolve_chat_base_url(
+        model,
+        api_base=(account.ext or {}).get("base_url") or api_base,
+    )
+    via_responses = uses_responses_api(model)
+    path = "/responses" if via_responses else "/chat/completions"
+    url = base_url.rstrip("/") + path
+    timeout_s = cfg.get_float("xai.timeout", 120.0)
+
+    if via_responses:
+        body = messages_to_responses_body(
+            model=model,
+            messages=messages,
+            stream=stream,
+            temperature=temperature,
+            top_p=top_p,
+        )
+    else:
+        body = _build_body(
+            model=model,
+            messages=messages,
+            stream=stream,
+            temperature=temperature,
+            top_p=top_p,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+    payload = orjson.dumps(body)
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream" if stream else "application/json",
+    }
+
+    proxy = await get_proxy_runtime()
+    lease = await proxy.acquire()
+
+    if stream:
+        async def _relay() -> AsyncGenerator[str, None]:
+            raw = _http.post_stream_raw(
+                url, payload, headers=headers, lease=lease, timeout_s=timeout_s
+            )
+            if via_responses:
+                async for chunk in translate_responses_stream_to_chat(raw, model=model):
+                    yield chunk
+                return
+            async for line in raw:
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", "replace")
+                if line.strip():
+                    yield f"{line}\n\n"
+
+        logger.info(
+            "xai chat stream started: model={} base={} path={}", model, base_url, path
+        )
+        return _relay()
+
+    result = await _http.post_json_raw(
+        url, payload, headers=headers, lease=lease, timeout_s=timeout_s
+    )
+    if via_responses:
+        result = responses_to_chat_completion(result, model=model)
+    logger.info("xai chat completed: model={} base={} path={}", model, base_url, path)
+    return result
+
+
+__all__ = ["completions"]

--- a/app/products/web/admin/__init__.py
+++ b/app/products/web/admin/__init__.py
@@ -165,11 +165,13 @@ from .tokens import router as _tokens_router  # noqa: E402
 from .batch import router as _batch_router  # noqa: E402
 from .assets import router as _assets_router  # noqa: E402
 from .cache import router as _cache_router  # noqa: E402
+from .xai import router as _xai_router  # noqa: E402
 
 router.include_router(_tokens_router)
 router.include_router(_batch_router)
 router.include_router(_assets_router)
 router.include_router(_cache_router)
+router.include_router(_xai_router)
 
 
 # ---------------------------------------------------------------------------

--- a/app/products/web/admin/tokens.py
+++ b/app/products/web/admin/tokens.py
@@ -26,6 +26,7 @@ from app.control.account.commands import (
     ListAccountsQuery,
 )
 from app.control.account.enums import AccountStatus
+from app.control.xai.pending import is_internal_record
 
 if TYPE_CHECKING:
     from app.control.account.refresh import AccountRefreshService
@@ -151,7 +152,8 @@ async def list_tokens(repo: "AccountRepository" = Depends(get_repo)):
             break
         page_num += 1
 
-    return _json({"tokens": [_serialize_record(r) for r in all_items]})
+    visible = [r for r in all_items if not is_internal_record(r)]
+    return _json({"tokens": [_serialize_record(r) for r in visible]})
 
 
 @router.post("/tokens")

--- a/app/products/web/admin/xai.py
+++ b/app/products/web/admin/xai.py
@@ -1,0 +1,232 @@
+"""Admin API — xAI official-API OAuth login + account management.
+
+Endpoints (all under ``/admin/api``, admin-guarded):
+  POST   /xai/oauth/start     — discovery + PKCE, loopback listener, authorize URL
+  POST   /xai/oauth/complete  — manual paste: callback URL / code + state
+  GET    /xai/oauth/poll      — poll loopback/manual completion outcome
+  GET    /xai/accounts        — list saved xAI accounts (masked)
+  DELETE /xai/accounts        — remove saved xAI account(s)
+
+OAuth uses the grok-cli registered loopback redirect
+``http://127.0.0.1:56121/callback`` (not ``app.app_url``).
+"""
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import orjson
+from fastapi import APIRouter, Body, Depends, Query
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from app.platform.errors import ValidationError
+from app.platform.logging.logger import logger
+from app.control.xai import account as xai_account
+from app.control.xai import oauth, pending
+from app.control.xai.callback_parse import parse_oauth_callback
+from app.control.xai.constants import OAUTH_REDIRECT_URI
+from app.control.xai.flow import finish_oauth
+from app.control.xai.loopback import get_loopback
+from app.control.xai import sessions as oauth_sessions
+from app.dataplane.proxy import get_proxy_runtime
+
+if TYPE_CHECKING:
+    from app.control.account.repository import AccountRepository
+
+from . import get_repo
+
+router = APIRouter(tags=["Admin - xAI"])
+
+
+def _json(data) -> Response:
+    return Response(content=orjson.dumps(data), media_type="application/json")
+
+
+def _mask(token: str) -> str:
+    return f"{token[:10]}...{token[-6:]}" if len(token) > 20 else token
+
+
+class XaiOAuthCompleteRequest(BaseModel):
+    state: str = Field(min_length=8)
+    callback: str = Field(min_length=1)
+
+
+async def _begin_oauth(repo: "AccountRepository") -> dict[str, Any]:
+    await pending.cleanup_expired(repo)
+    proxy = await get_proxy_runtime()
+    lease = await proxy.acquire()
+    auth_ep, token_ep = await oauth.discover(lease=lease)
+
+    from app.control.xai.pkce import generate_pkce
+
+    verifier, challenge = generate_pkce()
+    state = pending.new_state()
+    nonce = pending.new_state()
+
+    await pending.save(
+        repo,
+        state=state,
+        code_verifier=verifier,
+        code_challenge=challenge,
+        token_endpoint=token_ep,
+        redirect_uri=OAUTH_REDIRECT_URI,
+    )
+
+    authorize_url = oauth.build_authorize_url(
+        auth_ep,
+        redirect_uri=OAUTH_REDIRECT_URI,
+        code_challenge=challenge,
+        state=state,
+        nonce=nonce,
+    )
+
+    loopback = get_loopback()
+    loopback_available = await loopback.ensure_started()
+    if loopback_available:
+        oauth_sessions.clear_outcome(state)
+        asyncio.create_task(_wait_loopback(repo, state)).add_done_callback(
+            _log_background_task_error
+        )
+
+    logger.info(
+        "xai oauth started: redirect_uri={} loopback={}",
+        OAUTH_REDIRECT_URI,
+        loopback_available,
+    )
+    return {
+        "authorize_url": authorize_url,
+        "state": state,
+        "redirect_uri": OAUTH_REDIRECT_URI,
+        "loopback_available": loopback_available,
+    }
+
+
+def _log_background_task_error(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("xai oauth background task failed: error={}", exc)
+
+
+async def _wait_loopback(repo: "AccountRepository", state: str) -> None:
+    loopback = get_loopback()
+    try:
+        code = await loopback.wait_for_code(state)
+        result = await finish_oauth(repo, state=state, code=code)
+        oauth_sessions.set_outcome(
+            state,
+            status="ok",
+            message=result.get("message", ""),
+            email=result.get("email"),
+        )
+    except asyncio.TimeoutError:
+        loopback.cancel_waiter(state)
+        oauth_sessions.set_outcome(
+            state,
+            status="timeout",
+            message="授权超时，请重新登录或使用「手动粘贴」。",
+        )
+    except Exception as exc:  # noqa: BLE001
+        loopback.cancel_waiter(state)
+        oauth_sessions.set_outcome(state, status="error", message=str(exc))
+
+
+@router.post("/xai/oauth/start")
+async def xai_oauth_start(repo: "AccountRepository" = Depends(get_repo)):
+    """Begin xAI OAuth; start loopback listener and return the authorize URL."""
+    return _json(await _begin_oauth(repo))
+
+
+@router.post("/xai/oauth/complete")
+async def xai_oauth_complete(
+    req: XaiOAuthCompleteRequest,
+    repo: "AccountRepository" = Depends(get_repo),
+):
+    """Complete OAuth via pasted callback URL, query string, or bare code."""
+    get_loopback().cancel_waiter(req.state)
+    try:
+        code, parsed_state = parse_oauth_callback(
+            req.callback, expected_state=req.state
+        )
+    except ValueError as exc:
+        raise ValidationError(
+            str(exc),
+            param="callback",
+            code="oauth_callback_invalid",
+        ) from exc
+
+    if parsed_state != req.state:
+        raise ValidationError(
+            "state 与当前登录会话不匹配，请确认粘贴的是本次登录的回调。",
+            param="callback",
+            code="oauth_state_mismatch",
+        )
+
+    result = await finish_oauth(repo, state=req.state, code=code)
+    oauth_sessions.set_outcome(
+        req.state,
+        status="ok",
+        message=result.get("message", ""),
+        email=result.get("email"),
+    )
+    return _json(result)
+
+
+@router.get("/xai/oauth/poll")
+async def xai_oauth_poll(
+    state: str = Query(min_length=8),
+    repo: "AccountRepository" = Depends(get_repo),
+):
+    """Poll OAuth completion after ``/xai/oauth/start`` (loopback or manual)."""
+    outcome = oauth_sessions.peek_outcome(state)
+    if outcome:
+        oauth_sessions.pop_outcome(state)
+        return _json(outcome)
+
+    if await pending.exists(repo, state):
+        return _json({"status": "pending"})
+
+    return _json(
+        {
+            "status": "expired",
+            "message": "登录会话无效或已过期，请重新发起 xAI 登录。",
+        }
+    )
+
+
+@router.get("/xai/accounts")
+async def xai_list_accounts(repo: "AccountRepository" = Depends(get_repo)):
+    """List saved xAI accounts (token masked)."""
+    records = await xai_account.list_xai_accounts(repo)
+    items = [
+        {
+            "token": _mask(r.token),
+            "email": (r.ext or {}).get("email"),
+            "expires_at": (r.ext or {}).get("expires_at"),
+            "last_refresh": (r.ext or {}).get("last_refresh"),
+            "status": r.status,
+        }
+        for r in records
+    ]
+    return _json({"accounts": items})
+
+
+@router.delete("/xai/accounts")
+async def xai_delete_accounts(
+    tokens: list[str] | None = Body(default=None),
+    repo: "AccountRepository" = Depends(get_repo),
+):
+    """Delete saved xAI account(s). With no body, removes all xAI accounts."""
+    if tokens:
+        targets = tokens
+    else:
+        targets = [r.token for r in await xai_account.list_xai_accounts(repo)]
+    if not targets:
+        return _json({"deleted": 0})
+    await repo.delete_accounts(targets)
+    logger.info("xai accounts deleted: count={}", len(targets))
+    return _json({"deleted": len(targets)})
+
+
+__all__ = ["router"]

--- a/app/products/web/router.py
+++ b/app/products/web/router.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 
 from app.platform.auth.middleware import is_webui_enabled, verify_webui_key
 from app.platform.meta import get_project_version
@@ -57,6 +57,25 @@ async def admin_config():
 @router.get("/admin/cache", include_in_schema=False)
 async def admin_cache():
     return _serve_html("admin/cache.html")
+
+
+# --- Legacy xAI OAuth callback (deprecated) ---
+@router.get("/admin/xai/callback", include_in_schema=False)
+async def admin_xai_callback_legacy():
+    """OAuth no longer uses ``app.app_url``; redirect users to the admin UI."""
+    html = """<!doctype html><html lang="zh"><head><meta charset="utf-8">
+<title>xAI OAuth</title><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{font-family:system-ui,sans-serif;background:#0b0f17;color:#e5e7eb;
+display:flex;align-items:center;justify-content:center;height:100vh;margin:0}
+.card{background:#111827;border:1px solid #1f2937;border-radius:14px;padding:32px 40px;
+max-width:480px;text-align:center}.m{color:#9ca3af;font-size:14px;line-height:1.7}
+.b{margin-top:20px;display:inline-block;padding:8px 18px;border-radius:8px;
+background:#2563eb;color:#fff;text-decoration:none;font-size:14px}</style></head>
+<body><div class="card"><div class="m">xAI OAuth 已改为本机回环地址
+<code style="color:#e5e7eb">http://127.0.0.1:56121/callback</code>。
+请在管理后台「账号管理」点击「登录 xAI」；若浏览器未自动跳回，请使用「手动粘贴」。</div>
+<a class="b" href="/admin/account">返回账号管理</a></div></body></html>"""
+    return HTMLResponse(content=html, status_code=200)
 
 
 # --- WebUI ---

--- a/app/products/web/webui/chat.py
+++ b/app/products/web/webui/chat.py
@@ -2,12 +2,16 @@
 
 import time
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from app.control.model import registry as model_registry
 from app.platform.auth.middleware import verify_webui_key
-from app.products.openai.router import chat_completions_endpoint
+from app.products.openai.router import (
+    _available_pools,
+    _model_available_for_pools,
+    chat_completions_endpoint,
+)
 from app.products.openai.schemas import ChatCompletionRequest
 
 router = APIRouter(prefix="/webui/api", dependencies=[Depends(verify_webui_key)], tags=["WebUI - Chat"])
@@ -24,24 +28,31 @@ def _capability_name(spec) -> str:
 
 
 @router.get("/models")
-async def list_webui_models():
+async def list_webui_models(request: Request):
+    """List models available for the WebUI chat picker.
+
+    Uses the same pool/mode rules as ``GET /v1/models``: Grok Build OAuth
+    (pool ``xai`` only) yields ``grok-build-0.1`` and ``grok-composer-2.5-fast``.
+    """
+    pools = await _available_pools(request)
     models = [
         {
             "id": spec.model_name,
             "object": "model",
             "created": int(time.time()),
-            "owned_by": "xai",
+            "owned_by": "xai" if spec.is_xai() else "grok",
             "name": spec.public_name,
             "capability": _capability_name(spec),
         }
         for spec in model_registry.list_enabled()
+        if _model_available_for_pools(spec, pools)
     ]
     return JSONResponse({"object": "list", "data": models})
 
 
 @router.post("/chat/completions")
-async def webui_chat_completions(req: ChatCompletionRequest):
-    return await chat_completions_endpoint(req)
+async def webui_chat_completions(req: ChatCompletionRequest, request: Request):
+    return await chat_completions_endpoint(req, request)
 
 
 __all__ = ["router"]

--- a/app/statics/admin/account.html
+++ b/app/statics/admin/account.html
@@ -735,6 +735,22 @@
     </div>
   </div>
 
+  <!-- xAI 官方 API（OAuth 登录） -->
+  <div class="section-head">
+    <div class="section-title">xAI 官方 API（OAuth）</div>
+  </div>
+  <div class="stat-cell" id="xai-card" style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:18px">
+    <div style="min-width:0">
+      <div class="stat-label">通过 grok-cli OAuth 登录（回调 <code style="font-size:12px">127.0.0.1:56121</code>）。可用模型：<code style="font-size:12px">grok-build-0.1</code>、<code style="font-size:12px">grok-composer-2.5-fast</code>（非 API Key 全量模型）。</div>
+      <div id="xai-status" style="margin-top:6px;font-size:13px;color:#9ca3af">加载中…</div>
+    </div>
+    <div style="display:flex;gap:8px;flex-shrink:0;flex-wrap:wrap">
+      <button id="xai-login-btn" onclick="xaiLogin()" class="page-action-btn page-action-btn-primary">登录 xAI</button>
+      <button id="xai-paste-btn" onclick="xaiPasteOpen()" class="page-action-btn">手动粘贴</button>
+      <button id="xai-remove-btn" onclick="xaiRemove()" class="page-action-btn" style="display:none">移除</button>
+    </div>
+  </div>
+
   <div class="section-head">
     <div class="section-title" data-i18n="account.sectionOverview">账户概览</div>
   </div>
@@ -993,6 +1009,21 @@
 
 </main>
 
+<!-- ── xAI OAuth paste modal ───────────────────────────────────────────────── -->
+<div class="modal-overlay" id="modal-xai-paste">
+  <div class="modal">
+    <div class="modal-title">粘贴 xAI 授权回调</div>
+    <div class="dialog-body">
+      <div class="dialog-help">授权完成后，将浏览器地址栏的完整 URL、或页面上的授权码粘贴到下方。若仅粘贴授权码，需先点击「登录 xAI」发起本次会话。</div>
+      <textarea class="input dialog-textarea" id="xai-paste-callback" rows="5" placeholder="http://127.0.0.1:56121/callback?code=...&state=...&#10;或仅粘贴 code 值"></textarea>
+    </div>
+    <div class="dialog-actions">
+      <button onclick="closeModal('modal-xai-paste')" class="dialog-btn">取消</button>
+      <button onclick="xaiPasteSubmit()" class="dialog-btn dialog-btn-primary">完成登录</button>
+    </div>
+  </div>
+</div>
+
 <!-- ── Add Modal ───────────────────────────────────────────────────────────── -->
 <div class="modal-overlay" id="modal-import">
   <div class="modal">
@@ -1173,6 +1204,129 @@ async function _api(method, path, body) {
   return r.json();
 }
 
+// ── xAI OAuth ────────────────────────────────────────────────────────────────
+let _xaiOAuthState = null;
+let _xaiPollTimer = null;
+
+function xaiStopPoll() {
+  if (_xaiPollTimer) {
+    clearInterval(_xaiPollTimer);
+    _xaiPollTimer = null;
+  }
+}
+
+async function xaiPollOnce() {
+  if (!_xaiOAuthState) return;
+  try {
+    const data = await _api('GET', `/xai/oauth/poll?state=${encodeURIComponent(_xaiOAuthState)}`);
+    if (data.status === 'pending') return;
+    xaiStopPoll();
+    _xaiOAuthState = null;
+    if (data.status === 'ok') {
+      showToast(data.message || 'xAI 登录成功', 'success');
+      xaiRefresh();
+      return;
+    }
+    showToast(data.message || `xAI 登录失败（${data.status}）`, 'error');
+  } catch (e) {
+    xaiStopPoll();
+    showToast(`轮询登录状态失败：${e.message}`, 'error');
+  }
+}
+
+function xaiStartPoll() {
+  xaiStopPoll();
+  if (!_xaiOAuthState) return;
+  _xaiPollTimer = setInterval(xaiPollOnce, 2000);
+  xaiPollOnce();
+}
+
+async function xaiRefresh() {
+  const statusEl = document.getElementById('xai-status');
+  const removeBtn = document.getElementById('xai-remove-btn');
+  const loginBtn = document.getElementById('xai-login-btn');
+  if (!statusEl) return;
+  try {
+    const data = await _api('GET', '/xai/accounts');
+    const acc = (data.accounts || [])[0];
+    if (acc) {
+      const exp = acc.expires_at ? new Date(acc.expires_at).toLocaleString() : '未知';
+      statusEl.textContent = `已登录：${acc.email || acc.token}（令牌到期：${exp}）`;
+      statusEl.style.color = '#16a34a';
+      removeBtn.style.display = '';
+      loginBtn.textContent = '重新登录';
+    } else {
+      statusEl.textContent = '尚未登录 xAI 账号。';
+      statusEl.style.color = '#9ca3af';
+      removeBtn.style.display = 'none';
+      loginBtn.textContent = '登录 xAI';
+    }
+  } catch (e) {
+    statusEl.textContent = `加载 xAI 状态失败：${e.message}`;
+    statusEl.style.color = '#dc2626';
+  }
+}
+
+async function xaiLogin() {
+  try {
+    const data = await _api('POST', '/xai/oauth/start');
+    _xaiOAuthState = data.state || null;
+    if (data.authorize_url) {
+      window.open(data.authorize_url, '_blank');
+    }
+    if (data.loopback_available) {
+      xaiStartPoll();
+      showToast('已打开 xAI 登录页；本机 127.0.0.1:56121 正在等待回调，成功后自动保存。', 'info');
+    } else {
+      showToast('端口 56121 已被占用或未监听，请用「手动粘贴」完成登录。', 'info');
+      xaiPasteOpen();
+    }
+  } catch (e) {
+    showToast(`发起 xAI 登录失败：${e.message}`, 'error');
+  }
+}
+
+function xaiPasteOpen() {
+  document.getElementById('xai-paste-callback').value = '';
+  openModal('modal-xai-paste');
+}
+
+async function xaiPasteSubmit() {
+  const callback = document.getElementById('xai-paste-callback').value.trim();
+  if (!callback) {
+    showToast('请粘贴回调 URL 或授权码', 'error');
+    return;
+  }
+  if (!_xaiOAuthState) {
+    showToast('请先点击「登录 xAI」发起本次授权会话', 'error');
+    return;
+  }
+  try {
+    const data = await _api('POST', '/xai/oauth/complete', {
+      state: _xaiOAuthState,
+      callback,
+    });
+    xaiStopPoll();
+    _xaiOAuthState = null;
+    closeModal('modal-xai-paste');
+    showToast(data.message || 'xAI 登录成功', 'success');
+    xaiRefresh();
+  } catch (e) {
+    showToast(`完成登录失败：${e.message}`, 'error');
+  }
+}
+
+async function xaiRemove() {
+  if (!confirm('确定要移除已登录的 xAI 账号吗？')) return;
+  try {
+    await _api('DELETE', '/xai/accounts');
+    showToast('已移除 xAI 账号。', 'success');
+    xaiRefresh();
+  } catch (e) {
+    showToast(`移除失败：${e.message}`, 'error');
+  }
+}
+
 // Selection strategy reported by /status — "quota" | "random".
 // Controls whether quota columns / stats are rendered (hidden in random mode).
 let selectionStrategy = 'quota';
@@ -1194,6 +1348,7 @@ async function load() {
     applyStrategyUI();
     invalidateTokenView();
     render();
+    xaiRefresh();
   } catch (e) { showToast(`${tr('account.loadFailed', null, '加载失败')}: ${e.message}`, 'error'); }
 }
 

--- a/app/statics/js/webui/chat.js
+++ b/app/statics/js/webui/chat.js
@@ -1455,7 +1455,11 @@
       opt.textContent = formatModelOptionLabel(item.id, item.name || item.id);
       modelSelect.appendChild(opt);
     });
-    modelSelect.value = ids.includes(PREFERRED_MODEL) ? PREFERRED_MODEL : (ids[0] || PREFERRED_MODEL);
+    const xaiPreferred = 'grok-build-0.1';
+    const preferred = ids.includes(PREFERRED_MODEL)
+      ? PREFERRED_MODEL
+      : (ids.includes(xaiPreferred) ? xaiPreferred : (ids[0] || PREFERRED_MODEL));
+    modelSelect.value = preferred;
   }
 
   async function sendMessage() {

--- a/config.defaults.toml
+++ b/config.defaults.toml
@@ -62,6 +62,18 @@ imagine_public_image_proxy = false
 video_format = "grok_url"
 
 
+# ==================== xAI 官方 API（OAuth）====================
+[xai]
+# 是否启用 xAI 官方 API provider（grok-cli OAuth，调用 api.x.ai）
+enabled = true
+# OAuth Client ID（grok-cli 公共客户端，一般无需修改）
+client_id = "b1a00492-073a-47ea-816f-4c329264a828"
+# Grok Build / Composer OAuth 模型 API 基址（api.x.ai，Composer 走 /responses）
+base_url = "https://api.x.ai/v1"
+# 请求超时（秒）
+timeout = 120
+
+
 # ==================== 本地缓存 ====================
 [cache.local]
 # 图片缓存上限（MB），0 = 不限制；超限后按最旧文件优先清理，并回落到上限的 60%

--- a/tests/test_xai_oauth.py
+++ b/tests/test_xai_oauth.py
@@ -1,0 +1,198 @@
+"""Tests for the xAI OAuth provider auth logic.
+
+The project ships no pytest dependency, so this file doubles as a stdlib script:
+
+    uv run python tests/test_xai_oauth.py
+
+Each ``test_*`` function uses plain ``assert`` and can also be collected by
+pytest if it is ever added.
+"""
+
+import base64
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import orjson
+
+from app.control.xai import oauth
+from app.control.xai.callback_parse import parse_oauth_callback
+from app.control.xai.constants import OAUTH_REDIRECT_URI, XAI_OAUTH_MODEL_IDS
+from app.control.xai.responses_chat import (
+    messages_to_responses_body,
+    responses_to_chat_completion,
+    uses_responses_api,
+)
+from app.products.openai import xai_chat
+from app.control.xai.pkce import generate_pkce
+
+
+def test_pkce_challenge_matches_verifier():
+    verifier, challenge = generate_pkce()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert challenge == expected
+    # verifier/challenge are URL-safe base64 (no padding)
+    assert "=" not in verifier and "=" not in challenge
+
+
+def test_pkce_codes_are_unique():
+    a, _ = generate_pkce()
+    b, _ = generate_pkce()
+    assert a != b
+
+
+def test_build_authorize_url_has_required_params():
+    url = oauth.build_authorize_url(
+        "https://auth.x.ai/oauth/authorize",
+        redirect_uri=OAUTH_REDIRECT_URI,
+        code_challenge="CHAL",
+        state="STATE",
+        nonce="NONCE",
+    )
+    for must in (
+        "response_type=code",
+        "code_challenge=CHAL",
+        "code_challenge_method=S256",
+        "state=STATE",
+        "nonce=NONCE",
+        "plan=generic",
+        "referrer=grok2api",
+        "scope=openid",
+        f"redirect_uri={OAUTH_REDIRECT_URI.replace(':', '%3A').replace('/', '%2F')}",
+    ):
+        assert must in url, f"missing {must} in {url}"
+    assert url.startswith("https://auth.x.ai/oauth/authorize?")
+
+
+def test_parse_oauth_callback_full_url():
+    code, state = parse_oauth_callback(
+        "http://127.0.0.1:56121/callback?code=ABC&state=XYZ",
+    )
+    assert code == "ABC"
+    assert state == "XYZ"
+
+
+def test_parse_oauth_callback_bare_code():
+    code, state = parse_oauth_callback("ONLYCODE", expected_state="MYSTATE")
+    assert code == "ONLYCODE"
+    assert state == "MYSTATE"
+
+
+def test_xai_oauth_model_allowlist():
+    assert "grok-build-0.1" in XAI_OAUTH_MODEL_IDS
+    assert "grok-composer-2.5-fast" in XAI_OAUTH_MODEL_IDS
+    assert "grok-build" not in XAI_OAUTH_MODEL_IDS
+    assert "grok-4" not in XAI_OAUTH_MODEL_IDS
+
+
+def test_composer_uses_responses_api():
+    assert uses_responses_api("grok-composer-2.5-fast")
+    assert not uses_responses_api("grok-build-0.1")
+
+
+def test_messages_to_responses_body_simple_user():
+    body = messages_to_responses_body(
+        model="grok-composer-2.5-fast",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        temperature=0.8,
+        top_p=0.95,
+    )
+    assert body["input"] == "hello"
+    assert body["model"] == "grok-composer-2.5-fast"
+
+
+def test_responses_to_chat_completion_extracts_message_text():
+    out = responses_to_chat_completion(
+        {
+            "id": "r1",
+            "created_at": 1,
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Hi"}],
+                }
+            ],
+            "usage": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+        },
+        model="grok-composer-2.5-fast",
+    )
+    assert out["choices"][0]["message"]["content"] == "Hi"
+
+
+def test_xai_chat_rejects_non_oauth_model():
+    try:
+        xai_chat._validate_model("grok-4")
+    except Exception:
+        return
+    raise AssertionError("grok-4 should be rejected for OAuth path")
+
+
+def test_parse_oauth_callback_rejects_empty():
+    try:
+        parse_oauth_callback("  ")
+    except ValueError:
+        return
+    raise AssertionError("empty callback should be rejected")
+
+
+def test_url_validation_rejects_http():
+    try:
+        oauth._validate_xai_url("http://auth.x.ai/x", field="t")
+    except Exception:
+        return
+    raise AssertionError("http:// should be rejected")
+
+
+def test_url_validation_rejects_non_xai_domain():
+    try:
+        oauth._validate_xai_url("https://evil.example.com/x", field="t")
+    except Exception:
+        return
+    raise AssertionError("non-x.ai domain should be rejected")
+
+
+def test_url_validation_accepts_xai_subdomain():
+    assert oauth._validate_xai_url("https://auth.x.ai/oauth", field="t")
+
+
+def test_parse_id_token_extracts_email_and_sub():
+    payload = (
+        base64.urlsafe_b64encode(orjson.dumps({"email": "a@b.com", "sub": "xyz-1"}))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    email, sub = oauth.parse_id_token(f"header.{payload}.sig")
+    assert email == "a@b.com"
+    assert sub == "xyz-1"
+
+
+def test_parse_id_token_handles_garbage():
+    assert oauth.parse_id_token("") == (None, None)
+    assert oauth.parse_id_token("not-a-jwt") == (None, None)
+
+
+def _main() -> int:
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    print(f"\n{'OK' if not failures else f'{failures} FAILED'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_main())


### PR DESCRIPTION
为 grok2api 增加 Grok Build / grok-cli OAuth（auth.x.ai）能力，与现有 grok.com SSO（basic / super / heavy）账号池分离。

OAuth 与账号

• 使用 xAI 注册的 loopback 回调：http://127.0.0.1:56121/callback，完整 PKCE（S256）流程。
• 管理后台支持浏览器登录、轮询完成、以及手动粘贴 callback URL / code。
• 账号写入 pool=xai，不参与 grok 选号、配额刷新与 runtime 热路径；登录成功后清理 _xai_oauth_pending 占位行，并在 token 列表中隐藏 pending 记录。

模型与上游

• OAuth 仅开放：grok-build-0.1、grok-composer-2.5-fast（已移除别名 grok-build）。
• grok-build-0.1 → https://api.x.ai/v1/chat/completions
• grok-composer-2.5-fast → https://api.x.ai/v1/responses，并在网关侧转换为 OpenAI Chat Completions 格式（含流式 SSE）。

列表过滤

• GET /v1/models 与 WebUI GET /webui/api/models 按当前可用账号池过滤：仅 xai 池时只显示上述 2 个模型；存在 SSO 池时仍显示完整 Grok 目录（Grok 4.20、Imagine 等）。

其它

• ModelSpec 增加 provider（grok | xai），OpenAI /v1/chat/completions 与 WebUI 聊天按 provider 分发。
• 新增 [xai] 配置段（config.defaults.toml）。

Testing

• [x] uv run python tests/test_xai_oauth.py — 16/16 通过（PKCE、authorize URL、callback 解析、模型白名单、Responses 转换等）
• [x] uv run python -m compileall 相关新增模块 — 无语法错误
• [x] 本地 granian + 仅 pool=xai 账号：
  • GET /v1/models → 仅 grok-build-0.1、grok-composer-2.5-fast
  • POST /v1/chat/completions（grok-build-0.1）→ 200，有正常回复
  • POST /v1/chat/completions（grok-composer-2.5-fast）→ 200（经 /responses 转换）
  • Composer 流式 SSE 可输出标准 data: {...} chunk（非 b'...' 字节串）
• [x] WebUI 模型下拉：仅 xAI OAuth 时只显示 2 个模型；有 SSO 池时仍显示完整列表
• [x] 密钥检查：data/、logs/、.env 未提交；源码无用户 token / JWT 硬编码（仅公共 grok-cli client_id）

