### PR TITLE
fix: 设置保存报 400 — revision=0 被 required 校验拒绝 (#592)

### DIFF
--- a/backend/internal/transport/http/settings/handler.go
+++ b/backend/internal/transport/http/settings/handler.go
@@ -100,7 +100,7 @@ type providerBuildRecommendationDTO struct {
 }
 
 type updateRequest struct {
-	Revision uint64            `json:"revision,string" binding:"required"`
+	Revision uint64            `json:"revision,string"`
 	Config   settingsConfigDTO `json:"config" binding:"required"`
 }
 
@@ -110,8 +110,8 @@ func (h *Handler) get(c *gin.Context) {
 
 func (h *Handler) update(c *gin.Context) {
 	var request updateRequest
-	if c.ShouldBindJSON(&request) != nil {
-		response.Error(c, http.StatusBadRequest, "invalidRequest", "请求参数无效")
+	if err := c.ShouldBindJSON(&request); err != nil {
+		response.Error(c, http.StatusBadRequest, "invalidRequest", "请求参数无效: "+err.Error())
 		return
 	}
 	result, err := h.service.Update(c.Request.Context(), request.Revision, request.Config.toApplication())


### PR DESCRIPTION
## 问题

新部署的实例，在设置页修改**任意参数**保存时都报 `400 请求参数无效`（#592）。

## 根因

```go
type updateRequest struct {
    Revision uint64 `json:"revision,string" binding:"required"` // ← 这里
    Config   settingsConfigDTO `json:"config" binding:"required"`
}
```

`Revision` 标记了 `binding:"required"`。gin 的 `required` 校验将 `uint64` 零值 (`0`) 视为"空值"而拒绝。

新实例的设置 revision 从 `0` 开始 → 前端传 `"revision":"0"` → 反序列化为 `uint64(0)` → **required 校验失败 → 400**。

已修改设置（revision > 0）的实例不受影响，所以只有**首次保存**必现。

### 复现

```bash
# 本地验证
var req updateRequest
json.Unmarshal([]byte(`{"revision":"0","config":{...}}`), &req)
binding.Validator.ValidateStruct(req)
// → Key: 'updateRequest.Revision' Error:Field validation for 'Revision' failed on the 'required' tag
```

## 修复

1. **去掉 `Revision` 的 `binding:"required"`** — revision=0 是合法的初始值；乐观锁冲突由 `Service.Update` 通过 `ErrConflict` 检查，不需要在绑定层拦截
2. **`ShouldBindJSON` 失败时透传具体校验错误**（`err.Error()`）而非笼统的 "请求参数无效"，便于定位未来的绑定问题

Fixes #592