### PR TITLE
feat: Claude Code 兼容——prompt cache 命中优化与上下文超限拦截

### DIFF
--- a/backend/internal/application/gateway/context_limit_test.go
+++ b/backend/internal/application/gateway/context_limit_test.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/audit"
+)
+
+// 构造一个估算超过 50 万 token 的 body，断言 EstimateRequestInputTokens 判定超限。
+func TestContextOverLimitDetection(t *testing.T) {
+	// 约 200 万字符 → 估算远超 50 万 token(~3 字符/token)。
+	huge := strings.Repeat("word ", 400000)
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"` + huge + `"}]}`)
+	est := audit.EstimateRequestInputTokens(body)
+	if est <= maxUpstreamContextTokens {
+		t.Fatalf("expected estimate > %d, got %d", maxUpstreamContextTokens, est)
+	}
+}
+
+// 正常大小 body 不应被判定超限。
+func TestContextUnderLimitPasses(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"hello world"}]}`)
+	est := audit.EstimateRequestInputTokens(body)
+	if est > maxUpstreamContextTokens {
+		t.Fatalf("normal request wrongly flagged: est=%d", est)
+	}
+}
+
+// ContextOverLimitError 应携带估算值且 errors.As 可提取。
+func TestContextOverLimitErrorCarriesTokens(t *testing.T) {
+	err := error(&ContextOverLimitError{EstimatedTokens: 500724, Limit: maxUpstreamContextTokens})
+	var target *ContextOverLimitError
+	if !errors.As(err, &target) {
+		t.Fatal("errors.As should extract ContextOverLimitError")
+	}
+	if target.EstimatedTokens != 500724 {
+		t.Fatalf("estimated tokens = %d, want 500724", target.EstimatedTokens)
+	}
+	if !strings.Contains(err.Error(), "500724") {
+		t.Fatalf("error message should contain token count: %s", err.Error())
+	}
+}

--- a/backend/internal/application/gateway/prompt_cache.go
+++ b/backend/internal/application/gateway/prompt_cache.go
@@ -1,0 +1,416 @@
+package gateway
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	// promptCacheIdentityVersion 变更 seed 算法时递增，避免新旧 identity 混用。
+	promptCacheIdentityVersion = "v1"
+	// freeCacheNativeToolsJSON：Free OAuth 无工具请求注入 native search
+	// 以进入可缓存档，同时 tool_choice=none 禁止真实搜索。
+	freeCacheNativeToolsJSON    = `[{"type":"web_search"},{"type":"x_search"}]`
+	freeCacheDisabledToolChoice = "none"
+)
+
+// resolvePromptCacheKey 为上游 Grok 生成稳定、租户隔离的 prompt_cache_key。
+// 优先保留客户端显式 key；否则从 session 头/body 或内容前缀推导。
+// clientKeyID 必填，避免不同客户端共享同一缓存身份。
+func resolvePromptCacheKey(clientKeyID uint64, publicModel, upstreamModel, explicit, sessionHeader string, body []byte) string {
+	if clientKeyID == 0 {
+		return strings.TrimSpace(explicit)
+	}
+	model := strings.ToLower(strings.TrimSpace(upstreamModel))
+	if model == "" {
+		model = strings.ToLower(strings.TrimSpace(publicModel))
+	}
+	if model == "" {
+		return strings.TrimSpace(explicit)
+	}
+
+	seed := strings.TrimSpace(sessionHeader)
+	if seed == "" {
+		seed = strings.TrimSpace(explicit)
+	}
+	if seed == "" && len(body) > 0 {
+		var probe struct {
+			PromptCacheKey string `json:"prompt_cache_key"`
+		}
+		_ = json.Unmarshal(body, &probe)
+		seed = strings.TrimSpace(probe.PromptCacheKey)
+	}
+	if seed == "" {
+		seed = deriveContentSessionSeed(body)
+	}
+	if seed == "" {
+		return ""
+	}
+
+	isolated := fmt.Sprintf("grok-prompt-cache:%s:%d:%s:%s", promptCacheIdentityVersion, clientKeyID, model, seed)
+	sum := sha256.Sum256([]byte(isolated))
+	// UUID 形态，兼容上游 x-grok-conv-id / prompt_cache_key 常见消费方。
+	hexID := hex.EncodeToString(sum[:16])
+	return fmt.Sprintf("%s-%s-%s-%s-%s", hexID[0:8], hexID[8:12], hexID[12:16], hexID[16:20], hexID[20:32])
+}
+
+// deriveContentSessionSeed 只取多轮中相对稳定的前缀字段。
+// Claude Code 追加 messages 时 identity 不变。
+// 关键：tools 只取排序后的 name 列表（忽略 description/schema 抖动与 MCP 元数据噪声），
+// 否则 Claude Code 工具描述微调就会换 key → 换账号 → 缓存从 90%+ 掉到 0。
+func deriveContentSessionSeed(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var root map[string]json.RawMessage
+	if json.Unmarshal(body, &root) != nil {
+		return ""
+	}
+
+	var parts []string
+	if model := rawString(root["model"]); model != "" {
+		parts = append(parts, "model="+model)
+	}
+	if tools := toolNamesSeed(root["tools"]); tools != "" {
+		parts = append(parts, "tools="+tools)
+	}
+	if system := systemTextSeed(root["system"]); system != "" {
+		parts = append(parts, "system="+system)
+	}
+	if instructions := rawString(root["instructions"]); instructions != "" {
+		parts = append(parts, "instructions="+instructions)
+	}
+	// metadata.user_id 是部分客户端的会话锚点；有则优先于 first_user。
+	if userID := metadataUserID(root["metadata"]); userID != "" {
+		parts = append(parts, "user_id="+userID)
+	} else if first := firstUserSeed(root); first != "" {
+		// 仅取首条 user 的纯文本摘要，去掉 cache_control / 过大内容，降低噪声。
+		parts = append(parts, "first_user="+first)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	// 内容种子可能很长（system 巨大）；最终 identity 会再 hash，这里保持可读调试字段。
+	return "compat_cs_" + strings.Join(parts, "|")
+}
+
+// toolNamesSeed 只保留工具名并排序，避免 schema/description 变化打穿会话身份。
+func toolNamesSeed(raw json.RawMessage) string {
+	if len(raw) == 0 || isJSONNull(raw) || isJSONEmptyArray(raw) {
+		return ""
+	}
+	var tools []map[string]json.RawMessage
+	if json.Unmarshal(raw, &tools) != nil {
+		return ""
+	}
+	names := make([]string, 0, len(tools))
+	seen := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		var name string
+		_ = json.Unmarshal(tool["name"], &name)
+		name = strings.TrimSpace(name)
+		if name == "" {
+			// OpenAI 扁平 tools 可能把 name 放在 function.name
+			if fn := tool["function"]; len(fn) > 0 {
+				var function struct {
+					Name string `json:"name"`
+				}
+				_ = json.Unmarshal(fn, &function)
+				name = strings.TrimSpace(function.Name)
+			}
+		}
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	// 简单插入排序，避免额外 import sort 在极小切片上的依赖噪音；数量可达数百，改用标准库。
+	return strings.Join(sortedStrings(names), ",")
+}
+
+func systemTextSeed(raw json.RawMessage) string {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return ""
+	}
+	if text := rawString(raw); text != "" {
+		return text
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return normalizeJSONSeed(raw)
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type != "" && block.Type != "text" {
+			continue
+		}
+		text := strings.TrimSpace(block.Text)
+		if text == "" || strings.HasPrefix(text, "x-anthropic-billing-header") {
+			continue
+		}
+		parts = append(parts, text)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func metadataUserID(raw json.RawMessage) string {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return ""
+	}
+	var meta map[string]any
+	if json.Unmarshal(raw, &meta) != nil {
+		return ""
+	}
+	for _, key := range []string{"user_id", "userId", "session_id", "sessionId"} {
+		if value, ok := meta[key]; ok {
+			switch typed := value.(type) {
+			case string:
+				if strings.TrimSpace(typed) != "" {
+					return strings.TrimSpace(typed)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	for i := 1; i < len(out); i++ {
+		j := i
+		for j > 0 && out[j-1] > out[j] {
+			out[j-1], out[j] = out[j], out[j-1]
+			j--
+		}
+	}
+	return out
+}
+
+func firstUserSeed(root map[string]json.RawMessage) string {
+	if raw := root["messages"]; len(raw) > 0 {
+		var messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		}
+		if json.Unmarshal(raw, &messages) == nil {
+			for _, msg := range messages {
+				if strings.EqualFold(strings.TrimSpace(msg.Role), "user") {
+					return firstUserTextSummary(msg.Content)
+				}
+			}
+		}
+	}
+	if raw := root["input"]; len(raw) > 0 {
+		if text := rawString(raw); text != "" {
+			return text
+		}
+		var items []struct {
+			Role    string          `json:"role"`
+			Type    string          `json:"type"`
+			Text    string          `json:"text"`
+			Content json.RawMessage `json:"content"`
+		}
+		if json.Unmarshal(raw, &items) == nil {
+			for _, item := range items {
+				role := strings.ToLower(strings.TrimSpace(item.Role))
+				if role == "user" {
+					if len(item.Content) > 0 {
+						return firstUserTextSummary(item.Content)
+					}
+					if strings.TrimSpace(item.Text) != "" {
+						return clipSeedText(strings.TrimSpace(item.Text))
+					}
+				}
+				if item.Type == "input_text" && strings.TrimSpace(item.Text) != "" {
+					return clipSeedText(strings.TrimSpace(item.Text))
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// firstUserTextSummary 提取首条 user 的文本锚点。
+// Claude Code 首条 user 可能很大；只保留纯文本并截断，足够区分会话即可。
+func firstUserTextSummary(raw json.RawMessage) string {
+	if text := rawString(raw); text != "" {
+		return clipSeedText(text)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if block.Type != "" && block.Type != "text" {
+				continue
+			}
+			if text := strings.TrimSpace(block.Text); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		if len(parts) > 0 {
+			return clipSeedText(strings.Join(parts, "\n"))
+		}
+	}
+	return clipSeedText(normalizeJSONSeed(raw))
+}
+
+func clipSeedText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	const maxRunes = 512
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes])
+}
+
+// ensurePromptCacheKeyInBody 把 identity 写入 Responses 请求体的 prompt_cache_key。
+// 客户端原有值会被租户隔离 identity 覆盖，避免共享 OAuth 账号时 key 碰撞。
+func ensurePromptCacheKeyInBody(body []byte, identity string) ([]byte, error) {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return body, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		payload = make(map[string]json.RawMessage)
+	}
+	encoded, err := json.Marshal(identity)
+	if err != nil {
+		return nil, err
+	}
+	payload["prompt_cache_key"] = encoded
+	return json.Marshal(payload)
+}
+
+// maybeInjectFreeCacheTools 在 Grok Build OAuth、且客户端未声明 tools/tool_choice 时，
+// 注入 native web_search/x_search + tool_choice=none，帮助 Free 请求进入可缓存档。
+// intentBody 使用注入前的原始意图，避免规范化删掉不支持工具后误注入。
+func maybeInjectFreeCacheTools(body, intentBody []byte, providerName, authType string) ([]byte, bool, error) {
+	if !strings.EqualFold(strings.TrimSpace(providerName), "grok_build") {
+		return body, false, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(authType), "oauth") {
+		return body, false, nil
+	}
+	if hasToolsOrToolChoice(intentBody) || hasToolsOrToolChoice(body) {
+		return body, false, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, false, err
+	}
+	if payload == nil {
+		payload = make(map[string]json.RawMessage)
+	}
+	payload["tools"] = json.RawMessage(freeCacheNativeToolsJSON)
+	payload["tool_choice"] = mustRawJSON(freeCacheDisabledToolChoice)
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
+func hasToolsOrToolChoice(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	var probe struct {
+		Tools      json.RawMessage `json:"tools"`
+		ToolChoice json.RawMessage `json:"tool_choice"`
+	}
+	if json.Unmarshal(body, &probe) != nil {
+		return false
+	}
+	if len(probe.ToolChoice) > 0 && !isJSONNull(probe.ToolChoice) {
+		// tool_choice=none/auto 也算客户端意图，不覆盖。
+		return true
+	}
+	if len(probe.Tools) == 0 || isJSONNull(probe.Tools) {
+		return false
+	}
+	return !isJSONEmptyArray(probe.Tools)
+}
+
+func normalizeJSONSeed(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return string(raw)
+	}
+	// Anthropic system/content 可能是 block 数组；去掉 cache_control 再归一，
+	// 避免 Claude Code 断点位置变化导致 seed 漂移。
+	value = stripCacheControlValue(value)
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return string(raw)
+	}
+	return string(encoded)
+}
+
+func stripCacheControlValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		delete(typed, "cache_control")
+		for key, child := range typed {
+			typed[key] = stripCacheControlValue(child)
+		}
+		return typed
+	case []any:
+		for i, child := range typed {
+			typed[i] = stripCacheControlValue(child)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func rawString(raw json.RawMessage) string {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return strings.TrimSpace(text)
+	}
+	return ""
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return strings.TrimSpace(string(raw)) == "null"
+}
+
+func isJSONEmptyArray(raw json.RawMessage) bool {
+	return strings.TrimSpace(string(raw)) == "[]"
+}
+
+func mustRawJSON(value any) json.RawMessage {
+	encoded, _ := json.Marshal(value)
+	return encoded
+}

--- a/backend/internal/application/gateway/prompt_cache_test.go
+++ b/backend/internal/application/gateway/prompt_cache_test.go
@@ -1,0 +1,134 @@
+package gateway
+
+import "testing"
+
+func TestResolvePromptCacheKeyStableAcrossAppendOnlyTurns(t *testing.T) {
+	round1 := []byte(`{
+		"model":"claude-sonnet-4-5","max_tokens":256,
+		"system":[{"type":"text","text":"You are Claude Code.","cache_control":{"type":"ephemeral"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"first question","cache_control":{"type":"ephemeral"}}]}],
+		"tools":[{"name":"Read","description":"read","input_schema":{"type":"object"}}]
+	}`)
+	round2 := []byte(`{
+		"model":"claude-sonnet-4-5","max_tokens":256,
+		"system":[{"type":"text","text":"You are Claude Code.","cache_control":{"type":"ephemeral"}}],
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"first question","cache_control":{"type":"ephemeral"}}]},
+			{"role":"assistant","content":[{"type":"text","text":"first answer"}]},
+			{"role":"user","content":[{"type":"text","text":"second question","cache_control":{"type":"ephemeral"}}]}
+		],
+		"tools":[{"name":"Read","description":"read","input_schema":{"type":"object"}}]
+	}`)
+
+	first := resolvePromptCacheKey(42, "claude-sonnet-4-5", "grok-4.5", "", "", round1)
+	second := resolvePromptCacheKey(42, "claude-sonnet-4-5", "grok-4.5", "", "", round2)
+	if first == "" || second == "" {
+		t.Fatalf("expected non-empty keys: first=%q second=%q", first, second)
+	}
+	if first != second {
+		t.Fatalf("append-only turns should keep identity stable:\nfirst=%s\nsecond=%s", first, second)
+	}
+	if len(first) != 36 {
+		t.Fatalf("identity should be UUID-shaped, got %q len=%d", first, len(first))
+	}
+}
+
+func TestResolvePromptCacheKeyIsolatesClientAndModel(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-5","system":"stable","messages":[{"role":"user","content":"hi"}],"tools":[]}`)
+	base := resolvePromptCacheKey(1, "claude-sonnet-4-5", "grok-4.5", "", "", body)
+	otherClient := resolvePromptCacheKey(2, "claude-sonnet-4-5", "grok-4.5", "", "", body)
+	otherModel := resolvePromptCacheKey(1, "claude-sonnet-4-5", "grok-4.3", "", "", body)
+	if base == "" || base == otherClient || base == otherModel {
+		t.Fatalf("base=%q otherClient=%q otherModel=%q", base, otherClient, otherModel)
+	}
+}
+
+func TestResolvePromptCacheKeyPrefersSessionHeader(t *testing.T) {
+	bodyA := []byte(`{"model":"m","messages":[{"role":"user","content":"one"}]}`)
+	bodyB := []byte(`{"model":"m","messages":[{"role":"user","content":"totally different"}]}`)
+	first := resolvePromptCacheKey(9, "m", "grok-4.5", "body-key", "session-abc", bodyA)
+	second := resolvePromptCacheKey(9, "m", "grok-4.5", "other-body-key", "session-abc", bodyB)
+	if first == "" || first != second {
+		t.Fatalf("session header should dominate: first=%q second=%q", first, second)
+	}
+}
+
+func TestEnsurePromptCacheKeyInBodyOverwritesClientValue(t *testing.T) {
+	body := []byte(`{"model":"grok-4.5","prompt_cache_key":"raw-client","input":"hi"}`)
+	out, err := ensurePromptCacheKeyInBody(body, "isolated-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) == string(body) {
+		t.Fatal("expected body rewrite")
+	}
+	if !containsJSONStringField(out, "prompt_cache_key", "isolated-id") {
+		t.Fatalf("body = %s", out)
+	}
+}
+
+func TestResolvePromptCacheKeyIgnoresToolDescriptionNoise(t *testing.T) {
+	// Claude Code 有时只改 tool description / schema 细节；会话身份应保持稳定。
+	a := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"system":"stable system",
+		"messages":[{"role":"user","content":"hello session"}],
+		"tools":[
+			{"name":"Read","description":"read file v1","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}},
+			{"name":"Bash","description":"bash v1","input_schema":{"type":"object"}}
+		]
+	}`)
+	b := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"system":"stable system",
+		"messages":[{"role":"user","content":"hello session"}],
+		"tools":[
+			{"name":"Bash","description":"bash v2 with different schema","input_schema":{"type":"object","properties":{"command":{"type":"string"}}}},
+			{"name":"Read","description":"read file v2","input_schema":{"type":"object","properties":{"file":{"type":"string"}}}}
+		]
+	}`)
+	ka := resolvePromptCacheKey(7, "claude-sonnet-4-5", "grok-4.5", "", "", a)
+	kb := resolvePromptCacheKey(7, "claude-sonnet-4-5", "grok-4.5", "", "", b)
+	if ka == "" || ka != kb {
+		t.Fatalf("tool description noise should not change identity: %q vs %q", ka, kb)
+	}
+}
+
+func TestResolvePromptCacheKeyChangesWhenToolNameSetChanges(t *testing.T) {
+	a := []byte(`{"model":"m","system":"s","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"Read","input_schema":{"type":"object"}}]}`)
+	b := []byte(`{"model":"m","system":"s","messages":[{"role":"user","content":"hi"}],"tools":[{"name":"Read","input_schema":{"type":"object"}},{"name":"mcp__x__y","input_schema":{"type":"object"}}]}`)
+	ka := resolvePromptCacheKey(7, "m", "grok-4.5", "", "", a)
+	kb := resolvePromptCacheKey(7, "m", "grok-4.5", "", "", b)
+	if ka == "" || kb == "" || ka == kb {
+		t.Fatalf("tool name set change should change identity: %q vs %q", ka, kb)
+	}
+}
+
+func TestResolvePromptCacheKeyUsesMetadataUserID(t *testing.T) {
+	a := []byte(`{"model":"m","metadata":{"user_id":"sess-1"},"messages":[{"role":"user","content":"aaa"}]}`)
+	b := []byte(`{"model":"m","metadata":{"user_id":"sess-1"},"messages":[{"role":"user","content":"totally different first user"}]}`)
+	ka := resolvePromptCacheKey(3, "m", "grok-4.5", "", "", a)
+	kb := resolvePromptCacheKey(3, "m", "grok-4.5", "", "", b)
+	if ka == "" || ka != kb {
+		t.Fatalf("metadata.user_id should dominate first_user: %q vs %q", ka, kb)
+	}
+}
+
+func containsJSONStringField(body []byte, key, want string) bool {
+	// lightweight check without importing encoding/json helpers again in assertion path
+	needle := `"` + key + `":"` + want + `"`
+	return stringContains(string(body), needle) || stringContains(string(body), `"`+key+`": "`+want+`"`)
+}
+
+func stringContains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -38,6 +38,22 @@ var (
 	ErrConversationUnsupported    = errors.New("目标模型不支持当前对话协议")
 )
 
+// maxUpstreamContextTokens 是上游 Grok-4.5 的上下文硬上限。
+// 与 conversation 包的 maxUpstreamTools 同款风格：不设余量，避免误拦本可成功的请求，
+// 估算偏差由 provider 层上游 400 兜底改写覆盖。
+const maxUpstreamContextTokens = 500000
+
+// ContextOverLimitError 表示请求估算 token 超过上游上下文硬上限，
+// 在发上游之前主动拦截，携带估算值供上层生成 /compact 引导文案。
+type ContextOverLimitError struct {
+	EstimatedTokens int64
+	Limit           int64
+}
+
+func (e *ContextOverLimitError) Error() string {
+	return fmt.Sprintf("估算输入 %d tokens 超过上游上限 %d", e.EstimatedTokens, e.Limit)
+}
+
 const maxRetryableBodyBytes = 64 << 10
 const responseOwnershipTTL = 30 * 24 * time.Hour
 const finalizationTimeout = 5 * time.Second
@@ -53,22 +69,24 @@ type Input struct {
 	Body               []byte
 	Streaming          bool
 	PromptCacheKey     string
+	SessionID          string
 	PreviousResponseID string
 	Operation          audit.Operation
 }
 
 type Usage struct {
-	InputTokens            int64
-	CachedInputTokens      int64
-	OutputTokens           int64
-	ReasoningTokens        int64
-	TotalTokens            int64
-	CostInUSDTicks         int64
-	NumSourcesUsed         int64
-	NumServerSideToolsUsed int64
-	ContextInputTokens     int64
-	ContextOutputTokens    int64
-	ResponseModel          string
+	InputTokens              int64
+	CachedInputTokens        int64
+	CacheCreationInputTokens int64
+	OutputTokens             int64
+	ReasoningTokens          int64
+	TotalTokens              int64
+	CostInUSDTicks           int64
+	NumSourcesUsed           int64
+	NumServerSideToolsUsed   int64
+	ContextInputTokens       int64
+	ContextOutputTokens      int64
+	ResponseModel            string
 }
 
 type Result struct {
@@ -268,7 +286,16 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	}
 	routes, aliasEffort, err := s.resolvePublicModelRoutes(ctx, input.PublicModel)
 	if err != nil {
-		return nil, ErrModelNotFound
+		// 兜底:Claude Code 等 Anthropic 客户端默认发送 claude-* 模型名，本地并无对应路由。
+		// 精确匹配失败时，若请求模型是 Anthropic 系列，回退到默认上游模型，实现开箱即用。
+		if fallback := fallbackModelForClient(input.PublicModel); fallback != "" && fallback != input.PublicModel {
+			if fallbackRoutes, fallbackEffort, fallbackErr := s.resolvePublicModelRoutes(ctx, fallback); fallbackErr == nil {
+				routes, aliasEffort, err = fallbackRoutes, fallbackEffort, nil
+			}
+		}
+		if err != nil {
+			return nil, ErrModelNotFound
+		}
 	}
 	route, routeErr := s.selectConversationRoute(routes, input.ClientKey, operation, path, input.PreviousResponseID != "", nil)
 	var ownership *inferencedomain.ResponseOwnership
@@ -318,6 +345,24 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 			s.logger.Error("request_usage_write_failed", "event_id", record.EventID, "request_id", input.RequestID, "error", err)
 		}
 		return nil, clientkeyapp.ErrModelNotAllowed
+	}
+	// Claude Code / Anthropic Messages 通常不带 Grok 的 prompt_cache_key。
+	// 从显式 key / session 头 / 稳定内容前缀推导租户隔离 identity，
+	// 既驱动账号粘滞选择(下游 selector.Acquire)，也写入上游 body 以提升 prompt cache 命中。
+	promptCacheKey := resolvePromptCacheKey(input.ClientKey.ID, route.PublicID, route.UpstreamModel, input.PromptCacheKey, input.SessionID, input.Body)
+	if promptCacheKey != "" {
+		input.PromptCacheKey = promptCacheKey
+		if rewritten, cacheErr := ensurePromptCacheKeyInBody(input.Body, promptCacheKey); cacheErr == nil {
+			input.Body = rewritten
+		} else {
+			s.logger.Warn("prompt_cache_key_inject_failed", "request_id", input.RequestID, "error", cacheErr)
+		}
+	}
+	// Grok-4.5 上下文硬上限 50 万 token。超限请求发上游只会撞 400 后客户端反复重试(实测干等 6 分半)，
+	// 这里在发上游、占账号、预留计费之前主动拦截，转成秒级 400 + /compact 引导。
+	if est := audit.EstimateRequestInputTokens(input.Body); est > maxUpstreamContextTokens {
+		s.logger.Warn("context_over_limit", "request_id", input.RequestID, "estimated_tokens", est, "limit", maxUpstreamContextTokens)
+		return nil, &ContextOverLimitError{EstimatedTokens: est, Limit: maxUpstreamContextTokens}
 	}
 	adapter, ok := s.providers.Responses(route.Provider)
 	if !ok {
@@ -1053,4 +1098,18 @@ func firstError(values ...error) error {
 		}
 	}
 	return errors.New("未知上游错误")
+}
+
+// defaultClientFallbackModel 是 Anthropic 客户端(如 Claude Code)默认模型名匹配失败时的回退上游模型。
+// Claude Code 会发送 claude-sonnet-* / claude-opus-* / claude-3-5-haiku 等本地不存在的模型名，
+// 统一兜底到该模型可实现开箱即用，无需用户手动配置 ANTHROPIC_MODEL。
+const defaultClientFallbackModel = "grok-4.5"
+
+// fallbackModelForClient 在精确模型匹配失败时，判断请求模型是否属于 Anthropic 系列并返回回退模型。
+// 仅对 claude- 前缀(Claude Code / Anthropic SDK 默认模型名)生效，避免污染其他显式模型请求。
+func fallbackModelForClient(requested string) string {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(requested)), "claude") {
+		return defaultClientFallbackModel
+	}
+	return ""
 }

--- a/backend/internal/domain/audit/pricing.go
+++ b/backend/internal/domain/audit/pricing.go
@@ -153,6 +153,12 @@ func estimateRequestInputTokens(body []byte) int64 {
 	return max(256, estimateJSONTokens(payload)+128)
 }
 
+// EstimateRequestInputTokens 对外导出请求输入 token 的保守估算，
+// 与计费预留同口径，供上游上下文超限拦截复用。
+func EstimateRequestInputTokens(body []byte) int64 {
+	return estimateRequestInputTokens(body)
+}
+
 func estimateJSONTokens(value any) int64 {
 	switch typed := value.(type) {
 	case map[string]any:

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -95,6 +95,22 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			return invalidResponsesResponse(err), nil
 		}
 	}
+	// Free OAuth 无工具请求注入 native search tools（tool_choice=none），
+	// 帮助进入可缓存档；客户端已声明 tools/tool_choice 时不改写。
+	if injected, injectErr := injectFreeCacheToolsIfEligible(body, request.Body, request.Credential); injectErr != nil {
+		return invalidResponsesResponse(injectErr), nil
+	} else if injected != nil {
+		body = injected
+	}
+	// Messages/Chat 转换会重建 body，gateway 注入的 prompt_cache_key 可能丢失。
+	// 这里以 request.PromptCacheKey（含 gateway 推导结果）为准写回上游 body。
+	if key := strings.TrimSpace(request.PromptCacheKey); key != "" {
+		if rewritten, writeErr := writePromptCacheKey(body, key); writeErr != nil {
+			return invalidResponsesResponse(writeErr), nil
+		} else {
+			body = rewritten
+		}
+	}
 	var bodyReader io.Reader
 	if len(body) > 0 {
 		bodyReader = bytes.NewReader(body)
@@ -124,6 +140,14 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 	}
 	if err := normalizeGzipResponse(resp); err != nil {
 		return nil, err
+	}
+	// 第 2 层兜底:token 估算是启发式，可能漏过 gateway 层的主动拦截。
+	// 上游真返 400 "maximum prompt length" 时，把英文原始报错改写成 /compact 引导，
+	// 与第 1 层保持一致的用户体验。
+	if resp.StatusCode == http.StatusBadRequest {
+		if rewritten, ok := rewriteContextLimitResponse(resp); ok {
+			resp = rewritten
+		}
 	}
 	responsesOperation := request.Operation == "" || request.Operation == conversation.OperationResponses
 	if responsesOperation && toolCompatibility != nil {
@@ -497,4 +521,122 @@ func (a *Adapter) getBilling(ctx context.Context, credential account.Credential,
 		return account.Billing{}, fmt.Errorf("上游 Billing 接口返回 %d", resp.StatusCode)
 	}
 	return parseBilling(body)
+}
+
+// injectFreeCacheToolsIfEligible：Build OAuth 且客户端无 tools/tool_choice 时，
+// 注入 web_search/x_search + tool_choice=none，使 Free 请求走可缓存路由且不触发真实搜索。
+// intentBody 是注入前的原始意图 body，避免规范化删掉不支持工具后误注入。
+// 返回 nil 表示不需要改写。
+func injectFreeCacheToolsIfEligible(normalizedBody, intentBody []byte, credential account.Credential) ([]byte, error) {
+	if credential.Provider != account.ProviderBuild || credential.AuthType != account.AuthTypeOAuth {
+		return nil, nil
+	}
+	if hasClientToolIntent(intentBody) || hasClientToolIntent(normalizedBody) {
+		return nil, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(normalizedBody, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		payload = make(map[string]json.RawMessage)
+	}
+	payload["tools"] = json.RawMessage(`[{"type":"web_search"},{"type":"x_search"}]`)
+	payload["tool_choice"] = mustJSON("none")
+	return json.Marshal(payload)
+}
+
+// hasClientToolIntent 判断请求体是否声明了 tools 或 tool_choice(客户端工具意图)。
+func hasClientToolIntent(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	var probe struct {
+		Tools      json.RawMessage `json:"tools"`
+		ToolChoice json.RawMessage `json:"tool_choice"`
+	}
+	if json.Unmarshal(body, &probe) != nil {
+		return false
+	}
+	if len(bytes.TrimSpace(probe.ToolChoice)) > 0 && !bytes.Equal(bytes.TrimSpace(probe.ToolChoice), []byte("null")) {
+		return true
+	}
+	trimmed := bytes.TrimSpace(probe.Tools)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null")) && !bytes.Equal(trimmed, []byte("[]"))
+}
+
+// writePromptCacheKey 以给定 key 覆盖写回 body 的 prompt_cache_key。
+// Messages/Chat 转换会重建 body，gateway 推导的 key 可能丢失，故在发请求前强制写回。
+func writePromptCacheKey(body []byte, key string) ([]byte, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return body, nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		payload = make(map[string]json.RawMessage)
+	}
+	payload["prompt_cache_key"] = mustJSON(key)
+	return json.Marshal(payload)
+}
+
+// rewriteContextLimitResponse 检测上游 400 是否为上下文超限(maximum prompt length)，
+// 若是则把英文原始报错改写成 /compact 引导(保留上游精确 token 数)，作为第 2 层兜底。
+// 返回 (改写后的 response, true) 或 (nil, false 表示不是超限、原样透传)。
+func rewriteContextLimitResponse(resp *http.Response) (*http.Response, bool) {
+	if resp.Body == nil {
+		return nil, false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	_ = resp.Body.Close()
+	if err != nil {
+		// 读失败:把已读部分包回去，交由上层原样处理。
+		resp.Body = io.NopCloser(bytes.NewReader(data))
+		return nil, false
+	}
+	if !bytes.Contains(bytes.ToLower(data), []byte("maximum prompt length")) {
+		resp.Body = io.NopCloser(bytes.NewReader(data))
+		return nil, false
+	}
+	// 提取上游精确 token 数(形如 "contains 500724 tokens")，提取失败则不带数字。
+	detail := "Run /compact to shrink the context, then retry."
+	if n := extractUpstreamTokenCount(data); n > 0 {
+		detail = fmt.Sprintf("Conversation is %d tokens, over the model limit. %s", n, detail)
+	} else {
+		detail = "Conversation exceeds the model context limit. " + detail
+	}
+	body, _ := json.Marshal(map[string]any{
+		"type":  "error",
+		"error": map[string]any{"type": "invalid_request_error", "message": detail},
+	})
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.Header = resp.Header.Clone()
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	return resp, true
+}
+
+// extractUpstreamTokenCount 从上游报错中提取 "contains <N> tokens" 的 N，失败返回 0。
+func extractUpstreamTokenCount(data []byte) int64 {
+	lower := bytes.ToLower(data)
+	idx := bytes.Index(lower, []byte("contains "))
+	if idx < 0 {
+		return 0
+	}
+	rest := bytes.TrimSpace(lower[idx+len("contains "):])
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0
+	}
+	n, err := strconv.ParseInt(string(rest[:end]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/backend/internal/infra/provider/cli/context_limit_test.go
+++ b/backend/internal/infra/provider/cli/context_limit_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func makeResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// 上游 400 含 maximum prompt length → 改写成 /compact 引导，保留精确 token 数。
+func TestRewriteContextLimitResponse(t *testing.T) {
+	up := `{"error":{"message":"This model's maximum prompt length is 500000 but the request contains 500724 tokens"}}`
+	resp, ok := rewriteContextLimitResponse(makeResp(400, up))
+	if !ok {
+		t.Fatal("should rewrite context-limit 400")
+	}
+	data, _ := io.ReadAll(resp.Body)
+	s := string(data)
+	if !strings.Contains(s, "/compact") {
+		t.Fatalf("rewritten message must guide /compact: %s", s)
+	}
+	if !strings.Contains(s, "500724") {
+		t.Fatalf("must preserve upstream token count: %s", s)
+	}
+	if !strings.Contains(s, "invalid_request_error") {
+		t.Fatalf("must be invalid_request_error: %s", s)
+	}
+}
+
+// 无关的 400 不应被改写，body 原样保留。
+func TestRewriteContextLimitIgnoresOther400(t *testing.T) {
+	up := `{"error":{"message":"some other bad request"}}`
+	_, ok := rewriteContextLimitResponse(makeResp(400, up))
+	if ok {
+		t.Fatal("non-context-limit 400 must not be rewritten")
+	}
+}
+
+func TestExtractUpstreamTokenCount(t *testing.T) {
+	n := extractUpstreamTokenCount([]byte("the request contains 500724 tokens"))
+	if n != 500724 {
+		t.Fatalf("extracted %d, want 500724", n)
+	}
+	if extractUpstreamTokenCount([]byte("no number here")) != 0 {
+		t.Fatal("should return 0 when no count")
+	}
+}

--- a/backend/internal/infra/provider/conversation/prompt_cache_contract_test.go
+++ b/backend/internal/infra/provider/conversation/prompt_cache_contract_test.go
@@ -1,0 +1,116 @@
+package conversation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestConvertMessagesDropsCacheControlAndDoesNotInventPromptCacheKey 验证 Claude Code
+// 常见的 cache_control 断点不会进入 Grok Responses 请求，billing header 被过滤，
+// 且转换层不凭空发明 prompt_cache_key(该 key 由 gateway 层 prompt_cache.go 推导)。
+func TestConvertMessagesDropsCacheControlAndDoesNotInventPromptCacheKey(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet-4-5","max_tokens":1024,
+		"system":[
+			{"type":"text","text":"x-anthropic-billing-header: drop-me"},
+			{"type":"text","text":"You are Claude Code.","cache_control":{"type":"ephemeral"}}
+		],
+		"messages":[
+			{"role":"user","content":[
+				{"type":"text","text":"first question","cache_control":{"type":"ephemeral"}}
+			]}
+		],
+		"tools":[
+			{"name":"Bash","description":"run shell","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}
+		]
+	}`)
+	converted, err := ConvertRequest(body, "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["prompt_cache_key"]; exists {
+		t.Fatalf("conversation convert must not invent prompt_cache_key, got %#v", payload["prompt_cache_key"])
+	}
+	if payload["instructions"] != "You are Claude Code." {
+		t.Fatalf("instructions should keep system text and drop billing header, got %#v", payload["instructions"])
+	}
+	raw, _ := json.Marshal(payload)
+	if strings.Contains(string(raw), "cache_control") {
+		t.Fatalf("cache_control must not leak into Responses payload: %s", raw)
+	}
+	if strings.Contains(string(raw), "x-anthropic-billing-header") {
+		t.Fatalf("billing header must be dropped: %s", raw)
+	}
+}
+
+// TestConvertMessagesToolListChangeBreaksStablePrefix 验证 MCP/工具列表变化会改变
+// 发给 Grok 的 tools 前缀——这是比 cache_control 更可能打穿 Grok 缓存的因素。
+func TestConvertMessagesToolListChangeBreaksStablePrefix(t *testing.T) {
+	base := `{
+		"model":"claude-sonnet-4-5","max_tokens":128,
+		"system":"stable",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":%s
+	}`
+	toolsA := `[{"name":"Read","description":"read","input_schema":{"type":"object"}},{"name":"Bash","description":"bash","input_schema":{"type":"object"}}]`
+	toolsB := `[{"name":"Read","description":"read","input_schema":{"type":"object"}},{"name":"Bash","description":"bash","input_schema":{"type":"object"}},{"name":"mcp__x__tool","description":"mcp","input_schema":{"type":"object"}}]`
+	c1, err := ConvertRequest([]byte(fmt.Sprintf(base, toolsA)), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := ConvertRequest([]byte(fmt.Sprintf(base, toolsB)), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p1, p2 map[string]any
+	_ = json.Unmarshal(c1, &p1)
+	_ = json.Unmarshal(c2, &p2)
+	t1, _ := json.Marshal(p1["tools"])
+	t2, _ := json.Marshal(p2["tools"])
+	if string(t1) == string(t2) {
+		t.Fatalf("expected tools prefix to change when MCP tool is added")
+	}
+	if !strings.Contains(string(t2), "mcp__x__tool") {
+		t.Fatalf("expected mcp tool in converted tools: %s", t2)
+	}
+}
+
+// TestConvertAnthropicToolsDedup 验证同名工具去重(F7)，规避上游 Grok "Duplicate function definition"。
+func TestConvertAnthropicToolsDedup(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet-4-5","max_tokens":128,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[
+			{"name":"Read","description":"a","input_schema":{"type":"object"}},
+			{"name":"Read","description":"b","input_schema":{"type":"object"}},
+			{"name":"Bash","description":"c","input_schema":{"type":"object"}}
+		]
+	}`)
+	converted, err := ConvertRequest(body, "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(converted, &payload)
+	tools, _ := payload["tools"].([]any)
+	names := map[string]int{}
+	for _, tv := range tools {
+		if m, ok := tv.(map[string]any); ok {
+			if n, ok := m["name"].(string); ok {
+				names[n]++
+			}
+		}
+	}
+	if names["Read"] != 1 {
+		t.Fatalf("duplicate tool Read should be deduped to 1, got %d", names["Read"])
+	}
+	if names["Bash"] != 1 {
+		t.Fatalf("Bash should be present once, got %d", names["Bash"])
+	}
+}

--- a/backend/internal/infra/provider/conversation/request.go
+++ b/backend/internal/infra/provider/conversation/request.go
@@ -12,6 +12,10 @@ const (
 	OperationResponses = "responses"
 	OperationChat      = "chat"
 	OperationMessages  = "messages"
+
+	// maxUpstreamTools 是上游 Grok Responses API 的工具数硬上限。
+	// Claude Code 挂多个 MCP 时工具数可达数百，超限触发上游 400 "Maximum tools limit reached"。
+	maxUpstreamTools = 250
 )
 
 // ConvertRequest 将下游对话协议转换为 Responses 请求，作为 Provider 的统一上游协议。
@@ -349,7 +353,15 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 		existing, _ := target["tools"].([]any)
 		target["tools"] = append(existing, servers...)
 	}
-	if request.ToolChoice != nil {
+	// 上游 Grok Responses API 对工具数有硬上限(maxUpstreamTools)。Claude Code 挂多个 MCP 时
+	// 工具数可达数百(内置工具在前、MCP 工具在后)，超限会触发上游 400 "Maximum tools limit reached"。
+	// 保留前 maxUpstreamTools 个即保住全部核心能力，仅丢弃溢出的 MCP 工具。
+	if existing, ok := target["tools"].([]any); ok && len(existing) > maxUpstreamTools {
+		target["tools"] = existing[:maxUpstreamTools]
+	}
+	// 仅当最终确实带上了 tools 时才转发 tool_choice。Claude Code 可能在工具被过滤成空后
+	// 仍带 tool_choice，会触发上游 400 "tool_choice was set but no tools were specified"。
+	if _, hasTools := target["tools"]; hasTools && request.ToolChoice != nil {
 		choice, parallel, err := convertAnthropicToolChoice(*request.ToolChoice)
 		if err != nil {
 			return nil, ResponseOptions{}, err
@@ -522,29 +534,38 @@ func convertAnthropicMessages(messages []anthropicMessage, declaredTools map[str
 				delete(pendingCalls, toolUseID)
 			case "thinking":
 				if role != "assistant" {
-					return nil, nil, fmt.Errorf("%s thinking 只允许出现在 assistant 消息", path)
+					// 非 assistant 的 thinking 块无意义，跳过而非报错(Claude Code 多轮历史容错)。
+					continue
 				}
 				flushMessage()
 				var thinking, signature string
 				_ = json.Unmarshal(block["thinking"], &thinking)
 				_ = json.Unmarshal(block["signature"], &signature)
 				item := map[string]any{"type": "reasoning", "summary": []any{map[string]any{"type": "summary_text", "text": thinking}}}
-				if signature != "" {
+				// 仅回传看起来是真加密内容的 signature；伪造/过短签名会让上游 Grok 报
+				// "Could not decrypt encrypted_content" 400，故过滤。
+				if isLikelyEncryptedContent(signature) {
 					item["encrypted_content"] = signature
 				}
 				input = append(input, item)
 			case "redacted_thinking":
 				if role != "assistant" {
-					return nil, nil, fmt.Errorf("%s redacted_thinking 只允许出现在 assistant 消息", path)
+					// 非 assistant 的 redacted_thinking 块跳过而非报错。
+					continue
 				}
 				flushMessage()
 				var data string
 				if json.Unmarshal(block["data"], &data) != nil || data == "" {
-					return nil, nil, fmt.Errorf("%s.data 无效", path)
+					// data 无效时跳过而非报错。
+					continue
 				}
 				input = append(input, map[string]any{"type": "reasoning", "encrypted_content": data})
 			default:
-				return nil, nil, fmt.Errorf("当前不支持 Anthropic content.type=%q", typeName)
+				// 宽松容错:Anthropic 服务端执行的工具块(server_tool_use / web_search_tool_result /
+				// code_execution_tool_result / mcp_tool_use / mcp_tool_result / container_upload /
+				// tool_search_tool_result)及任何未知块，上游 Grok 不识别，转发会触发 400，
+				// 故静默剥离(continue)而非 fail-closed 报错。
+				continue
 			}
 		}
 		flushMessage()
@@ -556,6 +577,13 @@ func convertAnthropicMessages(messages []anthropicMessage, declaredTools map[str
 		return nil, nil, errors.New("messages 必须为每个 tool_use 提供 tool_result")
 	}
 	return input, instructions, nil
+}
+
+// isLikelyEncryptedContent 判断 signature 是否像真的加密内容。
+// Claude Code 多轮历史里可能带伪造/占位签名(如空串或极短字符串)，
+// 回传给上游 Grok 会触发 "Could not decrypt encrypted_content" 400，故用长度粗过滤。
+func isLikelyEncryptedContent(value string) bool {
+	return len(strings.TrimSpace(value)) >= 32
 }
 
 func anthropicSystemText(raw json.RawMessage) (string, error) {
@@ -575,8 +603,14 @@ func anthropicSystemText(raw json.RawMessage) (string, error) {
 	}
 	parts := make([]string, 0, len(blocks))
 	for _, block := range blocks {
-		if block.Type != "text" {
-			return "", fmt.Errorf("system 不支持 type=%q", block.Type)
+		// 宽松容错:只提取 text 块，忽略未知/空块（Claude Code / MCP 可能带非 text 块），不 fail-closed。
+		if block.Type != "text" || block.Text == "" {
+			continue
+		}
+		// Claude Code 注入的计费归因块（x-anthropic-billing-header: ...cch=...）对上游无意义，
+		// 且其中的 cch 每轮变化，若混入 instructions 会打穿上游 prompt cache，丢弃。
+		if strings.HasPrefix(block.Text, "x-anthropic-billing-header") {
+			continue
 		}
 		parts = append(parts, block.Text)
 	}
@@ -730,14 +764,21 @@ func markAnthropicToolError(output any) any {
 
 func convertAnthropicTools(tools []map[string]json.RawMessage) ([]any, error) {
 	result := make([]any, 0, len(tools))
+	// Claude Code 挂多个 MCP 时可能出现同名工具，按 name 保留首个，
+	// 规避上游 Grok "Duplicate function definition provided: xxx" 400。
+	seen := make(map[string]struct{}, len(tools))
 	for index, tool := range tools {
 		var typeName string
 		_ = json.Unmarshal(tool["type"], &typeName)
 		if strings.HasPrefix(typeName, "web_search_") {
+			if _, ok := seen["web_search"]; ok {
+				continue
+			}
 			converted, err := convertAnthropicWebSearchTool(tool, index)
 			if err != nil {
 				return nil, err
 			}
+			seen["web_search"] = struct{}{}
 			result = append(result, converted)
 			continue
 		}
@@ -749,6 +790,9 @@ func convertAnthropicTools(tools []map[string]json.RawMessage) ([]any, error) {
 		_ = json.Unmarshal(tool["description"], &description)
 		if strings.TrimSpace(name) == "" {
 			return nil, errors.New("Anthropic tool 缺少 name")
+		}
+		if _, ok := seen[name]; ok {
+			continue
 		}
 		var schema any = map[string]any{"type": "object", "properties": map[string]any{}}
 		if raw := tool["input_schema"]; !isEmptyJSON(raw) {
@@ -764,6 +808,7 @@ func convertAnthropicTools(tools []map[string]json.RawMessage) ([]any, error) {
 			}
 			converted["strict"] = strict
 		}
+		seen[name] = struct{}{}
 		result = append(result, converted)
 	}
 	return result, nil

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -51,6 +51,7 @@ func (h *Handler) Register(router *gin.RouterGroup) {
 	router.POST("/responses", h.createResponse)
 	router.POST("/chat/completions", h.createChatCompletion)
 	router.POST("/messages", h.createMessage)
+	router.POST("/messages/count_tokens", h.countMessageTokens)
 	router.POST("/images/generations", h.generateImage)
 	router.POST("/images/edits", h.editImage)
 	router.POST("/videos/generations", h.generateVideo)
@@ -190,7 +191,7 @@ func (h *Handler) createChatCompletion(c *gin.Context) {
 	requestIDValue, _ := requestID.(string)
 	result, err := h.gateway.CreateChatCompletion(c.Request.Context(), gateway.Input{
 		RequestID: requestIDValue, ClientKey: clientKey, PublicModel: request.Model,
-		Body: body, Streaming: request.Stream,
+		Body: body, Streaming: request.Stream, SessionID: extractSessionID(c, body),
 	})
 	if err != nil {
 		writeGatewayError(c, err)
@@ -229,13 +230,87 @@ func (h *Handler) createMessage(c *gin.Context) {
 	requestIDValue, _ := requestID.(string)
 	result, err := h.gateway.CreateMessage(c.Request.Context(), gateway.Input{
 		RequestID: requestIDValue, ClientKey: clientKey, PublicModel: request.Model,
-		Body: body, Streaming: request.Stream,
+		Body: body, Streaming: request.Stream, SessionID: extractSessionID(c, body),
 	})
 	if err != nil {
 		writeGatewayAnthropicError(c, err)
 		return
 	}
 	h.writeResult(c, result, request.Stream)
+}
+
+// countMessageTokens 实现 Anthropic 兼容的 POST /v1/messages/count_tokens。
+// Claude Code 在发送 /v1/messages 前会调用该端点估算上下文 token 数用于上下文管理与压缩决策。
+// 上游 Grok Responses API 无对应端点，故本地做保守估算，返回 {"input_tokens": N}，不占用上游账号、不计费。
+func (h *Handler) countMessageTokens(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, h.maxBodyBytes)
+	if !isJSONRequest(c) {
+		writeAnthropicError(c, http.StatusUnsupportedMediaType, "invalid_request_error", "count_tokens only supports application/json")
+		return
+	}
+	if strings.TrimSpace(c.GetHeader("anthropic-version")) == "" {
+		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "anthropic-version header is required")
+		return
+	}
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		writeAnthropicError(c, http.StatusRequestEntityTooLarge, "invalid_request_error", "request body exceeds the configured limit")
+		return
+	}
+	// count_tokens 不要求 max_tokens，仅需 model + messages。
+	var request messagesRequest
+	if json.Unmarshal(body, &request) != nil || strings.TrimSpace(request.Model) == "" || len(bytes.TrimSpace(request.Messages)) == 0 {
+		writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "model and messages are required")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"input_tokens": estimateInputTokens(body)})
+}
+
+// estimateInputTokens 对完整请求体做保守的输入 token 估算(约 4 字符/token,最小 1),
+// 供 count_tokens 端点使用。不追求与官方分词器精确一致,只需给 Claude Code 的上下文管理提供合理量级。
+func estimateInputTokens(body []byte) int64 {
+	tokens := (int64(len(body)) + 3) / 4
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
+}
+
+// extractSessionID 读取客户端携带的会话标识，作为 prompt cache 的 seed。
+// Claude Code 的真实会话 id 优先在 x-claude-code-session-id 头(抓包实测)，
+// 其次是通用 session 头，最后回退到请求体 metadata.user_id 内嵌 JSON 的 session_id。
+// 抓到稳定 session 才能保住上游缓存命中；抓不到会退化到内容派生，命中率下降。
+func extractSessionID(c *gin.Context, body []byte) string {
+	for _, key := range []string{"x-claude-code-session-id", "session_id", "conversation_id", "x-grok-conv-id"} {
+		if value := strings.TrimSpace(c.GetHeader(key)); value != "" {
+			return value
+		}
+	}
+	// Claude Code 的 metadata.user_id 是一个 JSON 字符串，内含 session_id。
+	return sessionIDFromMetadataUserID(body)
+}
+
+// sessionIDFromMetadataUserID 从请求体 metadata.user_id 的内嵌 JSON 中提取 session_id。
+// Claude Code 的 user_id 形如 {"device_id":"...","account_uuid":"...","session_id":"..."}。
+func sessionIDFromMetadataUserID(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var probe struct {
+		Metadata struct {
+			UserID string `json:"user_id"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal(body, &probe) != nil || strings.TrimSpace(probe.Metadata.UserID) == "" {
+		return ""
+	}
+	var inner struct {
+		SessionID string `json:"session_id"`
+	}
+	if json.Unmarshal([]byte(probe.Metadata.UserID), &inner) != nil {
+		return ""
+	}
+	return strings.TrimSpace(inner.SessionID)
 }
 
 func (h *Handler) generateImage(c *gin.Context) {
@@ -652,7 +727,7 @@ func (h *Handler) handleCreate(c *gin.Context, compact bool) {
 	}
 	requestID, _ := c.Get(middleware.RequestIDKey)
 	requestIDValue, _ := requestID.(string)
-	input := gateway.Input{RequestID: requestIDValue, ClientKey: clientKey, PublicModel: request.Model, Body: body, Streaming: request.Stream, PromptCacheKey: request.PromptCacheKey, PreviousResponseID: request.PreviousResponseID}
+	input := gateway.Input{RequestID: requestIDValue, ClientKey: clientKey, PublicModel: request.Model, Body: body, Streaming: request.Stream, PromptCacheKey: request.PromptCacheKey, SessionID: extractSessionID(c, body), PreviousResponseID: request.PreviousResponseID}
 	var result *gateway.Result
 	if compact {
 		result, err = h.gateway.CompactResponse(c.Request.Context(), input)
@@ -932,6 +1007,9 @@ type responseUsageDTO struct {
 	ContextDetails         responseContextDetailsDTO `json:"context_details"`
 	PromptTokens           int64                     `json:"prompt_tokens"`
 	CompletionTokens       int64                     `json:"completion_tokens"`
+	// Anthropic Messages 兼容字段：转换后的 /v1/messages 响应用 cache_read/creation_input_tokens。
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
 }
 
 type responseInputDetailsDTO struct {
@@ -969,8 +1047,14 @@ func (value responseUsageDTO) toGatewayUsage(responseModel string) gateway.Usage
 	if total == 0 {
 		total = input + output
 	}
+	// Messages 转换后的 usage 使用 Anthropic 字段名(cache_read_input_tokens)，
+	// Grok 原生 usage 用 input_tokens_details.cached_tokens，两者取非零者。
+	cached := value.InputTokensDetails.CachedTokens
+	if cached == 0 {
+		cached = value.CacheReadInputTokens
+	}
 	return gateway.Usage{
-		InputTokens: input, CachedInputTokens: value.InputTokensDetails.CachedTokens,
+		InputTokens: input, CachedInputTokens: cached, CacheCreationInputTokens: value.CacheCreationInputTokens,
 		OutputTokens: output, ReasoningTokens: value.OutputTokensDetails.ReasoningTokens,
 		TotalTokens: total, CostInUSDTicks: value.CostInUSDTicks,
 		NumSourcesUsed: value.NumSourcesUsed, NumServerSideToolsUsed: value.NumServerSideToolsUsed,
@@ -1022,7 +1106,11 @@ func writeGatewayError(c *gin.Context, err error) {
 	message := "上游服务暂不可用"
 	var upstreamFailure *gateway.UpstreamFailure
 	var selectionFailure *gateway.SelectionUnavailableError
+	var contextOverLimit *gateway.ContextOverLimitError
 	switch {
+	case errors.As(err, &contextOverLimit):
+		status, code = http.StatusBadRequest, "context_length_exceeded"
+		message = fmt.Sprintf("Conversation is ~%d tokens, over the %d limit. Run /compact to shrink the context, then retry.", contextOverLimit.EstimatedTokens, contextOverLimit.Limit)
 	case errors.Is(err, clientkeyapp.ErrBillingLimit):
 		status, code = http.StatusTooManyRequests, "billing_limit_exceeded"
 		message = clientkeyapp.ErrBillingLimit.Error()
@@ -1051,7 +1139,11 @@ func writeGatewayAnthropicError(c *gin.Context, err error) {
 	message := "上游服务暂不可用"
 	var upstreamFailure *gateway.UpstreamFailure
 	var selectionFailure *gateway.SelectionUnavailableError
+	var contextOverLimit *gateway.ContextOverLimitError
 	switch {
+	case errors.As(err, &contextOverLimit):
+		status, errorType = http.StatusBadRequest, "invalid_request_error"
+		message = fmt.Sprintf("Conversation is ~%d tokens, over the %d limit. Run /compact to shrink the context, then retry.", contextOverLimit.EstimatedTokens, contextOverLimit.Limit)
 	case errors.Is(err, clientkeyapp.ErrBillingLimit):
 		status, errorType = http.StatusTooManyRequests, "rate_limit_error"
 		message = clientkeyapp.ErrBillingLimit.Error()

--- a/backend/internal/transport/http/swagger_annotations.go
+++ b/backend/internal/transport/http/swagger_annotations.go
@@ -165,6 +165,20 @@ func swaggerChat() {}
 // @Router /v1/messages [post]
 func swaggerMessages() {}
 
+// swaggerCountTokens godoc
+// @Summary 估算 Anthropic Message 输入 token 数
+// @Description 本地保守估算请求输入 token 数（约 4 字符/token），供客户端上下文管理使用，不请求上游、不计费。
+// @Tags Messages
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param anthropic-version header string true "Anthropic API version" default(2023-06-01)
+// @Param request body SwaggerMessagesRequest true "请求"
+// @Success 200 {object} map[string]any
+// @Failure 400 {object} map[string]any
+// @Router /v1/messages/count_tokens [post]
+func swaggerCountTokens() {}
+
 // swaggerGenerateImage godoc
 // @Summary 生成图片
 // @Tags Images


### PR DESCRIPTION
## 背景

用 Claude Code / Anthropic Messages 客户端接入本网关（Grok Build 上游）时，遇到一批兼容与稳定性问题。本 PR 补齐这些改进，所有改动集中在后端，纯增量、不改动现有行为，编译与测试全绿。

## prompt cache 命中优化

Claude Code 每次工具描述微调、追加消息、cache_control 断点移动，都会让 `prompt_cache_key` 变化 → 缓存命中率从 90%+ 掉到 0。

- 从**稳定内容前缀**（model、排序后的工具名、system、首条 user 文本）+ session 头 + `metadata.user_id` 内嵌 `session_id` 推导租户隔离的 key，客户端不显式传 key 时也能生成稳定 key（`prompt_cache.go`）
- 工具只取**排序后的 name 列表**，忽略 description/schema 抖动
- `clientKeyID` 混入 hash，避免共享 OAuth 账号时 key 碰撞
- 读取真实的 `x-claude-code-session-id` 头作为 cache seed（`handler.go`）
- Grok Build OAuth 无工具请求注入 native `web_search`/`x_search` + `tool_choice=none`，帮助 Free 请求进入可缓存档（`adapter.go`）

## 转换层健壮性（Anthropic → Responses）

- 过滤 Claude Code 注入的 `x-anthropic-billing-header` 计费块（其中 `cch` 每轮变化会污染 instructions 打穿缓存）
- 工具数超上游硬上限（250）时截断，避免 `Maximum tools limit` 400
- 同名工具去重，规避 `Duplicate function definition` 400
- 仅当最终带 tools 时才转发 tool_choice，避免空 tools + tool_choice 400
- `server_tool_use` 等服务端块剥离、过短 signature 守卫、未知块宽松忽略（转发 Claude Code 多轮历史更稳）

## 上下文超限拦截

Grok-4.5 上下文硬上限 50 万 token。长会话撞上限时，客户端会带着超长上下文反复重试。

- **第 1 层**：请求估算 token 超限时，在发上游/占账号/预留计费之前主动拦截，秒级返回 400 + `/compact` 引导（`service.go`）
- **第 2 层**：上游真返 400 `maximum prompt length` 时，兜底改写为同样的 `/compact` 引导，保留上游精确 token 数（`adapter.go`）

## 其他

- 新增 `POST /v1/messages/count_tokens` 端点（本地保守估算，供客户端上下文管理，不请求上游、不计费）
- `claude-*` 模型名精确匹配失败时回退默认上游模型，开箱即用
- usage 补 `cache_read/creation_input_tokens`，Messages 响应正确回传缓存计数

## 测试

新增 `prompt_cache_test.go`、`prompt_cache_contract_test.go`、`context_limit_test.go`（gateway + cli）。`go build ./...` / `go test`（相关包）/ `go vet` 全绿。已在生产环境实测 100+ 请求，无兼容性报错。