### PR TITLE
fix: Chat/Messages 非流式错误响应透传上游错误详情

### DIFF
--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -159,7 +159,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			resp.Body = conversation.ConvertResponseStreamWithOptions(resp.Body, request.Operation, conversationOptions)
 			resp.Header.Del("Content-Length")
 			resp.Header.Set("Content-Type", "text/event-stream")
-		} else {
+		} else if !request.Streaming || resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			data, readErr := io.ReadAll(io.LimitReader(resp.Body, (64<<20)+1))
 			_ = resp.Body.Close()
 			if readErr != nil {
@@ -170,11 +170,17 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			}
 			converted, convertErr := conversation.ConvertResponseJSONWithOptions(data, request.Operation, conversationOptions)
 			if convertErr != nil {
-				return nil, convertErr
+				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+					resp.Body = io.NopCloser(bytes.NewReader(data))
+					resp.Header.Set("Content-Length", strconv.Itoa(len(data)))
+				} else {
+					return nil, convertErr
+				}
+			} else {
+				resp.Body = io.NopCloser(bytes.NewReader(converted))
+				resp.Header.Set("Content-Length", strconv.Itoa(len(converted)))
+				resp.Header.Set("Content-Type", "application/json")
 			}
-			resp.Body = io.NopCloser(bytes.NewReader(converted))
-			resp.Header.Set("Content-Length", strconv.Itoa(len(converted)))
-			resp.Header.Set("Content-Type", "application/json")
 		}
 	}
 	return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: resp.Header.Clone(), Body: resp.Body}, nil


### PR DESCRIPTION
## Summary

Closes #628

Chat/Messages 非流式分支（`adapter.go:162`）无条件将所有响应体通过 `ConvertResponseJSONWithOptions` 转换，包括非 2xx 错误响应。当上游返回非标准格式的错误（HTML、纯文本、非 Responses API JSON）时，转换失败导致原始错误信息丢失。

**影响**：所有通过 `/v1/chat/completions` 或 `/v1/messages` 以 `stream: false` 调用的用户，在遇到 429（限流）、401（认证失败）、500（上游错误）等情况时，收不到有意义的错误信息。

## Root Cause

Responses 路径（第 134 行）和流式路径（第 158 行）都有 `resp.StatusCode >= 200 && resp.StatusCode < 300` 守卫，但非流式 `else` 分支没有。

## Fix

- 非 2xx 响应仍先尝试转换（上游可能返回标准 Responses API error 格式）
- 转换失败时，非 2xx 响应直接透传原始 body（保留上游错误详情）
- 2xx 响应转换失败仍返回 Go error（行为不变）

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test ./...` 全量通过（57 包，0 失败）
- [x] 自审覆盖所有 4 种组合（流式/非流式 × 2xx/非2xx）