### PR TITLE
fix: clipboard copy fails on non-HTTPS LAN deployments (#591)

### DIFF
--- a/frontend/src/features/accounts/accounts-page.tsx
+++ b/frontend/src/features/accounts/accounts-page.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { copyToClipboard } from "@/shared/clipboard";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -710,7 +711,7 @@ export function AccountsPage() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button type="button" variant="ghost" size="icon" className="absolute right-1.5 top-1/2 size-8 -translate-y-1/2 rounded-md" aria-label={t("common.copy")} onClick={() => {
-                        void navigator.clipboard.writeText(deviceSession.userCode);
+                        void copyToClipboard(deviceSession.userCode);
                         toast.success(t("common.copied"));
                       }}><Copy /></Button>
                     </TooltipTrigger>

--- a/frontend/src/features/client-keys/client-keys-page.tsx
+++ b/frontend/src/features/client-keys/client-keys-page.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { copyToClipboard } from "@/shared/clipboard";
+
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -125,7 +127,7 @@ export function ClientKeysPage() {
   const copyMutation = useMutation({
     mutationFn: async (id: string) => {
       const result = await getClientKeySecret(id);
-      await navigator.clipboard.writeText(result.secret);
+      await copyToClipboard(result.secret);
       return id;
     },
     onSuccess: () => toast.success(t("common.copied")),
@@ -404,7 +406,7 @@ export function ClientKeysPage() {
                 <TooltipTrigger asChild>
                   <Button type="button" variant="ghost" size="icon" className="h-full w-8 shrink-0 rounded-none border-l" aria-label={t("keys.copySecret")} onClick={() => {
                     if (createdSecret) {
-                      void navigator.clipboard.writeText(createdSecret);
+                      void copyToClipboard(createdSecret);
                       toast.success(t("common.copied"));
                     }
                   }}><Copy /></Button>

--- a/frontend/src/features/docs/api-docs-page.tsx
+++ b/frontend/src/features/docs/api-docs-page.tsx
@@ -11,6 +11,7 @@ import { listModels } from "@/entities/model/model-api";
 import type { ModelRouteDTO } from "@/entities/model/types";
 import { getSystemInfo } from "@/entities/system/system-api";
 import { runtimeConfig } from "@/shared/config/runtime-config";
+import { copyToClipboard } from "@/shared/clipboard";
 import { cn } from "@/shared/lib/cn";
 
 type ExampleLanguage = "curl" | "python" | "javascript";
@@ -366,7 +367,7 @@ function CopyButton({ value, className }: { value: string; className?: string })
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   return (
-    <Button type="button" variant="ghost" size="icon" className={cn("size-7 shrink-0 text-muted-foreground", className)} aria-label={copied ? t("common.copied") : t("common.copy")} title={copied ? t("common.copied") : t("common.copy")} onClick={() => { void navigator.clipboard.writeText(value); setCopied(true); window.setTimeout(() => setCopied(false), 1500); }}>
+    <Button type="button" variant="ghost" size="icon" className={cn("size-7 shrink-0 text-muted-foreground", className)} aria-label={copied ? t("common.copied") : t("common.copy")} title={copied ? t("common.copied") : t("common.copy")} onClick={() => { void copyToClipboard(value); setCopied(true); window.setTimeout(() => setCopied(false), 1500); }}>
       {copied ? <Check /> : <Copy />}
     </Button>
   );

--- a/frontend/src/shared/clipboard.ts
+++ b/frontend/src/shared/clipboard.ts
@@ -1,0 +1,13 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}


### PR DESCRIPTION
## 问题

在局域网 HTTP 环境（如 `http://192.168.x.x:8000`）下，点击"复制密钥"等按钮时报错：

> Cannot read properties of undefined (reading 'writeText')

**原因**：`navigator.clipboard` API 需要[安全上下文](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security-considerations)（HTTPS 或 localhost）。通过 HTTP + 局域网 IP 访问时，`navigator.clipboard` 为 `undefined`。

## 修复

新增 `frontend/src/shared/clipboard.ts`，提供 `copyToClipboard()` 工具函数：
- 优先使用 `navigator.clipboard.writeText`（安全上下文可用时）
- 降级使用 `document.execCommand('copy')`（非安全上下文 fallback）

替换了以下 3 个文件中全部 4 处 `navigator.clipboard.writeText` 直接调用：
- `accounts-page.tsx` — Device OAuth 用户码复制
- `client-keys-page.tsx` — 客户端密钥创建/复制（2 处）
- `api-docs-page.tsx` — API 文档代码块复制

## 测试

- HTTPS 环境：走 `navigator.clipboard`，行为不变
- HTTP 局域网：走 `execCommand` fallback，复制正常，不再报错

Fixes #591