### PR TITLE
fix(config): accept newline-separated lists in get_list

### DIFF
--- a/app/platform/config/snapshot.py
+++ b/app/platform/config/snapshot.py
@@ -2,11 +2,17 @@
 
 import asyncio
 import os
+import re
 from pathlib import Path
 from typing import Any
 
 from .loader import _deep_merge, get_nested, load_toml
 from .backends import ConfigBackend, create_config_backend
+
+# List-valued config can arrive as a single string from the WebUI textarea
+# (each item on a new line) or a comma-separated string from env-var overrides.
+# Split on either delimiter so operators can use whichever feels natural.
+_LIST_SEPARATOR_RE = re.compile(r"[,\r\n]+")
 
 _BASE_DIR = Path(__file__).resolve().parents[3]  # project root
 
@@ -121,7 +127,7 @@ class ConfigSnapshot:
         if isinstance(val, list):
             return val
         if isinstance(val, str):
-            return [p.strip() for p in val.split(",") if p.strip()]
+            return [p.strip() for p in _LIST_SEPARATOR_RE.split(val) if p.strip()]
         return [val]
 
     async def update(self, patch: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

WebUI 的代理池字段（`proxy.egress.proxy_pool` 与 `resource_proxy_pool`）在 `app/statics/admin/config.html:578,587` 渲染成 `<textarea>`，UI 文案明确写「每行一个代理 URL」。textarea 的原始 value（含 `\n`）原样保存到 config backend，但 `ConfigSnapshot.get_list`（`app/platform/config/snapshot.py:117-125`）只按 `,` 切分，多行字符串被返回成单个列表元素。

后续在 `app/control/proxy/__init__.py:104-110` 被当成单个代理 URL 塞给 `ProxyDirectory`，再透给 `curl_cffi`，触发：

    curl: (5) Unsupported proxy syntax in
    "http://a:1\nhttp://b:2\nhttp://c:3": Malformed input to a URL function

影响：

- 按照 UI 文档配置的代理池会塌缩成 1 个非法条目，所有流量退化到首个代理或 direct
- 用户以为代理池在轮转，实际所有出站走同一 IP；除了功能失效，还会反向放大单 IP 指纹被上游识别的风险

修复：把分隔符从 `","` 改成正则 `[,\r\n]+`，同时接受逗号 / LF / CRLF。TOML 数组语义不变；逗号字符串（如 `retry.on_codes = "429,401,503"`）行为不变。

新增模块级常量 `_LIST_SEPARATOR_RE`，避免每次调用都重新编译正则。

## Testing

- `python -m py_compile app/platform/config/snapshot.py` ✓
- `ast.parse` 语法验证 ✓
- 行为对照测试（已本地跑通），输入 → 输出：

```
'http://a:1,http://b:2,http://c:3'        -> ['http://a:1', 'http://b:2', 'http://c:3']
'http://a:1\nhttp://b:2\nhttp://c:3'      -> ['http://a:1', 'http://b:2', 'http://c:3']
'http://a:1\r\nhttp://b:2\r\nhttp://c:3'  -> ['http://a:1', 'http://b:2', 'http://c:3']
'http://a:1, http://b:2,  http://c:3 '    -> ['http://a:1', 'http://b:2', 'http://c:3']
'http://a:1,\nhttp://b:2'                 -> ['http://a:1', 'http://b:2']
'429,401,503'                             -> ['429', '401', '503']
''                                        -> []
'single_value'                            -> ['single_value']
```

- 兼容性核对：grep 全仓 `get_list` 调用点，所有现存 list-shape 配置（proxy 池、`retry.on_codes`、`retry.reset_session_status_codes` 等）要么本就是 TOML 数组（走 `isinstance(val, list)` 早返回），要么是纯逗号串（新正则保留旧行为），未发现需要保留 `\n` 作为字面字符的字段

## Related

Closes #533