### PR TITLE
fix(transport): route asset URL prefetch 403 through build_feedback f…

### DIFF
--- a/app/dataplane/reverse/transport/asset_upload.py
+++ b/app/dataplane/reverse/transport/asset_upload.py
@@ -192,13 +192,15 @@ async def upload_from_input(token: str, file_input: str) -> tuple[str, str]:
                 resp = await session.get(file_input, headers=headers, timeout=30.0)
             raw  = resp.content
             if resp.status_code != 200:
+                body_text = ""
+                try:
+                    body_text = raw.decode("utf-8", "replace")[:300]
+                except Exception:
+                    pass
+                is_cloudflare = "just a moment" in body_text.lower()
                 await proxy.feedback(
                     lease,
-                    ProxyFeedback(
-                        kind        = ProxyFeedbackKind.UPSTREAM_5XX if resp.status_code >= 500
-                                      else ProxyFeedbackKind.FORBIDDEN,
-                        status_code = resp.status_code,
-                    ),
+                    build_feedback(resp.status_code, is_cloudflare=is_cloudflare),
                 )
                 raise UpstreamError(
                     f"Failed to fetch input URL: {resp.status_code}",


### PR DESCRIPTION
## Summary

`upload_from_input` 的 URL 预取分支在收到非 200 时硬编码 `ProxyFeedbackKind.FORBIDDEN`，导致资源 CDN 的 Cloudflare 5s 盾（HTTP 403 + `"Just a moment..."` HTML body）不会被识别为 challenge，`ProxyDirectory.feedback` 也就不会失效已污染的 `ClearanceBundle`。下一次请求继续复用同一份过期 `cf_clearance`，形成 403 循环。

修复方式：复用同文件主上传路径 L147–L150 已有的处理，改走 `build_feedback(status_code, is_cloudflare=...)`，并对 body 做 `"just a moment"` 嗅探。

- 403 + CF body → `CHALLENGE`，触发 bundle 失效 + 代理池游标推进
- 403 无 CF body → 仍按 `CHALLENGE` 处理（与主上传路径一致）
- 401 → `UNAUTHORIZED`、429 → `RATE_LIMITED`、≥500 → `UPSTREAM_5XX`，均由 `build_feedback` 统一映射，行为不再依赖调用点拼装

## Testing

- `python -m py_compile app/dataplane/reverse/transport/asset_upload.py` ✓
- 通过 `ast.parse` 验证语法树完整 ✓
- 静态比对 `app/control/proxy/feedback.py:6-17` 的 `classify_status_code` 表，确认所有原有 status code 行为不退化（5xx 仍走 UPSTREAM_5XX；非 4xx/5xx 仍走 FORBIDDEN 兜底）
- 无 mock CF 响应的单元测试可跑，需要线上 FlareSolverr + 真实资源 URL 才能端到端验证 challenge 触发

## Related

Relates to #491, #552