### PR TITLE
fix: 视频完成后未减本地配额且 quota 刷新仅限 weekly 模式

### DIFF
--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -305,8 +305,19 @@ func (s *Service) runVideoJob(parent context.Context, job media.Job, route model
 	if err := s.recordVideoUsage(context.Background(), job, time.Since(startedAt).Milliseconds()); err != nil {
 		s.logger.Error("video_usage_record_failed", "job_id", job.ID, "event_id", "video_usage_"+job.ID, "error", err)
 	}
-	if quotaKind, _ := s.providers.QuotaKind(route.Provider); quotaKind == provider.QuotaRemoteWindow && lease.QuotaMode == "weekly" {
-		s.accounts.QueueQuotaRefresh(job.AccountID, lease.QuotaMode)
+	if lease.QuotaMode != "" {
+		if lease.QuotaMode != "weekly" {
+			units := 1
+			updated, decrementErr := s.accounts.DecrementQuota(context.Background(), job.AccountID, lease.QuotaMode, units)
+			if decrementErr != nil {
+				s.logger.Warn("video_quota_decrement_failed", "provider", route.Provider, "account_id", job.AccountID, "mode", lease.QuotaMode, "units", units, "error", decrementErr)
+			} else if updated {
+				s.selector.ConsumeQuota(route.Provider, job.AccountID, lease.QuotaMode, units)
+			}
+		}
+		if quotaKind, _ := s.providers.QuotaKind(route.Provider); quotaKind == provider.QuotaRemoteWindow {
+			s.accounts.QueueQuotaRefresh(job.AccountID, lease.QuotaMode)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

视频生成完成后的 quota 处理与文本路径不一致：

**文本路径**（service.go:580-592）：
1. 非 weekly 模式 → `DecrementQuota` 减本地配额
2. `QuotaRemoteWindow` 类型 → `QueueQuotaRefresh` 刷新远端（所有模式）

**视频路径**（video.go:308-310 修复前）：
1. ❌ 没有 `DecrementQuota`
2. ❌ 只在 `lease.QuotaMode == "weekly"` 时 `QueueQuotaRefresh`

**影响**：非 weekly 模式（如 fast）的视频生成不减本地配额计数器，导致路由层认为该账号仍有余量，重复选择同一个号，直到远端 quota check 追上来。

## Fix

对齐文本路径：
- 非 weekly 模式成功后 `DecrementQuota(units=1)` + `ConsumeQuota`
- 所有 `QuotaRemoteWindow` provider 成功后 `QueueQuotaRefresh`（不再限制 weekly）

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test ./...` 全量通过
- [x] 逻辑与 service.go:580-592 文本路径完全对齐