### PR TITLE
fix(proxy): map AUTH_FAILURE to FORBIDDEN to preserve healthy clearan…

### DIFF
--- a/app/dataplane/reverse/feedback.py
+++ b/app/dataplane/reverse/feedback.py
@@ -61,10 +61,17 @@ def build_account_feedback(
 # Proxy feedback
 # ---------------------------------------------------------------------------
 
+# AUTH_FAILURE is an account-side credential problem (blocked-user,
+# bad-credentials, session-not-found, etc. — see is_invalid_credentials_body),
+# not a proxy/clearance problem. Mapping it to UNAUTHORIZED would invalidate
+# the cached ClearanceBundle (ProxyDirectory.feedback, control/proxy/__init__.py),
+# burning a healthy cf_clearance every time a banned account is exercised.
+# Map to FORBIDDEN so the pool cursor still advances under PROXY_POOL but the
+# bundle stays intact. Aligns with the principle in xai_usage._proxy_feedback_kind_for_error.
 _CATEGORY_TO_PROXY: dict[ResultCategory, ProxyFeedbackKind] = {
     ResultCategory.SUCCESS:      ProxyFeedbackKind.SUCCESS,
     ResultCategory.RATE_LIMITED:  ProxyFeedbackKind.RATE_LIMITED,
-    ResultCategory.AUTH_FAILURE:  ProxyFeedbackKind.UNAUTHORIZED,
+    ResultCategory.AUTH_FAILURE:  ProxyFeedbackKind.FORBIDDEN,
     ResultCategory.FORBIDDEN:     ProxyFeedbackKind.CHALLENGE,
     ResultCategory.UPSTREAM_5XX:  ProxyFeedbackKind.UPSTREAM_5XX,
     ResultCategory.TRANSPORT_ERR: ProxyFeedbackKind.TRANSPORT_ERROR,


### PR DESCRIPTION
## Summary

`ResultCategory.AUTH_FAILURE` 对应账号侧凭证失效（`blocked-user`、`bad-credentials`、`session-not-found`、`email-domain-rejected`、`account suspended` 等，识别逻辑见 `xai_usage.is_invalid_credentials_body`），跟代理 / Cloudflare 状态无关。

但原映射 `AUTH_FAILURE → UNAUTHORIZED` 在 `ProxyDirectory.feedback`（`app/control/proxy/__init__.py:185-198`）会无条件失效当前 `(proxy_url, clearance_host)` 维度的 `ClearanceBundle`，导致：

- 每命中一个被 xAI 拉黑的账号都会顺手烧掉一份完好的 `cf_clearance`
- 号池里有 N 个失效号，启动期就会触发 N 次 FlareSolverr 重刷
- 还没碰到真正的 CF challenge，clearance 已经被反复重建

修复：把映射改成 `AUTH_FAILURE → FORBIDDEN`。

- 在 `PROXY_POOL` 模式下，`__init__.py:200-221` 仍会推进 `_pool_cursor`，遇到坏号下次会换代理
- 但 `__init__.py:185-198` 不再失效 bundle，保留健康 clearance
- 与 `xai_usage._proxy_feedback_kind_for_error` 里已有的原则 "invalid or blocked accounts are account problems, not proxy problems" 一致，把同一条原则贯彻到 chat 主链路

仅改动 `_CATEGORY_TO_PROXY` 表中 1 行 + 注释，不引入新依赖、不改变其它分类（`FORBIDDEN → CHALLENGE`、`RATE_LIMITED → RATE_LIMITED` 等保持不变）。

## Testing

- `python -m py_compile app/dataplane/reverse/feedback.py` ✓
- `ast.parse` 语法验证 ✓
- 静态核对 `ProxyDirectory.feedback`（`__init__.py:183-221`）中 `FORBIDDEN` / `UNAUTHORIZED` 两个分支的语义差异：
  - `UNAUTHORIZED`：失效 bundle + 推进游标
  - `FORBIDDEN`：仅推进游标
  - 改动后被封号场景丢失"失效 bundle"的副作用，正是本 PR 想要去掉的
- 无需端到端验证：账号封禁路径走的是 `state_machine.apply_feedback` 的账号侧反馈，跟代理侧反馈两条独立链路，账号状态机行为不受本改动影响（账号侧仍由 `build_account_feedback` 处理）

## Related

Relates to #407, #452