### PR TITLE
feat(messages): map Build web_search_call to Anthropic server tool blocks

### DIFF
--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -333,6 +333,76 @@ func TestForwardResponsePreservesClaudeCodeMessagesOptions(t *testing.T) {
 	}
 }
 
+func TestForwardResponseMapsClaudeCodeWebSearchEndToEnd(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1"}, cipher)
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		tools, _ := payload["tools"].([]any)
+		if len(tools) != 1 || tools[0].(map[string]any)["type"] != "web_search" || payload["tool_choice"] != "required" {
+			t.Fatalf("upstream web search payload = %#v", payload)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Status: "200 OK", Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"resp_search","model":"grok-4.5","status":"completed",
+				"output":[
+					{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"url":"https://doc.rust-lang.org"}]}},
+					{"type":"message","content":[{"type":"output_text","text":"Here you go.","annotations":[{"type":"url_citation","url":"https://doc.rust-lang.org","title":"The Rust Book"}]}]}
+				],
+				"usage":{"input_tokens":7,"output_tokens":5,"total_tokens":12}
+			}`)),
+			Request: request,
+		}, nil
+	})
+
+	response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+		Credential: account.Credential{EncryptedAccessToken: encrypted},
+		Method:     http.MethodPost, Path: "/responses", Model: "grok-4.5", NormalizeBody: true,
+		Operation: conversation.OperationMessages,
+		Body: []byte(`{
+			"model":"public","max_tokens":256,
+			"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+			"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+			"tool_choice":{"type":"tool","name":"web_search"}
+		}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var payload map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	content := payload["content"].([]any)
+	if len(content) != 3 || content[0].(map[string]any)["type"] != "server_tool_use" || content[1].(map[string]any)["type"] != "web_search_tool_result" || content[2].(map[string]any)["text"] != "Here you go." {
+		t.Fatalf("messages web search response = %#v", payload)
+	}
+	use := content[0].(map[string]any)
+	if use["input"].(map[string]any)["query"] != "rust tutorials" || content[1].(map[string]any)["tool_use_id"] != use["id"] {
+		t.Fatalf("web search block linkage = %#v", content)
+	}
+	hits := content[1].(map[string]any)["content"].([]any)
+	if len(hits) != 1 || hits[0].(map[string]any)["title"] != "The Rust Book" {
+		t.Fatalf("web search hits = %#v", hits)
+	}
+	serverUsage := payload["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+	if serverUsage["web_search_requests"] != float64(1) || payload["stop_reason"] != "end_turn" {
+		t.Fatalf("messages web search usage = %#v", payload)
+	}
+}
+
 func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -108,7 +108,7 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 		target["tools"] = append(existing, servers...)
 	}
 	if request.ToolChoice != nil {
-		choice, parallel, err := convertAnthropicToolChoice(*request.ToolChoice)
+		choice, parallel, err := convertAnthropicToolChoice(*request.ToolChoice, hasAnthropicWebSearchTool(request.Tools))
 		if err != nil {
 			return nil, ResponseOptions{}, err
 		}
@@ -527,6 +527,17 @@ func convertAnthropicTools(tools []map[string]json.RawMessage) ([]any, error) {
 	return result, nil
 }
 
+func hasAnthropicWebSearchTool(tools []map[string]json.RawMessage) bool {
+	for _, tool := range tools {
+		var typeName string
+		_ = json.Unmarshal(tool["type"], &typeName)
+		if strings.HasPrefix(typeName, "web_search_") {
+			return true
+		}
+	}
+	return false
+}
+
 func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (map[string]any, error) {
 	converted := map[string]any{"type": "web_search"}
 	for key, raw := range tool {
@@ -594,7 +605,7 @@ func anthropicThinkingEffort(budget int) string {
 	}
 }
 
-func convertAnthropicToolChoice(choice anthropicToolChoice) (any, bool, error) {
+func convertAnthropicToolChoice(choice anthropicToolChoice, hasHostedWebSearch bool) (any, bool, error) {
 	parallel := !choice.DisableParallelToolUse
 	switch choice.Type {
 	case "auto", "none":
@@ -607,7 +618,7 @@ func convertAnthropicToolChoice(choice anthropicToolChoice) (any, bool, error) {
 		}
 		// Claude Code secondary search forces name=web_search (hosted). Build accepts
 		// hosted tool_choice only as "required" when a single hosted tool remains.
-		if strings.EqualFold(strings.TrimSpace(choice.Name), "web_search") {
+		if hasHostedWebSearch && strings.EqualFold(strings.TrimSpace(choice.Name), "web_search") {
 			return "required", parallel, nil
 		}
 		return map[string]any{"type": "function", "name": choice.Name}, parallel, nil

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -605,6 +605,11 @@ func convertAnthropicToolChoice(choice anthropicToolChoice) (any, bool, error) {
 		if strings.TrimSpace(choice.Name) == "" {
 			return nil, false, errors.New("tool_choice.tool 缺少 name")
 		}
+		// Claude Code secondary search forces name=web_search (hosted). Build accepts
+		// hosted tool_choice only as "required" when a single hosted tool remains.
+		if strings.EqualFold(strings.TrimSpace(choice.Name), "web_search") {
+			return "required", parallel, nil
+		}
 		return map[string]any{"type": "function", "name": choice.Name}, parallel, nil
 	default:
 		return nil, false, fmt.Errorf("不支持 tool_choice.type=%q", choice.Type)

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -75,6 +75,13 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 		}
 		target["text"] = map[string]any{"format": map[string]any{"type": "json_schema", "name": "anthropic_output", "schema": request.OutputConfig.Format.Schema}}
 	}
+	hasWebSearchTool := hasAnthropicWebSearchTool(request.Tools)
+	webSearchEnabled := hasWebSearchTool && (request.ToolChoice == nil || !strings.EqualFold(strings.TrimSpace(request.ToolChoice.Type), "none"))
+	webSearchRequired := webSearchEnabled && anthropicWebSearchRequired(request.Tools, request.ToolChoice)
+	webSearchQuery := ""
+	if webSearchEnabled {
+		webSearchQuery = anthropicWebSearchQuery(request.Messages)
+	}
 	if thinkingEnabled {
 		effort := anthropicThinkingEffort(request.Thinking.BudgetTokens)
 		if request.OutputConfig != nil && request.OutputConfig.Effort != "" {
@@ -108,7 +115,7 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 		target["tools"] = append(existing, servers...)
 	}
 	if request.ToolChoice != nil {
-		choice, parallel, err := convertAnthropicToolChoice(*request.ToolChoice, hasAnthropicWebSearchTool(request.Tools))
+		choice, parallel, err := convertAnthropicToolChoice(*request.ToolChoice, hasWebSearchTool)
 		if err != nil {
 			return nil, ResponseOptions{}, err
 		}
@@ -117,8 +124,11 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 	}
 	converted, err := json.Marshal(target)
 	return converted, ResponseOptions{
-		AnthropicThinking: thinkingEnabled,
-		StopSequences:     append([]string(nil), request.StopSequences...),
+		AnthropicThinking:          thinkingEnabled,
+		AnthropicWebSearch:         webSearchEnabled,
+		AnthropicWebSearchRequired: webSearchRequired,
+		AnthropicWebSearchQuery:    webSearchQuery,
+		StopSequences:              append([]string(nil), request.StopSequences...),
 	}, err
 }
 
@@ -536,6 +546,70 @@ func hasAnthropicWebSearchTool(tools []map[string]json.RawMessage) bool {
 		}
 	}
 	return false
+}
+
+func anthropicWebSearchRequired(tools []map[string]json.RawMessage, choice *anthropicToolChoice) bool {
+	if choice == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(choice.Type)) {
+	case "tool":
+		return strings.EqualFold(strings.TrimSpace(choice.Name), "web_search")
+	case "any":
+		return len(tools) == 1 && hasAnthropicWebSearchTool(tools)
+	default:
+		return false
+	}
+}
+
+func anthropicWebSearchQuery(messages []anthropicMessage) string {
+	const prefix = "perform a web search for the query:"
+	for index := len(messages) - 1; index >= 0; index-- {
+		if !strings.EqualFold(strings.TrimSpace(messages[index].Role), "user") {
+			continue
+		}
+		text := anthropicMessageText(messages[index].Content)
+		if text == "" {
+			continue
+		}
+		if offset := strings.Index(strings.ToLower(text), prefix); offset >= 0 {
+			text = strings.TrimSpace(text[offset+len(prefix):])
+		}
+		return truncateRunes(strings.TrimSpace(text), 4096)
+	}
+	return ""
+}
+
+func anthropicMessageText(raw json.RawMessage) string {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return strings.TrimSpace(text)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return ""
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == "text" && strings.TrimSpace(block.Text) != "" {
+			parts = append(parts, strings.TrimSpace(block.Text))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func truncateRunes(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit])
 }
 
 func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (map[string]any, error) {

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -8,7 +8,7 @@ import (
 )
 
 func messagesResponse(value parsedResponse, options ResponseOptions) map[string]any {
-	content := make([]any, 0, len(value.Calls))
+	content := make([]any, 0, len(value.Calls)+len(value.WebSearch)*2+2)
 	if options.AnthropicThinking && (value.Reasoning != "" || value.Signature != "") {
 		if value.Reasoning == "" {
 			content = append(content, map[string]any{"type": "redacted_thinking", "data": value.Signature})
@@ -20,7 +20,9 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 			content = append(content, thinking)
 		}
 	}
-	if value.Text != "" || len(value.Calls) == 0 {
+	// Hosted web search completes in-process; emit Anthropic server tool blocks first.
+	content = appendServerWebSearchContent(content, value.WebSearch)
+	if value.Text != "" || (len(value.Calls) == 0 && len(value.WebSearch) == 0) {
 		content = append(content, map[string]any{"type": "text", "text": value.Text})
 	}
 	for _, call := range value.Calls {
@@ -32,6 +34,7 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 	}
 	stopReason := "end_turn"
 	if len(value.Calls) > 0 {
+		// Client tools still pause the turn. Hosted web_search does not.
 		stopReason = "tool_use"
 	} else if value.StopSequence != "" {
 		stopReason = "stop_sequence"
@@ -43,7 +46,7 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 	return map[string]any{
 		"id": anthropicMessageID(value.ID), "type": "message", "role": "assistant",
 		"model": value.Model, "content": content, "stop_reason": stopReason, "stop_sequence": nullableAnthropicString(value.StopSequence),
-		"usage": anthropicUsage(value.Usage),
+		"usage": anthropicUsage(value.Usage, webSearchRequestCount(value.WebSearch)),
 	}
 }
 
@@ -95,11 +98,15 @@ func nullableAnthropicString(value string) any {
 	return value
 }
 
-func anthropicUsage(value responseUsage) map[string]any {
-	return map[string]any{
+func anthropicUsage(value responseUsage, webSearchRequests int) map[string]any {
+	usage := map[string]any{
 		"input_tokens": value.InputTokens, "output_tokens": value.OutputTokens,
 		"cache_creation_input_tokens": 0, "cache_read_input_tokens": value.InputTokensDetails.CachedTokens,
 	}
+	if webSearchRequests > 0 {
+		usage["server_tool_use"] = map[string]any{"web_search_requests": webSearchRequests}
+	}
+	return usage
 }
 
 func anthropicErrorJSON(value any) []byte {

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -8,7 +8,11 @@ import (
 )
 
 func messagesResponse(value parsedResponse, options ResponseOptions) map[string]any {
-	content := make([]any, 0, len(value.Calls)+len(value.WebSearch)*2+2)
+	webSearch := value.WebSearch
+	if options.AnthropicWebSearchRequired && len(webSearch) == 0 {
+		webSearch = []webSearchCall{unavailableWebSearchCall(options.AnthropicWebSearchQuery)}
+	}
+	content := make([]any, 0, len(value.Calls)+len(webSearch)*2+2)
 	if options.AnthropicThinking && (value.Reasoning != "" || value.Signature != "") {
 		if value.Reasoning == "" {
 			content = append(content, map[string]any{"type": "redacted_thinking", "data": value.Signature})
@@ -21,8 +25,8 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 		}
 	}
 	// Hosted web search completes in-process; emit Anthropic server tool blocks first.
-	content = appendServerWebSearchContent(content, value.WebSearch)
-	if value.Text != "" || (len(value.Calls) == 0 && len(value.WebSearch) == 0) {
+	content = appendServerWebSearchContent(content, webSearch)
+	if value.Text != "" || (len(value.Calls) == 0 && len(webSearch) == 0) {
 		content = append(content, map[string]any{"type": "text", "text": value.Text})
 	}
 	for _, call := range value.Calls {
@@ -46,7 +50,7 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 	return map[string]any{
 		"id": anthropicMessageID(value.ID), "type": "message", "role": "assistant",
 		"model": value.Model, "content": content, "stop_reason": stopReason, "stop_sequence": nullableAnthropicString(value.StopSequence),
-		"usage": anthropicUsage(value.Usage, webSearchRequestCount(value.WebSearch)),
+		"usage": anthropicUsage(value.Usage, webSearchRequestCount(webSearch)),
 	}
 }
 

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -12,7 +12,9 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 	if options.AnthropicWebSearchRequired && len(webSearch) == 0 {
 		webSearch = []webSearchCall{unavailableWebSearchCall(options.AnthropicWebSearchQuery)}
 	}
-	content := make([]any, 0, len(value.Calls)+len(webSearch)*2+2)
+	// Avoid capacity arithmetic on untrusted upstream lengths (CodeQL size overflow).
+	// appendServerWebSearchContent already hard-caps search blocks.
+	content := make([]any, 0)
 	if options.AnthropicThinking && (value.Reasoning != "" || value.Signature != "") {
 		if value.Reasoning == "" {
 			content = append(content, map[string]any{"type": "redacted_thinking", "data": value.Signature})

--- a/backend/internal/infra/provider/conversation/messages_stream.go
+++ b/backend/internal/infra/provider/conversation/messages_stream.go
@@ -209,6 +209,24 @@ func (c *streamConverter) toolArgumentsDoneMessages(itemID, arguments string) er
 }
 
 func (c *streamConverter) doneMessages(status string) error {
+	if c.thinkingStarted && !c.thinkingClosed {
+		c.thinkingClosed = true
+		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.thinkingIndex}); err != nil {
+			return err
+		}
+	}
+	if c.deferSearchText {
+		// Hosted search was observed before text, so preserve Anthropic's block order:
+		// server_tool_use → web_search_tool_result → text.
+		if err := c.emitPendingWebSearchResults(); err != nil {
+			return err
+		}
+		if pending := c.pendingSearchText.String(); pending != "" {
+			if err := c.textDeltaMessages(pending); err != nil {
+				return err
+			}
+		}
+	}
 	if c.stopSequence == "" {
 		if pending := c.stopFilter.Flush(); pending != "" {
 			if err := c.textDeltaWithoutFilter(pending); err != nil {
@@ -216,20 +234,15 @@ func (c *streamConverter) doneMessages(status string) error {
 			}
 		}
 	}
-	if c.thinkingStarted && !c.thinkingClosed {
-		c.thinkingClosed = true
-		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.thinkingIndex}); err != nil {
+	if c.textStarted {
+		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.textIndex}); err != nil {
 			return err
 		}
 	}
-	// Emit web_search_tool_result before closing text so order matches non-stream:
-	// server_tool_use → web_search_tool_result → text. If text already started, close it first then re-open is worse;
-	// CC secondary path mainly needs result blocks present before message_delta.
-	if err := c.emitPendingWebSearchResults(); err != nil {
-		return err
-	}
-	if c.textStarted {
-		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.textIndex}); err != nil {
+	if !c.deferSearchText {
+		// If text arrived before the search item, close it before starting any server
+		// tool blocks so content blocks never overlap.
+		if err := c.emitPendingWebSearchResults(); err != nil {
 			return err
 		}
 	}

--- a/backend/internal/infra/provider/conversation/messages_stream.go
+++ b/backend/internal/infra/provider/conversation/messages_stream.go
@@ -10,7 +10,7 @@ func (c *streamConverter) startMessages() error {
 		"type": "message_start", "message": map[string]any{
 			"id": anthropicMessageID(c.id), "type": "message", "role": "assistant",
 			"model": c.model, "content": []any{}, "stop_reason": nil, "stop_sequence": nil,
-			"usage": anthropicUsage(c.usage),
+			"usage": anthropicUsage(c.usage, 0),
 		},
 	})
 }
@@ -222,6 +222,12 @@ func (c *streamConverter) doneMessages(status string) error {
 			return err
 		}
 	}
+	// Emit web_search_tool_result before closing text so order matches non-stream:
+	// server_tool_use → web_search_tool_result → text. If text already started, close it first then re-open is worse;
+	// CC secondary path mainly needs result blocks present before message_delta.
+	if err := c.emitPendingWebSearchResults(); err != nil {
+		return err
+	}
 	if c.textStarted {
 		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": c.textIndex}); err != nil {
 			return err
@@ -229,6 +235,9 @@ func (c *streamConverter) doneMessages(status string) error {
 	}
 	openTools := make([]streamTool, 0)
 	for itemID, tool := range c.tools {
+		if strings.HasSuffix(itemID, "#ws") {
+			continue
+		}
 		if !tool.Closed {
 			tool.Closed = true
 			c.tools[itemID] = tool
@@ -242,16 +251,27 @@ func (c *streamConverter) doneMessages(status string) error {
 		}
 	}
 	stopReason := "end_turn"
-	if len(c.tools) > 0 {
+	// Only client function tools force tool_use stop. Hosted web_search is end_turn.
+	clientToolCount := 0
+	for itemID := range c.tools {
+		if !strings.HasSuffix(itemID, "#ws") {
+			clientToolCount++
+		}
+	}
+	if clientToolCount > 0 {
 		stopReason = "tool_use"
 	} else if c.stopSequence != "" {
 		stopReason = "stop_sequence"
 	} else if status == "incomplete" {
 		stopReason = "max_tokens"
 	}
+	usage := map[string]any{"input_tokens": c.usage.InputTokens, "output_tokens": c.usage.OutputTokens}
+	if n := webSearchRequestCount(c.webSearch); n > 0 {
+		usage["server_tool_use"] = map[string]any{"web_search_requests": n}
+	}
 	if err := c.writeEvent("message_delta", map[string]any{
 		"type": "message_delta", "delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nullableAnthropicString(c.stopSequence)},
-		"usage": map[string]any{"input_tokens": c.usage.InputTokens, "output_tokens": c.usage.OutputTokens},
+		"usage": usage,
 	}); err != nil {
 		return err
 	}

--- a/backend/internal/infra/provider/conversation/messages_stream.go
+++ b/backend/internal/infra/provider/conversation/messages_stream.go
@@ -215,6 +215,9 @@ func (c *streamConverter) doneMessages(status string) error {
 			return err
 		}
 	}
+	if c.options.AnthropicWebSearchRequired && len(c.webSearch) == 0 {
+		c.webSearch = []webSearchCall{unavailableWebSearchCall(c.options.AnthropicWebSearchQuery)}
+	}
 	if c.deferSearchText {
 		// Hosted search was observed before text, so preserve Anthropic's block order:
 		// server_tool_use → web_search_tool_result → text.
@@ -248,9 +251,6 @@ func (c *streamConverter) doneMessages(status string) error {
 	}
 	openTools := make([]streamTool, 0)
 	for itemID, tool := range c.tools {
-		if strings.HasSuffix(itemID, "#ws") {
-			continue
-		}
 		if !tool.Closed {
 			tool.Closed = true
 			c.tools[itemID] = tool
@@ -265,13 +265,7 @@ func (c *streamConverter) doneMessages(status string) error {
 	}
 	stopReason := "end_turn"
 	// Only client function tools force tool_use stop. Hosted web_search is end_turn.
-	clientToolCount := 0
-	for itemID := range c.tools {
-		if !strings.HasSuffix(itemID, "#ws") {
-			clientToolCount++
-		}
-	}
-	if clientToolCount > 0 {
+	if len(c.tools) > 0 {
 		stopReason = "tool_use"
 	} else if c.stopSequence != "" {
 		stopReason = "stop_sequence"

--- a/backend/internal/infra/provider/conversation/response.go
+++ b/backend/internal/infra/provider/conversation/response.go
@@ -138,6 +138,11 @@ func parseResponse(value responseEnvelope) parsedResponse {
 		case "function_call":
 			parsed.Calls = append(parsed.Calls, item)
 		case "web_search_call":
+			// Cap candidates early so pathological upstream envelopes cannot
+			// retain unbounded intermediate search state before dedupe.
+			if len(parsed.WebSearch) >= maxWebSearchCalls {
+				continue
+			}
 			if call, ok := parseWebSearchCallItem(item); ok {
 				parsed.WebSearch = append(parsed.WebSearch, call)
 			}

--- a/backend/internal/infra/provider/conversation/response.go
+++ b/backend/internal/infra/provider/conversation/response.go
@@ -33,12 +33,15 @@ type responseItem struct {
 	Name      string            `json:"name"`
 	Arguments string            `json:"arguments"`
 	Encrypted string            `json:"encrypted_content"`
+	// Action is populated for Build hosted tool items such as web_search_call.
+	Action map[string]any `json:"action"`
 }
 
 type responseContent struct {
-	Type    string `json:"type"`
-	Text    string `json:"text"`
-	Refusal string `json:"refusal"`
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	Refusal     string `json:"refusal"`
+	Annotations []any  `json:"annotations"`
 }
 
 type responseUsage struct {
@@ -62,6 +65,7 @@ type parsedResponse struct {
 	Signature    string
 	Refusal      string
 	Calls        []responseItem
+	WebSearch    []webSearchCall
 	Usage        responseUsage
 	Status       string
 	StopSequence string
@@ -105,9 +109,11 @@ func parseResponse(value responseEnvelope) parsedResponse {
 	if parsed.CreatedAt == 0 {
 		parsed.CreatedAt = time.Now().Unix()
 	}
+	var annotations []map[string]any
 	for _, item := range value.Output {
 		switch item.Type {
 		case "message":
+			annotations = append(annotations, extractMessageAnnotations(item)...)
 			for _, content := range item.Content {
 				switch content.Type {
 				case "output_text":
@@ -125,7 +131,15 @@ func parseResponse(value responseEnvelope) parsedResponse {
 			}
 		case "function_call":
 			parsed.Calls = append(parsed.Calls, item)
+		case "web_search_call":
+			if call, ok := parseWebSearchCallItem(item); ok {
+				parsed.WebSearch = append(parsed.WebSearch, call)
+			}
 		}
+	}
+	if len(parsed.WebSearch) > 0 {
+		parsed.WebSearch = dedupeWebSearchCalls(parsed.WebSearch)
+		parsed.WebSearch = mergeAnnotationTitles(parsed.WebSearch, annotations)
 	}
 	return parsed
 }

--- a/backend/internal/infra/provider/conversation/response.go
+++ b/backend/internal/infra/provider/conversation/response.go
@@ -8,8 +8,11 @@ import (
 
 // ResponseOptions 保留无法直接交给 Responses 上游执行的下游协议语义。
 type ResponseOptions struct {
-	AnthropicThinking bool
-	StopSequences     []string
+	AnthropicThinking          bool
+	AnthropicWebSearch         bool
+	AnthropicWebSearchRequired bool
+	AnthropicWebSearchQuery    string
+	StopSequences              []string
 }
 
 type responseEnvelope struct {
@@ -94,6 +97,9 @@ func ConvertResponseJSONWithOptions(body []byte, operation string, options Respo
 	parsed := parseResponse(envelope)
 	if operation == OperationMessages {
 		parsed.Text, parsed.StopSequence = applyAnthropicStopSequences(parsed.Text, options.StopSequences)
+		if !options.AnthropicWebSearch {
+			parsed.WebSearch = nil
+		}
 	}
 	var result any
 	if operation == OperationMessages {

--- a/backend/internal/infra/provider/conversation/server_web_search.go
+++ b/backend/internal/infra/provider/conversation/server_web_search.go
@@ -1,12 +1,14 @@
 package conversation
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/searchresult"
 )
 
 // webSearchHit is the minimal Claude Code WebSearchTool success payload.
@@ -24,14 +26,26 @@ type webSearchCall struct {
 	Code   string
 }
 
-func anthropicServerToolUseID(raw string, fallback any) string {
-	if strings.HasPrefix(raw, "srvtoolu_") {
-		return raw
+const maxWebSearchCalls = 32
+
+func unavailableWebSearchCall(query string) webSearchCall {
+	fallback := map[string]string{"type": "web_search", "query": query, "error": "unavailable"}
+	return webSearchCall{
+		ID: anthropicServerToolUseID("", fallback), Query: query,
+		Failed: true, Code: "unavailable",
 	}
+}
+
+func anthropicServerToolUseID(raw string, fallback any) string {
+	original := raw
+	raw = strings.TrimPrefix(raw, "srvtoolu_")
 	if raw == "" {
-		encoded, _ := json.Marshal(fallback)
-		sum := sha1.Sum(encoded)
-		return "srvtoolu_" + hex.EncodeToString(sum[:8])
+		encoded := []byte(original)
+		if original == "" {
+			encoded, _ = json.Marshal(fallback)
+		}
+		sum := sha256.Sum256(encoded)
+		return "srvtoolu_" + hex.EncodeToString(sum[:16])
 	}
 	// Build ids are long; keep stable prefix for multi-block pairing.
 	cleaned := strings.Map(func(r rune) rune {
@@ -40,8 +54,12 @@ func anthropicServerToolUseID(raw string, fallback any) string {
 		}
 		return '_'
 	}, raw)
-	if len(cleaned) > 48 {
-		cleaned = cleaned[len(cleaned)-48:]
+	if len(cleaned) > 48 || cleaned != raw {
+		sum := sha256.Sum256([]byte(original))
+		if len(cleaned) > 31 {
+			cleaned = cleaned[:31]
+		}
+		cleaned += "_" + hex.EncodeToString(sum[:8])
 	}
 	return "srvtoolu_" + cleaned
 }
@@ -62,21 +80,26 @@ func parseWebSearchCallItem(item responseItem) (webSearchCall, bool) {
 	}
 	// Prefer action.sources[].url
 	if rawSources, ok := action["sources"].([]any); ok {
+		seen := make(map[string]struct{}, len(rawSources))
 		for _, raw := range rawSources {
+			if len(call.Hits) >= searchresult.MaxResults {
+				break
+			}
 			source, _ := raw.(map[string]any)
 			if source == nil {
 				continue
 			}
 			link, _ := source["url"].(string)
-			link = strings.TrimSpace(link)
-			if link == "" {
+			link, valid := searchresult.NormalizeURL(link)
+			if !valid {
 				continue
 			}
-			title, _ := source["title"].(string)
-			title = strings.TrimSpace(title)
-			if title == "" {
-				title = titleFromURL(link)
+			if _, exists := seen[link]; exists {
+				continue
 			}
+			seen[link] = struct{}{}
+			title, _ := source["title"].(string)
+			title = searchresult.NormalizeTitle(title, titleFromURL(link))
 			call.Hits = append(call.Hits, webSearchHit{Title: title, URL: link})
 		}
 	}
@@ -113,25 +136,15 @@ func mergeAnnotationTitles(calls []webSearchCall, annotations []map[string]any) 
 		}
 		link, _ := ann["url"].(string)
 		title, _ := ann["title"].(string)
-		link = strings.TrimSpace(link)
+		link, valid := searchresult.NormalizeURL(link)
 		title = strings.TrimSpace(title)
-		if link == "" || title == "" {
+		if !valid || title == "" {
 			continue
 		}
-		// Skip numeric-only titles like "1","2" from Build
-		if len(title) <= 2 {
-			allDigit := true
-			for _, r := range title {
-				if r < '0' || r > '9' {
-					allDigit = false
-					break
-				}
-			}
-			if allDigit {
-				continue
-			}
+		if unhelpfulCitationTitle(title) {
+			continue
 		}
-		titles[link] = title
+		titles[link] = searchresult.NormalizeTitle(title, link)
 	}
 	for i := range calls {
 		for j := range calls[i].Hits {
@@ -141,6 +154,33 @@ func mergeAnnotationTitles(calls []webSearchCall, annotations []map[string]any) 
 		}
 	}
 	return calls
+}
+
+func unhelpfulCitationTitle(title string) bool {
+	value := strings.ToLower(strings.TrimSpace(title))
+	if value == "" {
+		return true
+	}
+	isDigits := func(candidate string) bool {
+		if candidate == "" {
+			return false
+		}
+		for _, r := range candidate {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	if isDigits(value) {
+		return true
+	}
+	for _, prefix := range []string{"source", "citation"} {
+		if strings.HasPrefix(value, prefix) && isDigits(strings.Trim(strings.TrimPrefix(value, prefix), " #:-")) {
+			return true
+		}
+	}
+	return false
 }
 
 func extractMessageAnnotations(item responseItem) []map[string]any {
@@ -179,12 +219,18 @@ func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
 		}
 		id := call.ID
 		if id == "" {
+			if len(order) >= maxWebSearchCalls {
+				continue
+			}
 			order = append(order, fmt.Sprintf("__anon_%d", len(order)))
 			best[order[len(order)-1]] = call
 			continue
 		}
 		prev, exists := best[id]
 		if !exists {
+			if len(order) >= maxWebSearchCalls {
+				continue
+			}
 			order = append(order, id)
 			best[id] = call
 			continue

--- a/backend/internal/infra/provider/conversation/server_web_search.go
+++ b/backend/internal/infra/provider/conversation/server_web_search.go
@@ -24,12 +24,13 @@ type webSearchCall struct {
 	Code   string
 }
 
-func anthropicServerToolUseID(raw string) string {
+func anthropicServerToolUseID(raw string, fallback any) string {
 	if strings.HasPrefix(raw, "srvtoolu_") {
 		return raw
 	}
 	if raw == "" {
-		sum := sha1.Sum([]byte(fmt.Sprintf("ws-%d", len(raw))))
+		encoded, _ := json.Marshal(fallback)
+		sum := sha1.Sum(encoded)
 		return "srvtoolu_" + hex.EncodeToString(sum[:8])
 	}
 	// Build ids are long; keep stable prefix for multi-block pairing.
@@ -49,8 +50,8 @@ func parseWebSearchCallItem(item responseItem) (webSearchCall, bool) {
 	if item.Type != "web_search_call" {
 		return webSearchCall{}, false
 	}
-	call := webSearchCall{ID: anthropicServerToolUseID(item.ID)}
 	action := item.Action
+	call := webSearchCall{ID: anthropicServerToolUseID(item.ID, action)}
 	if action == nil {
 		call.Failed = true
 		call.Code = "unavailable"
@@ -80,7 +81,8 @@ func parseWebSearchCallItem(item responseItem) (webSearchCall, bool) {
 		}
 	}
 	// Fallback: message annotations often have better titles; filled later by merge.
-	if item.Status != "" && item.Status != "completed" && len(call.Hits) == 0 {
+	status := strings.ToLower(strings.TrimSpace(item.Status))
+	if (status == "failed" || status == "incomplete") && len(call.Hits) == 0 {
 		call.Failed = true
 		call.Code = "unavailable"
 	}
@@ -166,12 +168,15 @@ func extractMessageAnnotations(item responseItem) []map[string]any {
 // dedupeWebSearchCalls keeps one entry per call id, preferring the payload with
 // more hits / a non-empty query. Build sometimes repeats web_search_call items.
 func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
-	if len(calls) <= 1 {
-		return calls
+	if len(calls) == 0 {
+		return nil
 	}
 	order := make([]string, 0, len(calls))
 	best := make(map[string]webSearchCall, len(calls))
 	for _, call := range calls {
+		if !call.Failed && strings.TrimSpace(call.Query) == "" && len(call.Hits) == 0 {
+			continue
+		}
 		id := call.ID
 		if id == "" {
 			order = append(order, fmt.Sprintf("__anon_%d", len(order)))
@@ -277,7 +282,7 @@ func appendServerWebSearchContent(content []any, calls []webSearchCall) []any {
 }
 
 func webSearchRequestCount(calls []webSearchCall) int {
-	return len(calls)
+	return len(dedupeWebSearchCalls(calls))
 }
 
 func queryJSONPartial(query string) string {

--- a/backend/internal/infra/provider/conversation/server_web_search.go
+++ b/backend/internal/infra/provider/conversation/server_web_search.go
@@ -76,7 +76,7 @@ func parseWebSearchCallItem(item responseItem) (webSearchCall, bool) {
 		return call, true
 	}
 	if q, _ := action["query"].(string); strings.TrimSpace(q) != "" {
-		call.Query = strings.TrimSpace(q)
+		call.Query = truncateRunes(strings.TrimSpace(q), 4096)
 	}
 	// Prefer action.sources[].url
 	if rawSources, ok := action["sources"].([]any); ok {
@@ -214,6 +214,7 @@ func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
 	order := make([]string, 0, len(calls))
 	best := make(map[string]webSearchCall, len(calls))
 	for _, call := range calls {
+		call.Hits = boundedWebSearchHits(call.Hits)
 		if !call.Failed && strings.TrimSpace(call.Query) == "" && len(call.Hits) == 0 {
 			continue
 		}
@@ -253,23 +254,7 @@ func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
 			}
 			// Union hits by URL if both have sources.
 			if len(prev.Hits) > 0 && len(call.Hits) > 0 {
-				seen := make(map[string]struct{}, len(call.Hits)+len(prev.Hits))
-				merged := make([]webSearchHit, 0, len(call.Hits)+len(prev.Hits))
-				for _, hit := range call.Hits {
-					if _, ok := seen[hit.URL]; ok {
-						continue
-					}
-					seen[hit.URL] = struct{}{}
-					merged = append(merged, hit)
-				}
-				for _, hit := range prev.Hits {
-					if _, ok := seen[hit.URL]; ok {
-						continue
-					}
-					seen[hit.URL] = struct{}{}
-					merged = append(merged, hit)
-				}
-				call.Hits = merged
+				call.Hits = boundedWebSearchHits(call.Hits, prev.Hits)
 			} else if len(call.Hits) == 0 {
 				call.Hits = prev.Hits
 			}
@@ -284,6 +269,24 @@ func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
 		out = append(out, best[id])
 	}
 	return out
+}
+
+func boundedWebSearchHits(groups ...[]webSearchHit) []webSearchHit {
+	seen := make(map[string]struct{}, searchresult.MaxResults)
+	bounded := make([]webSearchHit, 0, searchresult.MaxResults)
+	for _, hits := range groups {
+		for _, hit := range hits {
+			if len(bounded) >= searchresult.MaxResults {
+				return bounded
+			}
+			if _, exists := seen[hit.URL]; exists {
+				continue
+			}
+			seen[hit.URL] = struct{}{}
+			bounded = append(bounded, hit)
+		}
+	}
+	return bounded
 }
 
 func appendServerWebSearchContent(content []any, calls []webSearchCall) []any {

--- a/backend/internal/infra/provider/conversation/server_web_search.go
+++ b/backend/internal/infra/provider/conversation/server_web_search.go
@@ -1,0 +1,287 @@
+package conversation
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// webSearchHit is the minimal Claude Code WebSearchTool success payload.
+type webSearchHit struct {
+	Title string
+	URL   string
+}
+
+// webSearchCall is one Build web_search_call mapped for Anthropic Messages.
+type webSearchCall struct {
+	ID     string
+	Query  string
+	Hits   []webSearchHit
+	Failed bool
+	Code   string
+}
+
+func anthropicServerToolUseID(raw string) string {
+	if strings.HasPrefix(raw, "srvtoolu_") {
+		return raw
+	}
+	if raw == "" {
+		sum := sha1.Sum([]byte(fmt.Sprintf("ws-%d", len(raw))))
+		return "srvtoolu_" + hex.EncodeToString(sum[:8])
+	}
+	// Build ids are long; keep stable prefix for multi-block pairing.
+	cleaned := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			return r
+		}
+		return '_'
+	}, raw)
+	if len(cleaned) > 48 {
+		cleaned = cleaned[len(cleaned)-48:]
+	}
+	return "srvtoolu_" + cleaned
+}
+
+func parseWebSearchCallItem(item responseItem) (webSearchCall, bool) {
+	if item.Type != "web_search_call" {
+		return webSearchCall{}, false
+	}
+	call := webSearchCall{ID: anthropicServerToolUseID(item.ID)}
+	action := item.Action
+	if action == nil {
+		call.Failed = true
+		call.Code = "unavailable"
+		return call, true
+	}
+	if q, _ := action["query"].(string); strings.TrimSpace(q) != "" {
+		call.Query = strings.TrimSpace(q)
+	}
+	// Prefer action.sources[].url
+	if rawSources, ok := action["sources"].([]any); ok {
+		for _, raw := range rawSources {
+			source, _ := raw.(map[string]any)
+			if source == nil {
+				continue
+			}
+			link, _ := source["url"].(string)
+			link = strings.TrimSpace(link)
+			if link == "" {
+				continue
+			}
+			title, _ := source["title"].(string)
+			title = strings.TrimSpace(title)
+			if title == "" {
+				title = titleFromURL(link)
+			}
+			call.Hits = append(call.Hits, webSearchHit{Title: title, URL: link})
+		}
+	}
+	// Fallback: message annotations often have better titles; filled later by merge.
+	if item.Status != "" && item.Status != "completed" && len(call.Hits) == 0 {
+		call.Failed = true
+		call.Code = "unavailable"
+	}
+	return call, true
+}
+
+func titleFromURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return raw
+	}
+	return parsed.Host
+}
+
+func mergeAnnotationTitles(calls []webSearchCall, annotations []map[string]any) []webSearchCall {
+	if len(annotations) == 0 || len(calls) == 0 {
+		return calls
+	}
+	titles := make(map[string]string)
+	for _, ann := range annotations {
+		if strings.TrimSpace(fmt.Sprint(ann["type"])) != "url_citation" {
+			// nested url_citation object
+			if nested, ok := ann["url_citation"].(map[string]any); ok {
+				ann = nested
+			} else {
+				continue
+			}
+		}
+		link, _ := ann["url"].(string)
+		title, _ := ann["title"].(string)
+		link = strings.TrimSpace(link)
+		title = strings.TrimSpace(title)
+		if link == "" || title == "" {
+			continue
+		}
+		// Skip numeric-only titles like "1","2" from Build
+		if len(title) <= 2 {
+			allDigit := true
+			for _, r := range title {
+				if r < '0' || r > '9' {
+					allDigit = false
+					break
+				}
+			}
+			if allDigit {
+				continue
+			}
+		}
+		titles[link] = title
+	}
+	for i := range calls {
+		for j := range calls[i].Hits {
+			if better, ok := titles[calls[i].Hits[j].URL]; ok {
+				calls[i].Hits[j].Title = better
+			}
+		}
+	}
+	return calls
+}
+
+func extractMessageAnnotations(item responseItem) []map[string]any {
+	if item.Type != "message" {
+		return nil
+	}
+	var out []map[string]any
+	for _, content := range item.Content {
+		for _, ann := range content.Annotations {
+			if m, ok := ann.(map[string]any); ok {
+				out = append(out, m)
+			} else {
+				// re-marshal generic
+				raw, _ := json.Marshal(ann)
+				var m map[string]any
+				if json.Unmarshal(raw, &m) == nil {
+					out = append(out, m)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// dedupeWebSearchCalls keeps one entry per call id, preferring the payload with
+// more hits / a non-empty query. Build sometimes repeats web_search_call items.
+func dedupeWebSearchCalls(calls []webSearchCall) []webSearchCall {
+	if len(calls) <= 1 {
+		return calls
+	}
+	order := make([]string, 0, len(calls))
+	best := make(map[string]webSearchCall, len(calls))
+	for _, call := range calls {
+		id := call.ID
+		if id == "" {
+			order = append(order, fmt.Sprintf("__anon_%d", len(order)))
+			best[order[len(order)-1]] = call
+			continue
+		}
+		prev, exists := best[id]
+		if !exists {
+			order = append(order, id)
+			best[id] = call
+			continue
+		}
+		// Prefer richer payload.
+		score := func(c webSearchCall) int {
+			n := len(c.Hits) * 10
+			if strings.TrimSpace(c.Query) != "" {
+				n += 5
+			}
+			if !c.Failed {
+				n += 1
+			}
+			return n
+		}
+		if score(call) >= score(prev) {
+			// Keep non-empty query from either side.
+			if call.Query == "" {
+				call.Query = prev.Query
+			}
+			// Union hits by URL if both have sources.
+			if len(prev.Hits) > 0 && len(call.Hits) > 0 {
+				seen := make(map[string]struct{}, len(call.Hits)+len(prev.Hits))
+				merged := make([]webSearchHit, 0, len(call.Hits)+len(prev.Hits))
+				for _, hit := range call.Hits {
+					if _, ok := seen[hit.URL]; ok {
+						continue
+					}
+					seen[hit.URL] = struct{}{}
+					merged = append(merged, hit)
+				}
+				for _, hit := range prev.Hits {
+					if _, ok := seen[hit.URL]; ok {
+						continue
+					}
+					seen[hit.URL] = struct{}{}
+					merged = append(merged, hit)
+				}
+				call.Hits = merged
+			} else if len(call.Hits) == 0 {
+				call.Hits = prev.Hits
+			}
+			best[id] = call
+		} else if prev.Query == "" && call.Query != "" {
+			prev.Query = call.Query
+			best[id] = prev
+		}
+	}
+	out := make([]webSearchCall, 0, len(order))
+	for _, id := range order {
+		out = append(out, best[id])
+	}
+	return out
+}
+
+func appendServerWebSearchContent(content []any, calls []webSearchCall) []any {
+	calls = dedupeWebSearchCalls(calls)
+	for _, call := range calls {
+		content = append(content, map[string]any{
+			"type":  "server_tool_use",
+			"id":    call.ID,
+			"name":  "web_search",
+			"input": map[string]any{"query": call.Query},
+		})
+		if call.Failed {
+			code := call.Code
+			if code == "" {
+				code = "unavailable"
+			}
+			content = append(content, map[string]any{
+				"type":        "web_search_tool_result",
+				"tool_use_id": call.ID,
+				"content": map[string]any{
+					"type":       "web_search_tool_result_error",
+					"error_code": code,
+				},
+			})
+			continue
+		}
+		hits := make([]any, 0, len(call.Hits))
+		for _, hit := range call.Hits {
+			hits = append(hits, map[string]any{
+				"type":  "web_search_result",
+				"title": hit.Title,
+				"url":   hit.URL,
+			})
+		}
+		content = append(content, map[string]any{
+			"type":        "web_search_tool_result",
+			"tool_use_id": call.ID,
+			"content":     hits,
+		})
+	}
+	return content
+}
+
+func webSearchRequestCount(calls []webSearchCall) int {
+	return len(calls)
+}
+
+func queryJSONPartial(query string) string {
+	// Stable single-shot partial JSON for stream input_json_delta (CC regex-parses "query").
+	raw, _ := json.Marshal(map[string]string{"query": query})
+	return string(raw)
+}

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -524,6 +524,45 @@ func TestParseBuildWebSearchBoundsResultsAndTitles(t *testing.T) {
 	}
 }
 
+func TestParseResponseCapsWebSearchCandidatesBeforeDedupe(t *testing.T) {
+	output := make([]any, 0, maxWebSearchCalls+20)
+	for index := 0; index < maxWebSearchCalls+20; index++ {
+		output = append(output, map[string]any{
+			"type": "web_search_call", "id": "ws_" + strconv.Itoa(index), "status": "completed",
+			"action": map[string]any{
+				"type": "search", "query": "q" + strconv.Itoa(index),
+				"sources": []any{map[string]any{"type": "url", "url": "https://example.com/" + strconv.Itoa(index)}},
+			},
+		})
+	}
+	body, err := json.Marshal(map[string]any{
+		"id": "resp_cap", "model": "grok-4.5", "status": "completed", "created_at": 1,
+		"output": output, "usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	content, _ := msg["content"].([]any)
+	uses := 0
+	for _, block := range content {
+		m, _ := block.(map[string]any)
+		if m["type"] == "server_tool_use" {
+			uses++
+		}
+	}
+	if uses != maxWebSearchCalls {
+		t.Fatalf("server_tool_use count = %d, want %d", uses, maxWebSearchCalls)
+	}
+}
+
 func TestDedupeWebSearchCallsBoundsCallCount(t *testing.T) {
 	calls := make([]webSearchCall, 0, 40)
 	for index := 0; index < 40; index++ {

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -1,0 +1,168 @@
+package conversation
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestParseAndMapBuildWebSearchCall(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_ws1","model":"grok-4.5","status":"completed","created_at":123,
+		"output":[
+			{"type":"web_search_call","id":"ws_abc","status":"completed","action":{
+				"type":"search","query":"Claude Fable 5",
+				"sources":[
+					{"type":"url","url":"https://example.com/a"},
+					{"type":"url","url":"https://example.com/b","title":"Beta"}
+				]
+			}},
+			{"type":"web_search_call","id":"ws_abc","status":"completed","action":{"type":"search"}},
+			{"type":"web_search_call","id":"ws_abc","status":"completed","action":{"type":"search","query":""}},
+			{"type":"message","role":"assistant","content":[
+				{"type":"output_text","text":"Fable 5 is public.","annotations":[
+					{"type":"url_citation","url":"https://example.com/a","title":"Alpha Title","start_index":0,"end_index":5}
+				]}
+			]}
+		],
+		"usage":{"input_tokens":10,"output_tokens":5}
+	}`)
+	data, err := ConvertResponseJSON(body, OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg["stop_reason"] != "end_turn" {
+		t.Fatalf("stop_reason = %#v", msg["stop_reason"])
+	}
+	content, _ := msg["content"].([]any)
+	if len(content) < 3 {
+		t.Fatalf("content = %#v", content)
+	}
+	use := content[0].(map[string]any)
+	if use["type"] != "server_tool_use" || use["name"] != "web_search" {
+		t.Fatalf("server_tool_use = %#v", use)
+	}
+	input := use["input"].(map[string]any)
+	if input["query"] != "Claude Fable 5" {
+		t.Fatalf("query = %#v", input)
+	}
+	result := content[1].(map[string]any)
+	if result["type"] != "web_search_tool_result" || result["tool_use_id"] != use["id"] {
+		t.Fatalf("result = %#v", result)
+	}
+	hits, _ := result["content"].([]any)
+	if len(hits) != 2 {
+		t.Fatalf("hits = %#v", hits)
+	}
+	h0 := hits[0].(map[string]any)
+	if h0["url"] != "https://example.com/a" || h0["title"] != "Alpha Title" {
+		t.Fatalf("hit0 title from annotation expected Alpha Title, got %#v", h0)
+	}
+	text := content[2].(map[string]any)
+	if text["type"] != "text" || text["text"] != "Fable 5 is public." {
+		t.Fatalf("text = %#v", text)
+	}
+	usage := msg["usage"].(map[string]any)
+	stu := usage["server_tool_use"].(map[string]any)
+	if stu["web_search_requests"] != float64(1) {
+		t.Fatalf("usage = %#v", usage)
+	}
+	// Duplicate empty web_search_call items must collapse to one pair of blocks.
+	serverUses := 0
+	for _, raw := range content {
+		if block, _ := raw.(map[string]any); block["type"] == "server_tool_use" {
+			serverUses++
+		}
+	}
+	if serverUses != 1 {
+		t.Fatalf("expected 1 deduped server_tool_use, got %d in %#v", serverUses, content)
+	}
+}
+
+func TestConvertAnthropicWebSearchToolChoiceRequired(t *testing.T) {
+	converted, _, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"Perform a web search for the query: x"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(converted, &payload)
+	tools := payload["tools"].([]any)
+	if len(tools) != 1 || tools[0].(map[string]any)["type"] != "web_search" {
+		t.Fatalf("tools = %#v", tools)
+	}
+	if payload["tool_choice"] != "required" {
+		t.Fatalf("tool_choice = %#v", payload["tool_choice"])
+	}
+}
+
+func TestClientWebSearchFunctionNotPromoted(t *testing.T) {
+	converted, _, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"search"}],
+		"tools":[{"name":"WebSearch","description":"Search","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}}]
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(converted, &payload)
+	tools := payload["tools"].([]any)
+	if len(tools) != 1 {
+		t.Fatalf("tools = %#v", tools)
+	}
+	tool := tools[0].(map[string]any)
+	if tool["type"] != "function" || tool["name"] != "WebSearch" {
+		t.Fatalf("client WebSearch must remain function, got %#v", tool)
+	}
+}
+
+func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_1","type":"web_search_call","status":"in_progress","action":{"type":"search","query":"rust tutorials"}}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Here you go."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	stream := ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationMessages)
+	raw, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `"type":"server_tool_use"`) {
+		t.Fatalf("missing server_tool_use in stream:\n%s", text)
+	}
+	if !strings.Contains(text, `"type":"web_search_tool_result"`) {
+		t.Fatalf("missing web_search_tool_result in stream:\n%s", text)
+	}
+	if !strings.Contains(text, `https://doc.rust-lang.org`) {
+		t.Fatalf("missing hit url in stream:\n%s", text)
+	}
+	if !strings.Contains(text, `"query":"rust tutorials"`) && !strings.Contains(text, `"query\": \"rust tutorials\"`) {
+		// partial_json embeds query
+		if !strings.Contains(text, "rust tutorials") {
+			t.Fatalf("missing query in stream:\n%s", text)
+		}
+	}
+	if !strings.Contains(text, `"stop_reason":"end_turn"`) {
+		t.Fatalf("expected end_turn:\n%s", text)
+	}
+}

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestParseAndMapBuildWebSearchCall(t *testing.T) {
@@ -24,13 +26,13 @@ func TestParseAndMapBuildWebSearchCall(t *testing.T) {
 			{"type":"web_search_call","id":"ws_abc","status":"completed","action":{"type":"search","query":""}},
 			{"type":"message","role":"assistant","content":[
 				{"type":"output_text","text":"Fable 5 is public.","annotations":[
-					{"type":"url_citation","url":"https://example.com/a","title":"Alpha Title","start_index":0,"end_index":5}
+					{"type":"url_citation","url":"https://EXAMPLE.com/a","title":"Alpha Title","start_index":0,"end_index":5}
 				]}
 			]}
 		],
 		"usage":{"input_tokens":10,"output_tokens":5}
 	}`)
-	data, err := ConvertResponseJSON(body, OperationMessages)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,8 +88,177 @@ func TestParseAndMapBuildWebSearchCall(t *testing.T) {
 	}
 }
 
+func TestMergeAnnotationTitlesSkipsFootnoteLabels(t *testing.T) {
+	for _, title := range []string{"123", "Source 1", "citation 2"} {
+		calls := []webSearchCall{{Hits: []webSearchHit{{Title: "example.com", URL: "https://example.com/a"}}}}
+		merged := mergeAnnotationTitles(calls, []map[string]any{{
+			"type": "url_citation", "url": "https://example.com/a", "title": title,
+		}})
+		if got := merged[0].Hits[0].Title; got != "example.com" {
+			t.Fatalf("footnote title %q replaced fallback with %q", title, got)
+		}
+	}
+}
+
+func TestUnrequestedWebSearchItemsAreNotExposed(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_ws_unrequested","model":"grok-4.5","status":"completed",
+		"output":[
+			{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"private internal search","sources":[{"url":"https://example.com"}]}},
+			{"type":"message","content":[{"type":"output_text","text":"Plain answer."}]}
+		],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	content := msg["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "text" {
+		t.Fatalf("unrequested server search was exposed: %#v", content)
+	}
+	if _, exists := msg["usage"].(map[string]any)["server_tool_use"]; exists {
+		t.Fatalf("unrequested search usage was exposed: %#v", msg["usage"])
+	}
+}
+
+func TestUnrequestedWebSearchStreamItemsAreNotExposed(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_item.done`,
+		`data: {"type":"response.output_item.done","item":{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","query":"private internal search","sources":[{"url":"https://example.com"}]}}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Plain answer."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"private internal search","sources":[{"url":"https://example.com"}]}},{"type":"message","content":[{"type":"output_text","text":"Plain answer."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	raw, err := io.ReadAll(ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "server_tool_use") || strings.Contains(text, "web_search_tool_result") || !strings.Contains(text, "Plain answer.") {
+		t.Fatalf("unrequested stream search was exposed:\n%s", text)
+	}
+}
+
+func TestRequestedBuildSearchWithoutCallEmitsUnavailableResult(t *testing.T) {
+	_, options, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{
+		"id":"resp_no_call","model":"grok-4.5","status":"completed",
+		"output":[{"type":"message","content":[{"type":"output_text","text":"Search was unavailable."}]}],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var message map[string]any
+	if err := json.Unmarshal(data, &message); err != nil {
+		t.Fatal(err)
+	}
+	content := message["content"].([]any)
+	if len(content) != 3 || content[0].(map[string]any)["type"] != "server_tool_use" || content[1].(map[string]any)["type"] != "web_search_tool_result" || content[2].(map[string]any)["text"] != "Search was unavailable." {
+		t.Fatalf("content = %#v", content)
+	}
+	use := content[0].(map[string]any)
+	if use["input"].(map[string]any)["query"] != "rust tutorials" || content[1].(map[string]any)["tool_use_id"] != use["id"] {
+		t.Fatalf("fallback linkage = %#v", content)
+	}
+	errorContent := content[1].(map[string]any)["content"].(map[string]any)
+	if errorContent["type"] != "web_search_tool_result_error" || errorContent["error_code"] != "unavailable" {
+		t.Fatalf("fallback error = %#v", errorContent)
+	}
+	usage := message["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+	if usage["web_search_requests"] != float64(1) {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestOptionalBuildSearchWithoutCallRemainsPlainText(t *testing.T) {
+	_, options, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"answer with or without search"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}]
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{
+		"id":"resp_optional","model":"grok-4.5","status":"completed",
+		"output":[{"type":"message","content":[{"type":"output_text","text":"Plain answer."}]}],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var message map[string]any
+	if err := json.Unmarshal(data, &message); err != nil {
+		t.Fatal(err)
+	}
+	content := message["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "text" || content[0].(map[string]any)["text"] != "Plain answer." {
+		t.Fatalf("optional search fabricated server blocks: %#v", content)
+	}
+	if _, exists := message["usage"].(map[string]any)["server_tool_use"]; exists {
+		t.Fatalf("optional search fabricated usage: %#v", message["usage"])
+	}
+}
+
+func TestRequestedBuildSearchStreamWithoutCallEmitsUnavailableBeforeText(t *testing.T) {
+	_, options, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"stream":true,
+		"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_no_call","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Search was unavailable."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_no_call","model":"grok-4.5","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"Search was unavailable."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	raw, err := io.ReadAll(ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, options))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if got, want := contentBlockStartTypes(t, text), []string{"server_tool_use", "web_search_tool_result", "text"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("content block order = %v, want %v\n%s", got, want, text)
+	}
+	if !strings.Contains(text, `"error_code":"unavailable"`) || !strings.Contains(text, `"web_search_requests":1`) || !strings.Contains(text, "rust tutorials") {
+		t.Fatalf("missing unavailable fallback: %s", text)
+	}
+}
+
 func TestConvertAnthropicWebSearchToolChoiceRequired(t *testing.T) {
-	converted, _, err := ConvertRequestWithOptions([]byte(`{
+	converted, options, err := ConvertRequestWithOptions([]byte(`{
 		"model":"public","max_tokens":64,
 		"messages":[{"role":"user","content":"Perform a web search for the query: x"}],
 		"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
@@ -104,6 +275,9 @@ func TestConvertAnthropicWebSearchToolChoiceRequired(t *testing.T) {
 	}
 	if payload["tool_choice"] != "required" {
 		t.Fatalf("tool_choice = %#v", payload["tool_choice"])
+	}
+	if !options.AnthropicWebSearchRequired {
+		t.Fatalf("forced hosted search was not retained in response options: %#v", options)
 	}
 }
 
@@ -148,6 +322,46 @@ func TestClientLowercaseWebSearchToolChoiceRemainsFunction(t *testing.T) {
 	}
 }
 
+func TestResponseOptionsRetainOnlyExplicitWebSearchQuery(t *testing.T) {
+	_, searchOptions, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":[{"type":"text","text":"Perform a web search for the query: rust tutorials"}]}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}]
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !searchOptions.AnthropicWebSearch || searchOptions.AnthropicWebSearchRequired || searchOptions.AnthropicWebSearchQuery != "rust tutorials" {
+		t.Fatalf("search options = %#v", searchOptions)
+	}
+
+	_, regularOptions, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"private user prompt"}]
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if regularOptions.AnthropicWebSearch || regularOptions.AnthropicWebSearchQuery != "" {
+		t.Fatalf("regular request retained prompt data: %#v", regularOptions)
+	}
+}
+
+func TestWebSearchToolChoiceNoneDisablesResponseMapping(t *testing.T) {
+	_, options, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"Perform a web search for the query: private query"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}],
+		"tool_choice":{"type":"none"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if options.AnthropicWebSearch || options.AnthropicWebSearchQuery != "" {
+		t.Fatalf("tool_choice none retained web search state: %#v", options)
+	}
+}
+
 func TestMapBuildWebSearchFiltersEmptyDistinctCalls(t *testing.T) {
 	body := []byte(`{
 		"id":"resp_ws_empty","model":"grok-4.5","status":"completed",
@@ -162,7 +376,7 @@ func TestMapBuildWebSearchFiltersEmptyDistinctCalls(t *testing.T) {
 		],
 		"usage":{"input_tokens":3,"output_tokens":2}
 	}`)
-	data, err := ConvertResponseJSON(body, OperationMessages)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +414,7 @@ func TestMapBuildWebSearchDerivesDistinctMissingIDs(t *testing.T) {
 		],
 		"usage":{"input_tokens":3,"output_tokens":2}
 	}`)
-	data, err := ConvertResponseJSON(body, OperationMessages)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,6 +439,103 @@ func TestMapBuildWebSearchDerivesDistinctMissingIDs(t *testing.T) {
 	}
 }
 
+func TestAnthropicServerToolUseIDDoesNotCollideOnLongCommonSuffix(t *testing.T) {
+	suffix := strings.Repeat("z", 48)
+	first := anthropicServerToolUseID("first-prefix-"+suffix, nil)
+	second := anthropicServerToolUseID("second-prefix-"+suffix, nil)
+	if first == second {
+		t.Fatalf("long upstream IDs collided: %q", first)
+	}
+}
+
+func TestAnthropicServerToolUseIDNormalizesPrefixedUntrustedID(t *testing.T) {
+	raw := "srvtoolu_" + strings.Repeat("a", 80) + " bad\n"
+	got := anthropicServerToolUseID(raw, nil)
+	if !strings.HasPrefix(got, "srvtoolu_") || len(got) > 64 {
+		t.Fatalf("normalized id = %q (len=%d)", got, len(got))
+	}
+	if strings.IndexFunc(got, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-')
+	}) >= 0 {
+		t.Fatalf("normalized id retained unsafe characters: %q", got)
+	}
+	if again := anthropicServerToolUseID(raw, nil); again != got {
+		t.Fatalf("normalization is unstable: first=%q second=%q", got, again)
+	}
+}
+
+func TestMapBuildWebSearchFiltersUnsafeAndDuplicateSources(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_ws_sources","model":"grok-4.5","status":"completed",
+		"output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{
+			"type":"search","query":"security",
+			"sources":[
+				{"url":"https://example.com/a","title":"Example"},
+				{"url":"https://example.com/a","title":"Duplicate"},
+				{"url":"javascript:alert(1)","title":"Script"},
+				{"url":"file:///etc/passwd","title":"File"},
+				{"url":"/relative/path","title":"Relative"},
+				{"url":"https://user:secret@example.com/private","title":"Credential URL"}
+			]
+		}}],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSONWithOptions(body, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	content := msg["content"].([]any)
+	hits := content[1].(map[string]any)["content"].([]any)
+	if len(hits) != 1 {
+		t.Fatalf("unsafe or duplicate sources leaked into hits: %#v", hits)
+	}
+	hit := hits[0].(map[string]any)
+	if hit["url"] != "https://example.com/a" || hit["title"] != "Example" {
+		t.Fatalf("hit = %#v", hit)
+	}
+}
+
+func TestParseBuildWebSearchBoundsResultsAndTitles(t *testing.T) {
+	sources := make([]any, 0, 60)
+	for index := 0; index < 60; index++ {
+		sources = append(sources, map[string]any{
+			"url":   "https://example.com/" + strconv.Itoa(index),
+			"title": strings.Repeat("界", 600),
+		})
+	}
+	call, ok := parseWebSearchCallItem(responseItem{
+		ID: "ws_bounds", Type: "web_search_call", Status: "completed",
+		Action: map[string]any{"query": "bounds", "sources": sources},
+	})
+	if !ok {
+		t.Fatal("web search call was not parsed")
+	}
+	if len(call.Hits) != 50 {
+		t.Fatalf("hits = %d, want 50", len(call.Hits))
+	}
+	if got := utf8.RuneCountInString(call.Hits[0].Title); got != 512 {
+		t.Fatalf("title runes = %d, want 512", got)
+	}
+}
+
+func TestDedupeWebSearchCallsBoundsCallCount(t *testing.T) {
+	calls := make([]webSearchCall, 0, 40)
+	for index := 0; index < 40; index++ {
+		calls = append(calls, webSearchCall{
+			ID:    "srvtoolu_" + strconv.Itoa(index),
+			Query: "query " + strconv.Itoa(index),
+			Hits:  []webSearchHit{{Title: "Example", URL: "https://example.com/" + strconv.Itoa(index)}},
+		})
+	}
+	if got := len(dedupeWebSearchCalls(calls)); got != 32 {
+		t.Fatalf("deduped calls = %d, want 32", got)
+	}
+}
+
 func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
 	source := strings.Join([]string{
 		`event: response.created`,
@@ -240,7 +551,7 @@ func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
 		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
 		``,
 	}, "\n")
-	stream := ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationMessages)
+	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicWebSearch: true})
 	raw, err := io.ReadAll(stream)
 	if err != nil {
 		t.Fatal(err)
@@ -292,7 +603,7 @@ func TestStreamFiltersEmptyDistinctWebSearchCalls(t *testing.T) {
 		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_real","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"web_search_call","id":"ws_empty_1","status":"completed","action":{"type":"search"}},{"type":"web_search_call","id":"ws_empty_2","status":"completed","action":{"type":"search","query":""}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
 		``,
 	}, "\n")
-	stream := ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationMessages)
+	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicWebSearch: true})
 	raw, err := io.ReadAll(stream)
 	if err != nil {
 		t.Fatal(err)
@@ -334,7 +645,7 @@ func TestStreamDefersTextWhenWebSearchArrivesDuringThinking(t *testing.T) {
 		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
 		``,
 	}, "\n")
-	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicThinking: true})
+	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicThinking: true, AnthropicWebSearch: true})
 	raw, err := io.ReadAll(stream)
 	if err != nil {
 		t.Fatal(err)
@@ -342,6 +653,43 @@ func TestStreamDefersTextWhenWebSearchArrivesDuringThinking(t *testing.T) {
 	text := string(raw)
 	assertSequentialContentBlocks(t, text)
 	wantOrder := []string{"thinking", "server_tool_use", "web_search_tool_result", "text"}
+	if got := contentBlockStartTypes(t, text); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("content block order = %v, want %v\n%s", got, wantOrder, text)
+	}
+}
+
+func TestStreamUsesRequestContextWhenTextArrivesBeforeWebSearchItem(t *testing.T) {
+	_, options, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"stream":true,
+		"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Here you go."}`,
+		``,
+		`event: response.output_item.done`,
+		`data: {"type":"response.output_item.done","item":{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}}}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, options)
+	raw, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	assertSequentialContentBlocks(t, text)
+	wantOrder := []string{"server_tool_use", "web_search_tool_result", "text"}
 	if got := contentBlockStartTypes(t, text); !reflect.DeepEqual(got, wantOrder) {
 		t.Fatalf("content block order = %v, want %v\n%s", got, wantOrder, text)
 	}

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/searchresult"
 )
 
 func TestParseAndMapBuildWebSearchCall(t *testing.T) {
@@ -536,6 +538,68 @@ func TestDedupeWebSearchCallsBoundsCallCount(t *testing.T) {
 	}
 }
 
+func TestDedupeWebSearchCallsBoundsMergedHits(t *testing.T) {
+	first := webSearchCall{ID: "srvtoolu_merge", Query: "query"}
+	second := webSearchCall{ID: "srvtoolu_merge", Query: "query"}
+	for index := 0; index < searchresult.MaxResults; index++ {
+		first.Hits = append(first.Hits, webSearchHit{Title: "First", URL: "https://example.com/a/" + strconv.Itoa(index)})
+		second.Hits = append(second.Hits, webSearchHit{Title: "Second", URL: "https://example.com/b/" + strconv.Itoa(index)})
+	}
+	merged := dedupeWebSearchCalls([]webSearchCall{first, second})
+	if len(merged) != 1 || len(merged[0].Hits) != searchresult.MaxResults {
+		t.Fatalf("merged calls = %#v", merged)
+	}
+}
+
+func TestParseWebSearchCallBoundsUpstreamQuery(t *testing.T) {
+	call, ok := parseWebSearchCallItem(responseItem{
+		ID: "ws_long_query", Type: "web_search_call", Status: "completed",
+		Action: map[string]any{"type": "search", "query": strings.Repeat("界", 5000)},
+	})
+	if !ok {
+		t.Fatal("web search call was not parsed")
+	}
+	if got := utf8.RuneCountInString(call.Query); got != 4096 {
+		t.Fatalf("query runes = %d, want 4096", got)
+	}
+}
+
+func TestStreamCapsWebSearchCallsBeforeEmission(t *testing.T) {
+	var output strings.Builder
+	converter := newStreamConverter(&output, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
+	for index := 0; index < maxWebSearchCalls+10; index++ {
+		call := webSearchCall{
+			ID:    "srvtoolu_stream_" + strconv.Itoa(index),
+			Query: "query " + strconv.Itoa(index),
+			Hits:  []webSearchHit{{Title: "Example", URL: "https://example.com/" + strconv.Itoa(index)}},
+		}
+		if err := converter.noteWebSearch(call, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(converter.webSearch) != maxWebSearchCalls {
+		t.Fatalf("tracked web search calls = %d, want %d", len(converter.webSearch), maxWebSearchCalls)
+	}
+	if got := strings.Count(output.String(), `"type":"server_tool_use"`); got != maxWebSearchCalls {
+		t.Fatalf("emitted server tool uses = %d, want %d", got, maxWebSearchCalls)
+	}
+}
+
+func TestStreamRejectsOversizedDeferredSearchText(t *testing.T) {
+	converter := newStreamConverter(io.Discard, OperationMessages, ResponseOptions{AnthropicWebSearch: true})
+	data, err := json.Marshal(map[string]any{
+		"type":  "response.output_text.delta",
+		"delta": strings.Repeat("x", (8<<20)+1),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = converter.handle("response.output_text.delta", data)
+	if err == nil || !strings.Contains(err.Error(), "缓冲") {
+		t.Fatalf("oversized deferred text error = %v", err)
+	}
+}
+
 func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
 	source := strings.Join([]string{
 		`event: response.created`,
@@ -692,6 +756,36 @@ func TestStreamUsesRequestContextWhenTextArrivesBeforeWebSearchItem(t *testing.T
 	wantOrder := []string{"server_tool_use", "web_search_tool_result", "text"}
 	if got := contentBlockStartTypes(t, text); !reflect.DeepEqual(got, wantOrder) {
 		t.Fatalf("content block order = %v, want %v\n%s", got, wantOrder, text)
+	}
+}
+
+func TestStreamFinalEnvelopeDoesNotOrphanEarlierWebSearchUse(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_early","type":"web_search_call","status":"in_progress","action":{"type":"search","query":"early query"}}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Answer."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_final","status":"completed","action":{"type":"search","query":"final query","sources":[{"url":"https://example.com/final"}]}},{"type":"message","content":[{"type":"output_text","text":"Answer."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	raw, err := io.ReadAll(ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicWebSearch: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	uses := strings.Count(text, `"type":"server_tool_use"`)
+	results := strings.Count(text, `"type":"web_search_tool_result"`)
+	if uses != 2 || results != uses {
+		t.Fatalf("uses=%d results=%d; earlier use was orphaned\n%s", uses, results, text)
+	}
+	if !strings.Contains(text, "early query") || !strings.Contains(text, "final query") || !strings.Contains(text, `"web_search_requests":2`) {
+		t.Fatalf("merged stream lost a search call\n%s", text)
 	}
 }
 

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -1,8 +1,10 @@
 package conversation
 
 import (
+	"bufio"
 	"encoding/json"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -126,6 +128,103 @@ func TestClientWebSearchFunctionNotPromoted(t *testing.T) {
 	}
 }
 
+func TestClientLowercaseWebSearchToolChoiceRemainsFunction(t *testing.T) {
+	converted, _, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[{"role":"user","content":"search"}],
+		"tools":[{"name":"web_search","description":"Search","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{"type": "function", "name": "web_search"}
+	if got := payload["tool_choice"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("client function tool_choice = %#v, want %#v", got, want)
+	}
+}
+
+func TestMapBuildWebSearchFiltersEmptyDistinctCalls(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_ws_empty","model":"grok-4.5","status":"completed",
+		"output":[
+			{"type":"web_search_call","id":"ws_real","status":"completed","action":{
+				"type":"search","query":"rust tutorials",
+				"sources":[{"type":"url","url":"https://doc.rust-lang.org"}]
+			}},
+			{"type":"web_search_call","id":"ws_empty_1","status":"completed","action":{"type":"search"}},
+			{"type":"web_search_call","id":"ws_empty_2","status":"completed","action":{"type":"search","query":""}},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Here you go."}]}
+		],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSON(body, OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	content := msg["content"].([]any)
+	serverUses := 0
+	results := 0
+	for _, raw := range content {
+		block := raw.(map[string]any)
+		switch block["type"] {
+		case "server_tool_use":
+			serverUses++
+		case "web_search_tool_result":
+			results++
+		}
+	}
+	if serverUses != 1 || results != 1 {
+		t.Fatalf("expected one real search pair, got uses=%d results=%d content=%#v", serverUses, results, content)
+	}
+	usage := msg["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+	if usage["web_search_requests"] != float64(1) {
+		t.Fatalf("usage must count only real searches: %#v", usage)
+	}
+}
+
+func TestMapBuildWebSearchDerivesDistinctMissingIDs(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_ws_missing_ids","model":"grok-4.5","status":"completed",
+		"output":[
+			{"type":"web_search_call","status":"completed","action":{"type":"search","query":"rust","sources":[{"url":"https://www.rust-lang.org"}]}},
+			{"type":"web_search_call","status":"completed","action":{"type":"search","query":"go","sources":[{"url":"https://go.dev"}]}}
+		],
+		"usage":{"input_tokens":3,"output_tokens":2}
+	}`)
+	data, err := ConvertResponseJSON(body, OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatal(err)
+	}
+	content := msg["content"].([]any)
+	var ids []string
+	for _, raw := range content {
+		block := raw.(map[string]any)
+		if block["type"] == "server_tool_use" {
+			ids = append(ids, block["id"].(string))
+		}
+	}
+	if len(ids) != 2 || ids[0] == ids[1] {
+		t.Fatalf("missing upstream IDs must derive distinct stable IDs, got %v content=%#v", ids, content)
+	}
+	usage := msg["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+	if usage["web_search_requests"] != float64(2) {
+		t.Fatalf("usage = %#v, want two searches", usage)
+	}
+}
+
 func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
 	source := strings.Join([]string{
 		`event: response.created`,
@@ -164,5 +263,155 @@ func TestStreamEmitsServerWebSearchBlocks(t *testing.T) {
 	}
 	if !strings.Contains(text, `"stop_reason":"end_turn"`) {
 		t.Fatalf("expected end_turn:\n%s", text)
+	}
+	assertSequentialContentBlocks(t, text)
+	wantOrder := []string{"server_tool_use", "web_search_tool_result", "text"}
+	if got := contentBlockStartTypes(t, text); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("content block order = %v, want %v\n%s", got, wantOrder, text)
+	}
+}
+
+func TestStreamFiltersEmptyDistinctWebSearchCalls(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_real","type":"web_search_call","status":"in_progress","action":{"type":"search","query":"rust tutorials"}}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_empty_1","type":"web_search_call","status":"in_progress","action":{"type":"search"}}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_empty_2","type":"web_search_call","status":"in_progress","action":{"type":"search","query":""}}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Here you go."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_real","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"web_search_call","id":"ws_empty_1","status":"completed","action":{"type":"search"}},{"type":"web_search_call","id":"ws_empty_2","status":"completed","action":{"type":"search","query":""}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	stream := ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationMessages)
+	raw, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if got := strings.Count(text, `"type":"server_tool_use"`); got != 1 {
+		t.Fatalf("expected one real server_tool_use, got %d\n%s", got, text)
+	}
+	if got := strings.Count(text, `"type":"web_search_tool_result"`); got != 1 {
+		t.Fatalf("expected one real web_search_tool_result, got %d\n%s", got, text)
+	}
+	if !strings.Contains(text, `"web_search_requests":1`) {
+		t.Fatalf("usage must count only real searches\n%s", text)
+	}
+	assertSequentialContentBlocks(t, text)
+}
+
+func TestStreamDefersTextWhenWebSearchArrivesDuringThinking(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"reasoning_1","type":"reasoning"}}`,
+		``,
+		`event: response.reasoning_text.delta`,
+		`data: {"type":"response.reasoning_text.delta","delta":"Need current sources."}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","item":{"id":"ws_1","type":"web_search_call","status":"in_progress","action":{"type":"search","query":"rust tutorials"}}}`,
+		``,
+		`event: response.output_item.done`,
+		`data: {"type":"response.output_item.done","item":{"id":"reasoning_1","type":"reasoning","encrypted_content":"sig"}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"Here you go."}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"type":"url","url":"https://doc.rust-lang.org"}]}},{"type":"message","content":[{"type":"output_text","text":"Here you go."}]}],"usage":{"input_tokens":3,"output_tokens":2}}}`,
+		``,
+	}, "\n")
+	stream := ConvertResponseStreamWithOptions(io.NopCloser(strings.NewReader(source)), OperationMessages, ResponseOptions{AnthropicThinking: true})
+	raw, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	assertSequentialContentBlocks(t, text)
+	wantOrder := []string{"thinking", "server_tool_use", "web_search_tool_result", "text"}
+	if got := contentBlockStartTypes(t, text); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("content block order = %v, want %v\n%s", got, wantOrder, text)
+	}
+}
+
+func contentBlockStartTypes(t *testing.T, stream string) []string {
+	t.Helper()
+	var types []string
+	scanner := bufio.NewScanner(strings.NewReader(stream))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event struct {
+			Type         string `json:"type"`
+			ContentBlock struct {
+				Type string `json:"type"`
+			} `json:"content_block"`
+		}
+		if json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event) != nil {
+			continue
+		}
+		if event.Type == "content_block_start" {
+			types = append(types, event.ContentBlock.Type)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return types
+}
+
+func assertSequentialContentBlocks(t *testing.T, stream string) {
+	t.Helper()
+	openIndex := -1
+	scanner := bufio.NewScanner(strings.NewReader(stream))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var event struct {
+			Type  string `json:"type"`
+			Index int    `json:"index"`
+		}
+		if json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event) != nil {
+			continue
+		}
+		switch event.Type {
+		case "content_block_start":
+			if openIndex >= 0 {
+				t.Fatalf("content block %d started before block %d stopped\n%s", event.Index, openIndex, stream)
+			}
+			openIndex = event.Index
+		case "content_block_delta":
+			if openIndex != event.Index {
+				t.Fatalf("delta for block %d while block %d is open\n%s", event.Index, openIndex, stream)
+			}
+		case "content_block_stop":
+			if openIndex != event.Index {
+				t.Fatalf("stop for block %d while block %d is open\n%s", event.Index, openIndex, stream)
+			}
+			openIndex = -1
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if openIndex >= 0 {
+		t.Fatalf("content block %d never stopped\n%s", openIndex, stream)
 	}
 }

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -34,27 +34,29 @@ func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, op
 }
 
 type streamConverter struct {
-	writer           io.Writer
-	operation        string
-	id               string
-	model            string
-	created          int64
-	started          bool
-	finished         bool
-	textStarted      bool
-	textIndex        int
-	thinkingStarted  bool
-	thinkingClosed   bool
-	thinkingIndex    int
-	thinkingItemID   string
-	nextIndex        int
-	tools            map[string]streamTool
-	webSearch        []webSearchCall
-	webSearchEmitted map[string]bool
-	usage            responseUsage
-	options          ResponseOptions
-	stopFilter       *anthropicStreamStopFilter
-	stopSequence     string
+	writer            io.Writer
+	operation         string
+	id                string
+	model             string
+	created           int64
+	started           bool
+	finished          bool
+	textStarted       bool
+	textIndex         int
+	thinkingStarted   bool
+	thinkingClosed    bool
+	thinkingIndex     int
+	thinkingItemID    string
+	nextIndex         int
+	tools             map[string]streamTool
+	webSearch         []webSearchCall
+	webSearchEmitted  map[string]bool
+	deferSearchText   bool
+	pendingSearchText strings.Builder
+	usage             responseUsage
+	options           ResponseOptions
+	stopFilter        *anthropicStreamStopFilter
+	stopSequence      string
 }
 
 type streamTool struct {
@@ -78,6 +80,11 @@ func newStreamConverter(writer io.Writer, operation string, options ResponseOpti
 // so we always use the completed action.sources payload from the final envelope when available.
 // For progressive UI we still emit server_tool_use as soon as we see the call.
 func (c *streamConverter) noteWebSearch(call webSearchCall, final bool) error {
+	filtered := dedupeWebSearchCalls([]webSearchCall{call})
+	if len(filtered) == 0 {
+		return nil
+	}
+	call = filtered[0]
 	replaced := false
 	for i, existing := range c.webSearch {
 		if existing.ID == call.ID {
@@ -91,6 +98,12 @@ func (c *streamConverter) noteWebSearch(call webSearchCall, final bool) error {
 	}
 	if !replaced {
 		c.webSearch = append(c.webSearch, call)
+	}
+	if !c.textStarted {
+		c.deferSearchText = true
+	}
+	if c.textStarted || (c.thinkingStarted && !c.thinkingClosed) {
+		return nil
 	}
 	// Emit server_tool_use promptly so Claude Code can show "Searching: …".
 	return c.emitWebSearchUse(call)
@@ -133,6 +146,7 @@ func (c *streamConverter) emitWebSearchUse(call webSearchCall) error {
 }
 
 func (c *streamConverter) emitPendingWebSearchResults() error {
+	c.webSearch = dedupeWebSearchCalls(c.webSearch)
 	for _, call := range c.webSearch {
 		if c.webSearchEmitted[call.ID+"#result"] {
 			continue
@@ -206,6 +220,10 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		_ = json.Unmarshal(root["delta"], &delta)
 		if err := c.start(); err != nil {
 			return err
+		}
+		if c.operation == OperationMessages && c.deferSearchText {
+			c.pendingSearchText.WriteString(delta)
+			return nil
 		}
 		return c.textDelta(delta)
 	case "response.reasoning_summary_text.delta":

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const maxDeferredSearchTextBytes = 8 << 20
+
 // ConvertResponseStream 将 Responses SSE 转换为 Chat Completions 或 Anthropic Messages SSE。
 func ConvertResponseStream(source io.ReadCloser, operation string) io.ReadCloser {
 	return ConvertResponseStreamWithOptions(source, operation, ResponseOptions{})
@@ -98,6 +100,9 @@ func (c *streamConverter) noteWebSearch(call webSearchCall, final bool) error {
 		}
 	}
 	if !replaced {
+		if len(c.webSearch) >= maxWebSearchCalls {
+			return nil
+		}
 		c.webSearch = append(c.webSearch, call)
 	}
 	if !c.textStarted {
@@ -217,8 +222,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 			return err
 		}
 		if c.operation == OperationMessages && c.deferSearchText {
-			c.pendingSearchText.WriteString(delta)
-			return nil
+			return c.bufferSearchText(delta)
 		}
 		return c.textDelta(delta)
 	case "response.reasoning_summary_text.delta":
@@ -283,8 +287,10 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		c.setResponse(response)
 		if c.operation == OperationMessages && c.options.AnthropicWebSearch {
 			parsed := parseResponse(response)
-			if len(parsed.WebSearch) > 0 {
-				c.webSearch = parsed.WebSearch
+			for _, call := range parsed.WebSearch {
+				if err := c.noteWebSearch(call, true); err != nil {
+					return err
+				}
 			}
 		}
 		status := response.Status
@@ -295,6 +301,14 @@ func (c *streamConverter) handle(event string, data []byte) error {
 	case "error", "response.failed":
 		return c.streamError(data)
 	}
+	return nil
+}
+
+func (c *streamConverter) bufferSearchText(delta string) error {
+	if len(delta) > maxDeferredSearchTextBytes-c.pendingSearchText.Len() {
+		return fmt.Errorf("WebSearch 延迟文本缓冲超过 %d MiB", maxDeferredSearchTextBytes>>20)
+	}
+	c.pendingSearchText.WriteString(delta)
 	return nil
 }
 

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -72,6 +72,7 @@ func newStreamConverter(writer io.Writer, operation string, options ResponseOpti
 	return &streamConverter{
 		writer: writer, operation: operation, created: time.Now().Unix(), tools: make(map[string]streamTool),
 		webSearchEmitted: make(map[string]bool),
+		deferSearchText:  operation == OperationMessages && options.AnthropicWebSearch,
 		options:          options, stopFilter: newAnthropicStreamStopFilter(options.StopSequences),
 	}
 }
@@ -119,9 +120,6 @@ func (c *streamConverter) emitWebSearchUse(call webSearchCall) error {
 	index := c.nextIndex
 	c.nextIndex++
 	c.webSearchEmitted[call.ID+"#use"] = true
-	c.webSearchEmitted[call.ID+"#useIndex"] = true
-	// stash index in a side map via tools-like pattern: reuse tools map with special name
-	c.tools[call.ID+"#ws"] = streamTool{Index: index, ID: call.ID, Name: "web_search", Closed: false}
 	if err := c.writeEvent("content_block_start", map[string]any{
 		"type": "content_block_start", "index": index,
 		"content_block": map[string]any{"type": "server_tool_use", "id": call.ID, "name": "web_search", "input": map[string]any{}},
@@ -139,9 +137,6 @@ func (c *streamConverter) emitWebSearchUse(call webSearchCall) error {
 	if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": index}); err != nil {
 		return err
 	}
-	tool := c.tools[call.ID+"#ws"]
-	tool.Closed = true
-	c.tools[call.ID+"#ws"] = tool
 	return nil
 }
 
@@ -246,7 +241,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		if item.Type == "reasoning" && c.operation == OperationMessages && c.options.AnthropicThinking {
 			return c.thinkingStart(item.ID)
 		}
-		if item.Type == "web_search_call" && c.operation == OperationMessages {
+		if item.Type == "web_search_call" && c.operation == OperationMessages && c.options.AnthropicWebSearch {
 			if call, ok := parseWebSearchCallItem(item); ok {
 				return c.noteWebSearch(call, false)
 			}
@@ -277,7 +272,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		if item.Type == "reasoning" {
 			return c.thinkingDone(item)
 		}
-		if item.Type == "web_search_call" && c.operation == OperationMessages {
+		if item.Type == "web_search_call" && c.operation == OperationMessages && c.options.AnthropicWebSearch {
 			if call, ok := parseWebSearchCallItem(item); ok {
 				return c.noteWebSearch(call, true)
 			}
@@ -286,7 +281,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		var response responseEnvelope
 		_ = json.Unmarshal(root["response"], &response)
 		c.setResponse(response)
-		if c.operation == OperationMessages {
+		if c.operation == OperationMessages && c.options.AnthropicWebSearch {
 			parsed := parseResponse(response)
 			if len(parsed.WebSearch) > 0 {
 				c.webSearch = parsed.WebSearch

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -34,25 +34,27 @@ func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, op
 }
 
 type streamConverter struct {
-	writer          io.Writer
-	operation       string
-	id              string
-	model           string
-	created         int64
-	started         bool
-	finished        bool
-	textStarted     bool
-	textIndex       int
-	thinkingStarted bool
-	thinkingClosed  bool
-	thinkingIndex   int
-	thinkingItemID  string
-	nextIndex       int
-	tools           map[string]streamTool
-	usage           responseUsage
-	options         ResponseOptions
-	stopFilter      *anthropicStreamStopFilter
-	stopSequence    string
+	writer           io.Writer
+	operation        string
+	id               string
+	model            string
+	created          int64
+	started          bool
+	finished         bool
+	textStarted      bool
+	textIndex        int
+	thinkingStarted  bool
+	thinkingClosed   bool
+	thinkingIndex    int
+	thinkingItemID   string
+	nextIndex        int
+	tools            map[string]streamTool
+	webSearch        []webSearchCall
+	webSearchEmitted map[string]bool
+	usage            responseUsage
+	options          ResponseOptions
+	stopFilter       *anthropicStreamStopFilter
+	stopSequence     string
 }
 
 type streamTool struct {
@@ -67,8 +69,112 @@ type streamTool struct {
 func newStreamConverter(writer io.Writer, operation string, options ResponseOptions) *streamConverter {
 	return &streamConverter{
 		writer: writer, operation: operation, created: time.Now().Unix(), tools: make(map[string]streamTool),
-		options: options, stopFilter: newAnthropicStreamStopFilter(options.StopSequences),
+		webSearchEmitted: make(map[string]bool),
+		options:          options, stopFilter: newAnthropicStreamStopFilter(options.StopSequences),
 	}
+}
+
+// noteWebSearch records a Build web_search_call. Emission is deferred to doneMessages
+// so we always use the completed action.sources payload from the final envelope when available.
+// For progressive UI we still emit server_tool_use as soon as we see the call.
+func (c *streamConverter) noteWebSearch(call webSearchCall, final bool) error {
+	replaced := false
+	for i, existing := range c.webSearch {
+		if existing.ID == call.ID {
+			// Prefer richer final payload.
+			if final || len(call.Hits) >= len(existing.Hits) {
+				c.webSearch[i] = call
+			}
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		c.webSearch = append(c.webSearch, call)
+	}
+	// Emit server_tool_use promptly so Claude Code can show "Searching: …".
+	return c.emitWebSearchUse(call)
+}
+
+func (c *streamConverter) emitWebSearchUse(call webSearchCall) error {
+	if err := c.start(); err != nil {
+		return err
+	}
+	if c.webSearchEmitted[call.ID+"#use"] {
+		return nil
+	}
+	index := c.nextIndex
+	c.nextIndex++
+	c.webSearchEmitted[call.ID+"#use"] = true
+	c.webSearchEmitted[call.ID+"#useIndex"] = true
+	// stash index in a side map via tools-like pattern: reuse tools map with special name
+	c.tools[call.ID+"#ws"] = streamTool{Index: index, ID: call.ID, Name: "web_search", Closed: false}
+	if err := c.writeEvent("content_block_start", map[string]any{
+		"type": "content_block_start", "index": index,
+		"content_block": map[string]any{"type": "server_tool_use", "id": call.ID, "name": "web_search", "input": map[string]any{}},
+	}); err != nil {
+		return err
+	}
+	if call.Query != "" {
+		if err := c.writeEvent("content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": index,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": queryJSONPartial(call.Query)},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": index}); err != nil {
+		return err
+	}
+	tool := c.tools[call.ID+"#ws"]
+	tool.Closed = true
+	c.tools[call.ID+"#ws"] = tool
+	return nil
+}
+
+func (c *streamConverter) emitPendingWebSearchResults() error {
+	for _, call := range c.webSearch {
+		if c.webSearchEmitted[call.ID+"#result"] {
+			continue
+		}
+		if !c.webSearchEmitted[call.ID+"#use"] {
+			if err := c.emitWebSearchUse(call); err != nil {
+				return err
+			}
+		}
+		if err := c.start(); err != nil {
+			return err
+		}
+		index := c.nextIndex
+		c.nextIndex++
+		c.webSearchEmitted[call.ID+"#result"] = true
+		var content any
+		if call.Failed {
+			code := call.Code
+			if code == "" {
+				code = "unavailable"
+			}
+			content = map[string]any{"type": "web_search_tool_result_error", "error_code": code}
+		} else {
+			hits := make([]any, 0, len(call.Hits))
+			for _, hit := range call.Hits {
+				hits = append(hits, map[string]any{"type": "web_search_result", "title": hit.Title, "url": hit.URL})
+			}
+			content = hits
+		}
+		if err := c.writeEvent("content_block_start", map[string]any{
+			"type": "content_block_start", "index": index,
+			"content_block": map[string]any{
+				"type": "web_search_tool_result", "tool_use_id": call.ID, "content": content,
+			},
+		}); err != nil {
+			return err
+		}
+		if err := c.writeEvent("content_block_stop", map[string]any{"type": "content_block_stop", "index": index}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *streamConverter) handle(event string, data []byte) error {
@@ -122,6 +228,12 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		if item.Type == "reasoning" && c.operation == OperationMessages && c.options.AnthropicThinking {
 			return c.thinkingStart(item.ID)
 		}
+		if item.Type == "web_search_call" && c.operation == OperationMessages {
+			if call, ok := parseWebSearchCallItem(item); ok {
+				return c.noteWebSearch(call, false)
+			}
+			return nil
+		}
 		if item.Type != "function_call" {
 			return nil
 		}
@@ -147,10 +259,21 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		if item.Type == "reasoning" {
 			return c.thinkingDone(item)
 		}
+		if item.Type == "web_search_call" && c.operation == OperationMessages {
+			if call, ok := parseWebSearchCallItem(item); ok {
+				return c.noteWebSearch(call, true)
+			}
+		}
 	case "response.completed", "response.incomplete":
 		var response responseEnvelope
 		_ = json.Unmarshal(root["response"], &response)
 		c.setResponse(response)
+		if c.operation == OperationMessages {
+			parsed := parseResponse(response)
+			if len(parsed.WebSearch) > 0 {
+				c.webSearch = parsed.WebSearch
+			}
+		}
 		status := response.Status
 		if status == "" && typeName == "response.incomplete" {
 			status = "incomplete"

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -305,7 +305,8 @@ func (c *streamConverter) handle(event string, data []byte) error {
 }
 
 func (c *streamConverter) bufferSearchText(delta string) error {
-	if len(delta) > maxDeferredSearchTextBytes-c.pendingSearchText.Len() {
+	pending := c.pendingSearchText.Len()
+	if pending >= maxDeferredSearchTextBytes || len(delta) > maxDeferredSearchTextBytes-pending {
 		return fmt.Errorf("WebSearch 延迟文本缓冲超过 %d MiB", maxDeferredSearchTextBytes>>20)
 	}
 	c.pendingSearchText.WriteString(delta)

--- a/backend/internal/infra/provider/searchresult/url.go
+++ b/backend/internal/infra/provider/searchresult/url.go
@@ -3,6 +3,7 @@ package searchresult
 import (
 	"net/url"
 	"strings"
+	"unicode"
 )
 
 const (
@@ -15,7 +16,7 @@ const (
 // URLs so upstream search data cannot introduce active or privacy-sensitive links.
 func NormalizeURL(raw string) (string, bool) {
 	raw = strings.TrimSpace(raw)
-	if raw == "" || len(raw) > maxURLBytes || strings.IndexAny(raw, "\r\n\t") >= 0 {
+	if raw == "" || len(raw) > maxURLBytes || strings.IndexFunc(raw, unsafeTextRune) >= 0 {
 		return "", false
 	}
 	parsed, err := url.Parse(raw)
@@ -35,13 +36,31 @@ func NormalizeURL(raw string) (string, bool) {
 }
 
 func NormalizeTitle(raw, fallback string) string {
-	value := strings.TrimSpace(raw)
+	value := sanitizeTitle(raw)
 	if value == "" {
-		value = strings.TrimSpace(fallback)
+		value = sanitizeTitle(fallback)
 	}
 	runes := []rune(value)
 	if len(runes) > MaxTitleRunes {
 		value = string(runes[:MaxTitleRunes])
 	}
 	return value
+}
+
+func unsafeTextRune(r rune) bool {
+	return unicode.IsControl(r) || unicode.In(r, unicode.Cf)
+}
+
+func sanitizeTitle(value string) string {
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		}
+		if unsafeTextRune(r) {
+			return -1
+		}
+		return r
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }

--- a/backend/internal/infra/provider/searchresult/url.go
+++ b/backend/internal/infra/provider/searchresult/url.go
@@ -1,0 +1,47 @@
+package searchresult
+
+import (
+	"net/url"
+	"strings"
+)
+
+const (
+	maxURLBytes   = 8 << 10
+	MaxResults    = 50
+	MaxTitleRunes = 512
+)
+
+// NormalizeURL accepts only public-link schemes and rejects credential-bearing
+// URLs so upstream search data cannot introduce active or privacy-sensitive links.
+func NormalizeURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || len(raw) > maxURLBytes || strings.IndexAny(raw, "\r\n\t") >= 0 {
+		return "", false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Opaque != "" || parsed.Hostname() == "" || parsed.User != nil {
+		return "", false
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", false
+	}
+	parsed.Host = strings.ToLower(parsed.Host)
+	normalized := parsed.String()
+	if len(normalized) > maxURLBytes {
+		return "", false
+	}
+	return normalized, true
+}
+
+func NormalizeTitle(raw, fallback string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = strings.TrimSpace(fallback)
+	}
+	runes := []rune(value)
+	if len(runes) > MaxTitleRunes {
+		value = string(runes[:MaxTitleRunes])
+	}
+	return value
+}

--- a/backend/internal/infra/provider/searchresult/url_test.go
+++ b/backend/internal/infra/provider/searchresult/url_test.go
@@ -1,0 +1,70 @@
+package searchresult
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{name: "https", raw: " HTTPS://Example.COM/path?q=1#fragment ", want: "https://example.com/path?q=1#fragment", ok: true},
+		{name: "http", raw: "http://example.com", want: "http://example.com", ok: true},
+		{name: "script", raw: "javascript:alert(1)"},
+		{name: "file", raw: "file:///etc/passwd"},
+		{name: "relative", raw: "/relative/path"},
+		{name: "credentials", raw: "https://user:secret@example.com/private"},
+		{name: "control", raw: "https://example.com/\nprivate"},
+		{name: "oversized", raw: "https://example.com/" + strings.Repeat("a", maxURLBytes)},
+		{name: "encoding expansion", raw: "https://example.com/#" + strings.Repeat("´", maxURLBytes/2)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := NormalizeURL(test.raw)
+			if ok != test.ok || got != test.want {
+				t.Fatalf("NormalizeURL(%q) = %q, %v; want %q, %v", test.raw, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	value := NormalizeTitle(strings.Repeat("界", MaxTitleRunes+10), "fallback")
+	if utf8.RuneCountInString(value) != MaxTitleRunes {
+		t.Fatalf("title runes = %d", utf8.RuneCountInString(value))
+	}
+	if got := NormalizeTitle("  ", " fallback "); got != "fallback" {
+		t.Fatalf("fallback title = %q", got)
+	}
+}
+
+func FuzzNormalizeURL(f *testing.F) {
+	for _, seed := range []string{
+		"https://example.com/path?q=1",
+		"http://localhost:8080/test",
+		"javascript:alert(1)",
+		"https://user:pass@example.com",
+		"\x00https://example.com",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		normalized, ok := NormalizeURL(raw)
+		if !ok {
+			return
+		}
+		parsed, err := url.Parse(normalized)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil {
+			t.Fatalf("unsafe normalized URL %q from %q", normalized, raw)
+		}
+		if len(normalized) > maxURLBytes || strings.IndexAny(normalized, "\r\n\t") >= 0 {
+			t.Fatalf("unbounded normalized URL %q", normalized)
+		}
+	})
+}

--- a/backend/internal/infra/provider/searchresult/url_test.go
+++ b/backend/internal/infra/provider/searchresult/url_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -21,6 +22,7 @@ func TestNormalizeURL(t *testing.T) {
 		{name: "relative", raw: "/relative/path"},
 		{name: "credentials", raw: "https://user:secret@example.com/private"},
 		{name: "control", raw: "https://example.com/\nprivate"},
+		{name: "bidi control", raw: "https://example.com/\u202Ehidden"},
 		{name: "oversized", raw: "https://example.com/" + strings.Repeat("a", maxURLBytes)},
 		{name: "encoding expansion", raw: "https://example.com/#" + strings.Repeat("´", maxURLBytes/2)},
 	}
@@ -41,6 +43,12 @@ func TestNormalizeTitle(t *testing.T) {
 	}
 	if got := NormalizeTitle("  ", " fallback "); got != "fallback" {
 		t.Fatalf("fallback title = %q", got)
+	}
+	if got := NormalizeTitle("Safe\x1b[31m\nTitle\u202E", "fallback"); got != "Safe[31m Title" {
+		t.Fatalf("control-safe title = %q", got)
+	}
+	if got := NormalizeTitle("\x1b\u202E", "Clean fallback"); got != "Clean fallback" {
+		t.Fatalf("sanitized-empty fallback title = %q", got)
 	}
 }
 
@@ -63,7 +71,9 @@ func FuzzNormalizeURL(f *testing.F) {
 		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Hostname() == "" || parsed.User != nil {
 			t.Fatalf("unsafe normalized URL %q from %q", normalized, raw)
 		}
-		if len(normalized) > maxURLBytes || strings.IndexAny(normalized, "\r\n\t") >= 0 {
+		if len(normalized) > maxURLBytes || strings.IndexFunc(normalized, func(r rune) bool {
+			return unicode.IsControl(r) || unicode.In(r, unicode.Cf)
+		}) >= 0 {
 			t.Fatalf("unbounded normalized URL %q", normalized)
 		}
 	})

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -29,12 +30,19 @@ import (
 
 const webResponseTTL = 30 * 24 * time.Hour
 
+const maxDeferredSearchTextBytes = 8 << 20
+
+const maxTrackedServerTools = 1024
+
 var (
 	errWebAntiBot    = errors.New("Grok Web anti-bot rejection")
 	errWebUsageLimit = errors.New("Grok Web usage limit reached")
 )
 
-var grokRenderPattern = regexp.MustCompile(`(?s)<grok:render\s+card_id="([^"]+)"\s+card_type="([^"]+)"\s+type="([^"]+)"[^>]*>.*?</grok:render>`)
+var (
+	grokRenderPattern   = regexp.MustCompile(`(?s)<grok:render\s+card_id="([^"]+)"\s+card_type="([^"]+)"\s+type="([^"]+)"[^>]*>.*?</grok:render>`)
+	grokToolNamePattern = regexp.MustCompile(`(?is)<xai:tool_name>\s*(.*?)\s*</xai:tool_name>`)
+)
 
 type openAIRequest struct {
 	Model              string          `json:"model"`
@@ -80,10 +88,12 @@ type parsedChat struct {
 	Annotations    []map[string]any
 	sourceKeys     map[string]struct{}
 	serverToolKeys map[string]struct{}
+	webSearchKeys  map[string]struct{}
 	cardCache      map[string]map[string]any
 	citationIndex  map[string]int
 	lastCitation   int
 	ServerTools    int64
+	WebSearchTools int64
 	InputTokens    int64
 	ToolCalls      []parsedToolCall
 	Tools          []any
@@ -910,13 +920,21 @@ func collectSearchSources(parsed *parsedChat, response map[string]any) {
 }
 
 func appendSearchSource(parsed *parsedChat, value, title, sourceType string) {
+	value, valid := searchresult.NormalizeURL(value)
+	if !valid {
+		return
+	}
+	if parsed.sourceKeys == nil {
+		parsed.sourceKeys = make(map[string]struct{})
+	}
 	if _, exists := parsed.sourceKeys[value]; exists {
 		return
 	}
-	parsed.sourceKeys[value] = struct{}{}
-	if strings.TrimSpace(title) == "" {
-		title = value
+	if len(parsed.SearchSources) >= searchresult.MaxResults {
+		return
 	}
+	parsed.sourceKeys[value] = struct{}{}
+	title = searchresult.NormalizeTitle(title, value)
 	parsed.SearchSources = append(parsed.SearchSources, map[string]any{"url": value, "title": title, "type": sourceType})
 }
 
@@ -924,18 +942,59 @@ func collectServerTool(parsed *parsedChat, response map[string]any) {
 	if parsed.serverToolKeys == nil {
 		parsed.serverToolKeys = make(map[string]struct{})
 	}
-	key := firstString(response, "rolloutId", "responseId", "toolUsageCardId", "messageTag")
-	if step, ok := numberAsInt(response["messageStepId"]); ok {
-		key += fmt.Sprintf(":%d", step)
+	key := serverToolKey(response)
+	if _, exists := parsed.serverToolKeys[key]; !exists {
+		if len(parsed.serverToolKeys) >= maxTrackedServerTools {
+			return
+		}
+		parsed.serverToolKeys[key] = struct{}{}
+		parsed.ServerTools++
 	}
-	if key == "" {
-		key = firstString(response, "token", "messageTag")
-	}
-	if _, exists := parsed.serverToolKeys[key]; exists {
+	if webServerToolName(response) != "web_search" {
 		return
 	}
-	parsed.serverToolKeys[key] = struct{}{}
-	parsed.ServerTools++
+	if parsed.webSearchKeys == nil {
+		parsed.webSearchKeys = make(map[string]struct{})
+	}
+	if _, exists := parsed.webSearchKeys[key]; exists || len(parsed.webSearchKeys) >= maxTrackedServerTools {
+		return
+	}
+	parsed.webSearchKeys[key] = struct{}{}
+	parsed.WebSearchTools++
+}
+
+func serverToolKey(response map[string]any) string {
+	key := firstString(response, "rolloutId", "responseId", "toolUsageCardId")
+	step, hasStep := numberAsInt(response["messageStepId"])
+	if key != "" {
+		if hasStep {
+			key += fmt.Sprintf(":%d", step)
+		}
+		return key
+	}
+	if token, _ := response["token"].(string); token != "" {
+		sum := sha256.Sum256([]byte(token))
+		return "token:" + hex.EncodeToString(sum[:8])
+	}
+	if hasStep {
+		return fmt.Sprintf("step:%d", step)
+	}
+	return firstString(response, "messageTag")
+}
+
+func webServerToolName(response map[string]any) string {
+	if name := strings.ToLower(strings.TrimSpace(firstString(response, "toolName", "tool_name"))); name != "" {
+		return name
+	}
+	token, _ := response["token"].(string)
+	match := grokToolNamePattern.FindStringSubmatch(token)
+	if len(match) < 2 {
+		return ""
+	}
+	name := strings.TrimSpace(match[1])
+	name = strings.TrimPrefix(name, "<![CDATA[")
+	name = strings.TrimSuffix(name, "]]>")
+	return strings.ToLower(strings.TrimSpace(name))
 }
 
 func applyParsedToolCalls(parsed *parsedChat, configuration toolConfiguration) {
@@ -1104,7 +1163,8 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 		return fmt.Sprintf("![%s](%s)", title, thumbnail), nil
 	case "render_inline_citation":
 		value, _ := card["url"].(string)
-		if value == "" {
+		value, valid := searchresult.NormalizeURL(value)
+		if !valid {
 			return "", nil
 		}
 		if parsed.citationIndex == nil {
@@ -1129,6 +1189,9 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 }
 
 func searchSourceTitle(sources []map[string]any, rawURL string) string {
+	if normalized, valid := searchresult.NormalizeURL(rawURL); valid {
+		rawURL = normalized
+	}
 	for _, source := range sources {
 		if value, _ := source["url"].(string); value == rawURL {
 			if title, _ := source["title"].(string); title != "" {
@@ -1316,8 +1379,8 @@ func shouldEmitWebMessagesSearch(parsed parsedChat, options conversation.Respons
 }
 
 func webMessagesSearchRequests(parsed parsedChat) int64 {
-	if parsed.ServerTools > 0 {
-		return parsed.ServerTools
+	if parsed.WebSearchTools > 0 {
+		return parsed.WebSearchTools
 	}
 	return 1
 }
@@ -1443,8 +1506,7 @@ func (s *webMessagesStream) Delta(kind, delta string) error {
 				return err
 			}
 		}
-		s.pendingText.WriteString(delta)
-		return nil
+		return s.bufferSearchText(delta)
 	}
 	if err := s.startText(); err != nil {
 		return err
@@ -1457,6 +1519,14 @@ func (s *webMessagesStream) Delta(kind, delta string) error {
 		return nil
 	}
 	return s.writeTextDelta(emit)
+}
+
+func (s *webMessagesStream) bufferSearchText(delta string) error {
+	if len(delta) > maxDeferredSearchTextBytes-s.pendingText.Len() {
+		return fmt.Errorf("WebSearch 延迟文本缓冲超过 %d MiB", maxDeferredSearchTextBytes>>20)
+	}
+	s.pendingText.WriteString(delta)
+	return nil
 }
 
 func (s *webMessagesStream) startText() error {

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -23,6 +23,7 @@ import (
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/searchresult"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 )
 
@@ -1171,9 +1172,13 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	}
 	if operation == conversation.OperationMessages {
 		visibleText, stopSequence := applyWebStopSequences(parsed.Text.String(), options.StopSequences)
-		content := make([]any, 0, len(parsed.ToolCalls))
+		emitWebSearch := shouldEmitWebMessagesSearch(parsed, options)
+		content := make([]any, 0, len(parsed.ToolCalls)+3)
 		if options.AnthropicThinking && parsed.Reasoning.Len() > 0 {
 			content = append(content, map[string]any{"type": "thinking", "thinking": parsed.Reasoning.String()})
+		}
+		if emitWebSearch {
+			content = append(content, webMessagesSearchBlocks(newWebID("srvtoolu"), parsed, options)...)
 		}
 		if visibleText != "" || len(parsed.ToolCalls) == 0 {
 			content = append(content, map[string]any{"type": "text", "text": visibleText})
@@ -1191,10 +1196,14 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 		} else if stopSequence != "" {
 			stopReason = "stop_sequence"
 		}
+		usage := map[string]any{"input_tokens": inputTokens, "output_tokens": outputTokens, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+		if emitWebSearch {
+			usage["server_tool_use"] = map[string]any{"web_search_requests": webMessagesSearchRequests(parsed)}
+		}
 		return map[string]any{
 			"id": strings.Replace(responseID, "resp_", "msg_", 1), "type": "message", "role": "assistant", "model": model,
 			"content": content, "stop_reason": stopReason, "stop_sequence": nullableWebString(stopSequence),
-			"usage": map[string]any{"input_tokens": inputTokens, "output_tokens": outputTokens, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+			"usage": usage,
 		}
 	}
 	output := make([]any, 0, 2)
@@ -1270,6 +1279,49 @@ func webAnthropicToolID(value string) string {
 	return "toolu_" + value
 }
 
+func webMessagesSearchBlocks(id string, parsed parsedChat, options conversation.ResponseOptions) []any {
+	use := map[string]any{
+		"type": "server_tool_use", "id": id, "name": "web_search",
+		"input": map[string]any{"query": options.AnthropicWebSearchQuery},
+	}
+	hits := make([]any, 0, len(parsed.SearchSources))
+	seen := make(map[string]struct{}, len(parsed.SearchSources))
+	for _, source := range parsed.SearchSources {
+		if len(hits) >= searchresult.MaxResults {
+			break
+		}
+		rawURL, _ := source["url"].(string)
+		rawURL, valid := searchresult.NormalizeURL(rawURL)
+		if !valid {
+			continue
+		}
+		if _, exists := seen[rawURL]; exists {
+			continue
+		}
+		seen[rawURL] = struct{}{}
+		title, _ := source["title"].(string)
+		title = searchresult.NormalizeTitle(title, rawURL)
+		hits = append(hits, map[string]any{"type": "web_search_result", "title": title, "url": rawURL})
+	}
+	var content any = hits
+	if parsed.ServerTools == 0 && len(hits) == 0 {
+		content = map[string]any{"type": "web_search_tool_result_error", "error_code": "unavailable"}
+	}
+	result := map[string]any{"type": "web_search_tool_result", "tool_use_id": id, "content": content}
+	return []any{use, result}
+}
+
+func shouldEmitWebMessagesSearch(parsed parsedChat, options conversation.ResponseOptions) bool {
+	return options.AnthropicWebSearch && (options.AnthropicWebSearchRequired || parsed.ServerTools > 0 || len(parsed.SearchSources) > 0)
+}
+
+func webMessagesSearchRequests(parsed parsedChat) int64 {
+	if parsed.ServerTools > 0 {
+		return parsed.ServerTools
+	}
+	return 1
+}
+
 func chatToolCalls(calls []parsedToolCall) []any {
 	values := make([]any, 0, len(calls))
 	for _, call := range calls {
@@ -1318,6 +1370,9 @@ type webMessagesStream struct {
 	textIndex       int
 	nextIndex       int
 	hasTools        bool
+	webSearchID     string
+	webSearchUse    bool
+	pendingText     strings.Builder
 	stopSequence    string
 	stopFilter      *webStopFilter
 }
@@ -1334,13 +1389,19 @@ func (s *webMessagesStream) Start() error {
 		return nil
 	}
 	s.started = true
-	return writeSSE(s.writer, "message_start", map[string]any{
+	if err := writeSSE(s.writer, "message_start", map[string]any{
 		"type": "message_start", "message": map[string]any{
 			"id": strings.Replace(s.responseID, "resp_", "msg_", 1), "type": "message", "role": "assistant", "model": s.model,
 			"content": []any{}, "stop_reason": nil, "stop_sequence": nil,
 			"usage": map[string]any{"input_tokens": s.inputTokens, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
 		},
-	})
+	}); err != nil {
+		return err
+	}
+	if s.options.AnthropicWebSearchRequired && !s.options.AnthropicThinking {
+		return s.startWebSearch()
+	}
+	return nil
 }
 
 func (s *webMessagesStream) Delta(kind, delta string) error {
@@ -1371,6 +1432,18 @@ func (s *webMessagesStream) Delta(kind, delta string) error {
 		})
 	}
 	if kind != "text" {
+		return nil
+	}
+	if s.options.AnthropicWebSearch {
+		if err := s.closeThinking(); err != nil {
+			return err
+		}
+		if s.options.AnthropicWebSearchRequired {
+			if err := s.startWebSearch(); err != nil {
+				return err
+			}
+		}
+		s.pendingText.WriteString(delta)
 		return nil
 	}
 	if err := s.startText(); err != nil {
@@ -1447,9 +1520,74 @@ func (s *webMessagesStream) Tools(calls []parsedToolCall) error {
 	return nil
 }
 
+func (s *webMessagesStream) startWebSearch() error {
+	if s.webSearchUse {
+		return nil
+	}
+	s.webSearchUse = true
+	if s.webSearchID == "" {
+		s.webSearchID = newWebID("srvtoolu")
+	}
+	index := s.nextIndex
+	s.nextIndex++
+	if err := writeSSE(s.writer, "content_block_start", map[string]any{
+		"type": "content_block_start", "index": index,
+		"content_block": map[string]any{"type": "server_tool_use", "id": s.webSearchID, "name": "web_search", "input": map[string]any{}},
+	}); err != nil {
+		return err
+	}
+	if query := s.options.AnthropicWebSearchQuery; query != "" {
+		encoded, _ := json.Marshal(map[string]string{"query": query})
+		if err := writeSSE(s.writer, "content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": index,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": string(encoded)},
+		}); err != nil {
+			return err
+		}
+	}
+	return writeSSE(s.writer, "content_block_stop", map[string]any{"type": "content_block_stop", "index": index})
+}
+
+func (s *webMessagesStream) finishWebSearch(parsed parsedChat) error {
+	if !shouldEmitWebMessagesSearch(parsed, s.options) {
+		return nil
+	}
+	if err := s.startWebSearch(); err != nil {
+		return err
+	}
+	blocks := webMessagesSearchBlocks(s.webSearchID, parsed, s.options)
+	result := blocks[1]
+	index := s.nextIndex
+	s.nextIndex++
+	if err := writeSSE(s.writer, "content_block_start", map[string]any{
+		"type": "content_block_start", "index": index, "content_block": result,
+	}); err != nil {
+		return err
+	}
+	return writeSSE(s.writer, "content_block_stop", map[string]any{"type": "content_block_stop", "index": index})
+}
+
 func (s *webMessagesStream) Finish(parsed parsedChat, payload map[string]any) error {
 	if err := s.Start(); err != nil {
 		return err
+	}
+	if err := s.closeThinking(); err != nil {
+		return err
+	}
+	if err := s.finishWebSearch(parsed); err != nil {
+		return err
+	}
+	if s.options.AnthropicWebSearch && s.pendingText.Len() > 0 {
+		if err := s.startText(); err != nil {
+			return err
+		}
+		emit, matched := s.stopFilter.Push(s.pendingText.String())
+		if matched != "" {
+			s.stopSequence = matched
+		}
+		if err := s.writeTextDelta(emit); err != nil {
+			return err
+		}
 	}
 	if s.stopSequence == "" {
 		if pending := s.stopFilter.Flush(); pending != "" {
@@ -1461,9 +1599,6 @@ func (s *webMessagesStream) Finish(parsed parsedChat, payload map[string]any) er
 			}
 		}
 	}
-	if err := s.closeThinking(); err != nil {
-		return err
-	}
 	if err := s.closeText(); err != nil {
 		return err
 	}
@@ -1474,9 +1609,13 @@ func (s *webMessagesStream) Finish(parsed parsedChat, payload map[string]any) er
 		stopReason = "stop_sequence"
 	}
 	usage, _ := payload["usage"].(map[string]any)
+	finalUsage := map[string]any{"output_tokens": usage["output_tokens"]}
+	if shouldEmitWebMessagesSearch(parsed, s.options) {
+		finalUsage["server_tool_use"] = map[string]any{"web_search_requests": webMessagesSearchRequests(parsed)}
+	}
 	if err := writeSSE(s.writer, "message_delta", map[string]any{
 		"type": "message_delta", "delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nullableWebString(s.stopSequence)},
-		"usage": map[string]any{"output_tokens": usage["output_tokens"]},
+		"usage": finalUsage,
 	}); err != nil {
 		return err
 	}

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -1236,7 +1236,8 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	if operation == conversation.OperationMessages {
 		visibleText, stopSequence := applyWebStopSequences(parsed.Text.String(), options.StopSequences)
 		emitWebSearch := shouldEmitWebMessagesSearch(parsed, options)
-		content := make([]any, 0, len(parsed.ToolCalls)+3)
+		// Zero initial capacity: tool/search counts come from untrusted upstream.
+		content := make([]any, 0)
 		if options.AnthropicThinking && parsed.Reasoning.Len() > 0 {
 			content = append(content, map[string]any{"type": "thinking", "thinking": parsed.Reasoning.String()})
 		}
@@ -1347,8 +1348,8 @@ func webMessagesSearchBlocks(id string, parsed parsedChat, options conversation.
 		"type": "server_tool_use", "id": id, "name": "web_search",
 		"input": map[string]any{"query": options.AnthropicWebSearchQuery},
 	}
-	hits := make([]any, 0, len(parsed.SearchSources))
-	seen := make(map[string]struct{}, len(parsed.SearchSources))
+	hits := make([]any, 0, searchresult.MaxResults)
+	seen := make(map[string]struct{}, searchresult.MaxResults)
 	for _, source := range parsed.SearchSources {
 		if len(hits) >= searchresult.MaxResults {
 			break
@@ -1522,7 +1523,8 @@ func (s *webMessagesStream) Delta(kind, delta string) error {
 }
 
 func (s *webMessagesStream) bufferSearchText(delta string) error {
-	if len(delta) > maxDeferredSearchTextBytes-s.pendingText.Len() {
+	pending := s.pendingText.Len()
+	if pending >= maxDeferredSearchTextBytes || len(delta) > maxDeferredSearchTextBytes-pending {
 		return fmt.Errorf("WebSearch 延迟文本缓冲超过 %d MiB", maxDeferredSearchTextBytes>>20)
 	}
 	s.pendingText.WriteString(delta)

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -1367,7 +1367,7 @@ func webMessagesSearchBlocks(id string, parsed parsedChat, options conversation.
 		hits = append(hits, map[string]any{"type": "web_search_result", "title": title, "url": rawURL})
 	}
 	var content any = hits
-	if parsed.ServerTools == 0 && len(hits) == 0 {
+	if parsed.WebSearchTools == 0 && len(hits) == 0 {
 		content = map[string]any{"type": "web_search_tool_result_error", "error_code": "unavailable"}
 	}
 	result := map[string]any{"type": "web_search_tool_result", "tool_use_id": id, "content": content}
@@ -1375,7 +1375,7 @@ func webMessagesSearchBlocks(id string, parsed parsedChat, options conversation.
 }
 
 func shouldEmitWebMessagesSearch(parsed parsedChat, options conversation.ResponseOptions) bool {
-	return options.AnthropicWebSearch && (options.AnthropicWebSearchRequired || parsed.ServerTools > 0 || len(parsed.SearchSources) > 0)
+	return options.AnthropicWebSearch && (options.AnthropicWebSearchRequired || parsed.WebSearchTools > 0 || len(parsed.SearchSources) > 0)
 }
 
 func webMessagesSearchRequests(parsed parsedChat) int64 {

--- a/backend/internal/infra/provider/web/protocol_test.go
+++ b/backend/internal/infra/provider/web/protocol_test.go
@@ -19,6 +19,7 @@ import (
 	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 	"github.com/chenyme/grok2api/backend/internal/infra/security"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 )
@@ -241,6 +242,104 @@ func TestChatImageUploadFeedsFileMetadataIntoConversation(t *testing.T) {
 	result, err := io.ReadAll(response.Body)
 	if err != nil || response.StatusCode != http.StatusOK || !bytes.Contains(result, []byte(`"content":"seen"`)) {
 		t.Fatalf("status=%d body=%s err=%v", response.StatusCode, result, err)
+	}
+}
+
+func TestForwardMessagesWebSearchEndToEnd(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		name := "non_stream"
+		if streaming {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			var upstreamMessage string
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != "/rest/app-chat/conversations/new" {
+					http.NotFound(writer, request)
+					return
+				}
+				var payload map[string]any
+				if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+					t.Errorf("upstream payload: %v", err)
+					writer.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				upstreamMessage, _ = payload["message"].(string)
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(writer, "data: {\"result\":{\"conversation\":{\"conversationId\":\"conv_1\"}}}\n")
+				_, _ = io.WriteString(writer, "data: {\"result\":{\"response\":{\"rolloutId\":\"search_1\",\"messageStepId\":1,\"messageTag\":\"tool_usage_card\"}}}\n")
+				_, _ = io.WriteString(writer, "data: {\"result\":{\"response\":{\"token\":\"Here you go.\",\"isThinking\":false,\"messageTag\":\"final\",\"webSearchResults\":{\"results\":[{\"url\":\"https://doc.rust-lang.org\",\"title\":\"The Rust Book\"}]}}}}\n")
+				_, _ = io.WriteString(writer, "data: [DONE]\n")
+			}))
+			defer server.Close()
+
+			cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			encrypted, err := cipher.Encrypt("test-sso")
+			if err != nil {
+				t.Fatal(err)
+			}
+			adapter := NewAdapter(Config{BaseURL: server.URL, StatsigMode: "manual"}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+			body, _ := json.Marshal(map[string]any{
+				"model": "public", "max_tokens": 256, "stream": streaming,
+				"messages":    []any{map[string]any{"role": "user", "content": "Perform a web search for the query: rust tutorials"}},
+				"tools":       []any{map[string]any{"type": "web_search_20250305", "name": "web_search", "max_uses": 8}},
+				"tool_choice": map[string]any{"type": "tool", "name": "web_search"},
+			})
+			response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+				Credential: account.Credential{ID: 1, EncryptedAccessToken: encrypted}, Method: http.MethodPost,
+				Path: "/responses", Body: body, Model: "grok-chat-fast", Operation: conversation.OperationMessages,
+				Streaming: streaming,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			result, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(upstreamMessage, "rust tutorials") || strings.Contains(upstreamMessage, "You MUST call at least one available tool") {
+				t.Fatalf("upstream message = %q", upstreamMessage)
+			}
+
+			if streaming {
+				text := string(result)
+				useAt := strings.Index(text, `"type":"server_tool_use"`)
+				resultAt := strings.Index(text, `"type":"web_search_tool_result"`)
+				textAt := strings.Index(text, `"content_block":{"text":"","type":"text"}`)
+				if response.StatusCode != http.StatusOK || useAt < 0 || resultAt < 0 || textAt < 0 || !(useAt < resultAt && resultAt < textAt) {
+					t.Fatalf("stream status=%d body=%s", response.StatusCode, text)
+				}
+				if !strings.Contains(text, "rust tutorials") || !strings.Contains(text, `"web_search_requests":1`) || !strings.Contains(text, "The Rust Book") {
+					t.Fatalf("stream missing query, usage, or hit: %s", text)
+				}
+				return
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(result, &payload); err != nil {
+				t.Fatal(err)
+			}
+			content := payload["content"].([]any)
+			if response.StatusCode != http.StatusOK || len(content) != 3 || content[0].(map[string]any)["type"] != "server_tool_use" || content[1].(map[string]any)["type"] != "web_search_tool_result" || content[2].(map[string]any)["text"] != "Here you go." {
+				t.Fatalf("non-stream status=%d payload=%#v", response.StatusCode, payload)
+			}
+			use := content[0].(map[string]any)
+			if use["input"].(map[string]any)["query"] != "rust tutorials" || content[1].(map[string]any)["tool_use_id"] != use["id"] {
+				t.Fatalf("web search linkage = %#v", content)
+			}
+			hits := content[1].(map[string]any)["content"].([]any)
+			if len(hits) != 1 || hits[0].(map[string]any)["title"] != "The Rust Book" || payload["stop_reason"] != "end_turn" {
+				t.Fatalf("web search result = %#v", payload)
+			}
+			usage := payload["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+			if usage["web_search_requests"] != float64(1) {
+				t.Fatalf("web search usage = %#v", usage)
+			}
+		})
 	}
 }
 

--- a/backend/internal/infra/provider/web/tools.go
+++ b/backend/internal/infra/provider/web/tools.go
@@ -35,12 +35,13 @@ type functionTool struct {
 }
 
 type toolConfiguration struct {
-	Functions      []functionTool
-	available      map[string]struct{}
-	Choice         string
-	ForcedName     string
-	ResponseTools  []any
-	ResponseChoice any
+	Functions       []functionTool
+	HostedWebSearch bool
+	available       map[string]struct{}
+	Choice          string
+	ForcedName      string
+	ResponseTools   []any
+	ResponseChoice  any
 }
 
 type parsedToolCall struct {
@@ -97,6 +98,7 @@ func parseToolConfiguration(rawTools, rawChoice json.RawMessage) (toolConfigurat
 			switch strings.ToLower(strings.TrimSpace(typeName)) {
 			case "web_search", "web_search_preview":
 				// Grok Web 原生搜索始终由上游执行，这两个标准声明无需注入函数提示词。
+				configuration.HostedWebSearch = true
 			default:
 				return toolConfiguration{}, fmt.Errorf("Grok Web 暂不支持 tools.type=%q", typeName)
 			}
@@ -122,7 +124,7 @@ func parseToolConfiguration(rawTools, rawChoice json.RawMessage) (toolConfigurat
 			return toolConfiguration{}, fmt.Errorf("tool_choice 指定的函数 %q 不存在", forcedName)
 		}
 	}
-	if (choice == "required" || forcedName != "") && len(configuration.Functions) == 0 {
+	if (choice == "required" || forcedName != "") && len(configuration.Functions) == 0 && !configuration.HostedWebSearch {
 		return toolConfiguration{}, errors.New("tool_choice 要求调用函数，但 tools 中没有可用函数")
 	}
 	return configuration, nil
@@ -218,7 +220,7 @@ func injectToolPrompt(prompt string, configuration toolConfiguration) string {
 	choiceInstruction := "Call a tool when it is clearly needed. Otherwise respond in plain text."
 	if configuration.ForcedName != "" {
 		choiceInstruction = fmt.Sprintf("You MUST call the tool named %q and must not write a plain-text reply.", configuration.ForcedName)
-	} else if configuration.Choice == "required" {
+	} else if configuration.Choice == "required" && !configuration.HostedWebSearch {
 		choiceInstruction = "You MUST call at least one available tool and must not write a plain-text reply."
 	}
 	system := fmt.Sprintf(`You have access to the following tools.

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -223,6 +223,28 @@ func TestBuildMessagesResultDoesNotFabricateOptionalWebSearch(t *testing.T) {
 	}
 }
 
+func TestBuildMessagesResultDoesNotTreatOtherServerToolsAsWebSearch(t *testing.T) {
+	parsed := parsedChat{ServerTools: 1}
+	parsed.Text.WriteString("Generated an image instead.")
+	result := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsed, false, conversation.ResponseOptions{
+		AnthropicWebSearch: true, AnthropicWebSearchQuery: "optional query",
+	})
+	content := result["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "text" {
+		t.Fatalf("non-search server tool fabricated web search blocks: %#v", content)
+	}
+	if _, exists := result["usage"].(map[string]any)["server_tool_use"]; exists {
+		t.Fatalf("non-search server tool fabricated web search usage: %#v", result["usage"])
+	}
+
+	required := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsed, false, webSearchResponseOptions(t))
+	requiredContent := required["content"].([]any)
+	errorContent, ok := requiredContent[1].(map[string]any)["content"].(map[string]any)
+	if !ok || errorContent["type"] != "web_search_tool_result_error" || errorContent["error_code"] != "unavailable" {
+		t.Fatalf("forced search with only a non-search server tool = %#v", requiredContent)
+	}
+}
+
 func TestBuildMessagesResultFiltersUnsafeAndDuplicateSearchSources(t *testing.T) {
 	options := webSearchResponseOptions(t)
 	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -3,8 +3,10 @@ package web
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 )
@@ -27,6 +29,65 @@ func TestParseToolConfigurationSupportsChatAndResponsesSchemas(t *testing.T) {
 	}
 	if len(responses.Functions) != 1 || responses.Functions[0].Name != "lookup" || len(responses.ResponseTools) != 2 {
 		t.Fatalf("responses tool config = %#v", responses)
+	}
+}
+
+func TestParseToolConfigurationAllowsRequiredHostedWebSearch(t *testing.T) {
+	configuration, err := parseToolConfiguration(
+		json.RawMessage(`[{"type":"web_search","max_uses":8}]`),
+		json.RawMessage(`"required"`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.Choice != "required" || len(configuration.Functions) != 0 || len(configuration.ResponseTools) != 1 {
+		t.Fatalf("configuration = %#v", configuration)
+	}
+}
+
+func TestInjectToolPromptDoesNotForceClientFunctionWhenHostedSearchIsRequired(t *testing.T) {
+	configuration, err := parseToolConfiguration(
+		json.RawMessage(`[
+			{"type":"web_search"},
+			{"type":"function","name":"lookup","description":"Look up local data","parameters":{"type":"object"}}
+		]`),
+		json.RawMessage(`"required"`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := injectToolPrompt("find the latest release", configuration)
+	if !strings.Contains(prompt, "Tool: lookup") {
+		t.Fatalf("client function definition missing from prompt: %s", prompt)
+	}
+	if strings.Contains(prompt, "You MUST call at least one available tool") {
+		t.Fatalf("hosted-search required incorrectly forced a client function: %s", prompt)
+	}
+	if !strings.Contains(prompt, "Call a tool when it is clearly needed") {
+		t.Fatalf("mixed hosted/client tool guidance is not optional: %s", prompt)
+	}
+}
+
+func TestAnthropicWebSearchRequestConvertsForWebProvider(t *testing.T) {
+	converted, options, err := conversation.ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"stream":true,
+		"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-chat-fast", conversation.OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var input openAIRequest
+	if err := json.Unmarshal(converted, &input); err != nil {
+		t.Fatal(err)
+	}
+	configuration, err := parseToolConfiguration(input.Tools, input.ToolChoice)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !options.AnthropicWebSearch || !options.AnthropicWebSearchRequired || options.AnthropicWebSearchQuery != "rust tutorials" || !configuration.HostedWebSearch || configuration.Choice != "required" {
+		t.Fatalf("options=%#v configuration=%#v", options, configuration)
 	}
 }
 
@@ -105,6 +166,101 @@ func TestBuildMessagesResultPreservesThinkingAndStopSequence(t *testing.T) {
 	}
 }
 
+func TestBuildMessagesResultEmitsServerWebSearchBlocks(t *testing.T) {
+	options := webSearchResponseOptions(t)
+	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{
+		{"url": "https://doc.rust-lang.org", "title": "The Rust Book", "type": "web"},
+	}}
+	parsed.Text.WriteString("Here you go.")
+	result := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsed, false, options)
+	content := result["content"].([]any)
+	if len(content) != 3 {
+		t.Fatalf("content = %#v", content)
+	}
+	use := content[0].(map[string]any)
+	if use["type"] != "server_tool_use" || use["name"] != "web_search" || use["input"].(map[string]any)["query"] != "rust tutorials" {
+		t.Fatalf("server_tool_use = %#v", use)
+	}
+	searchResult := content[1].(map[string]any)
+	if searchResult["type"] != "web_search_tool_result" || searchResult["tool_use_id"] != use["id"] {
+		t.Fatalf("web_search_tool_result = %#v", searchResult)
+	}
+	hits := searchResult["content"].([]any)
+	if len(hits) != 1 || hits[0].(map[string]any)["url"] != "https://doc.rust-lang.org" {
+		t.Fatalf("hits = %#v", hits)
+	}
+	if content[2].(map[string]any)["type"] != "text" || result["stop_reason"] != "end_turn" {
+		t.Fatalf("result = %#v", result)
+	}
+	usage := result["usage"].(map[string]any)["server_tool_use"].(map[string]any)
+	if usage["web_search_requests"] != int64(1) {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestBuildMessagesResultEmitsUnavailableWebSearchError(t *testing.T) {
+	result := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsedChat{}, false, webSearchResponseOptions(t))
+	content := result["content"].([]any)
+	errorContent := content[1].(map[string]any)["content"].(map[string]any)
+	if errorContent["type"] != "web_search_tool_result_error" || errorContent["error_code"] != "unavailable" {
+		t.Fatalf("error content = %#v", errorContent)
+	}
+}
+
+func TestBuildMessagesResultDoesNotFabricateOptionalWebSearch(t *testing.T) {
+	parsed := parsedChat{}
+	parsed.Text.WriteString("Plain answer.")
+	result := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsed, false, conversation.ResponseOptions{
+		AnthropicWebSearch: true, AnthropicWebSearchQuery: "optional query",
+	})
+	content := result["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "text" || content[0].(map[string]any)["text"] != "Plain answer." {
+		t.Fatalf("optional search fabricated server blocks: %#v", content)
+	}
+	if _, exists := result["usage"].(map[string]any)["server_tool_use"]; exists {
+		t.Fatalf("optional search fabricated usage: %#v", result["usage"])
+	}
+}
+
+func TestBuildMessagesResultFiltersUnsafeAndDuplicateSearchSources(t *testing.T) {
+	options := webSearchResponseOptions(t)
+	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{
+		{"url": "https://example.com/a", "title": "Example"},
+		{"url": "https://example.com/a", "title": "Duplicate"},
+		{"url": "javascript:alert(1)", "title": "Script"},
+		{"url": "file:///etc/passwd", "title": "File"},
+		{"url": "/relative/path", "title": "Relative"},
+		{"url": "https://user:secret@example.com/private", "title": "Credential URL"},
+	}}
+	result := buildOpenAIResult("messages", "resp_test", "grok-chat-fast", parsed, false, options)
+	content := result["content"].([]any)
+	hits := content[1].(map[string]any)["content"].([]any)
+	if len(hits) != 1 {
+		t.Fatalf("unsafe or duplicate sources leaked into hits: %#v", hits)
+	}
+	if hits[0].(map[string]any)["url"] != "https://example.com/a" {
+		t.Fatalf("hits = %#v", hits)
+	}
+}
+
+func TestBuildMessagesResultBoundsSearchSourcesAndTitles(t *testing.T) {
+	parsed := parsedChat{ServerTools: 1, SearchSources: make([]map[string]any, 0, 60)}
+	for index := 0; index < 60; index++ {
+		parsed.SearchSources = append(parsed.SearchSources, map[string]any{
+			"url":   "https://example.com/" + strconv.Itoa(index),
+			"title": strings.Repeat("界", 600),
+		})
+	}
+	blocks := webMessagesSearchBlocks("srvtoolu_test", parsed, webSearchResponseOptions(t))
+	hits := blocks[1].(map[string]any)["content"].([]any)
+	if len(hits) != 50 {
+		t.Fatalf("hits = %d, want 50", len(hits))
+	}
+	if got := utf8.RuneCountInString(hits[0].(map[string]any)["title"].(string)); got != 512 {
+		t.Fatalf("title runes = %d, want 512", got)
+	}
+}
+
 func TestWebMessagesStreamPreservesThinkingAndSplitStopSequence(t *testing.T) {
 	var output bytes.Buffer
 	stream := newWebMessagesStream(&output, "resp_test", "grok-chat-fast", 3, conversation.ResponseOptions{
@@ -126,6 +282,98 @@ func TestWebMessagesStreamPreservesThinkingAndSplitStopSequence(t *testing.T) {
 	if strings.Contains(text, "XYZ") || !strings.Contains(text, `"thinking":"thought"`) || !strings.Contains(text, `"text":"ABC"`) || !strings.Contains(text, `"stop_reason":"stop_sequence"`) {
 		t.Fatalf("stream = %s", text)
 	}
+}
+
+func TestWebMessagesStreamEmitsServerWebSearchBeforeBufferedText(t *testing.T) {
+	var output bytes.Buffer
+	stream := newWebMessagesStream(&output, "resp_test", "grok-chat-fast", 3, webSearchResponseOptions(t))
+	if err := stream.Delta("text", "Here you go."); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{
+		{"url": "https://doc.rust-lang.org", "title": "The Rust Book", "type": "web"},
+	}}
+	if err := stream.Finish(parsed, map[string]any{"usage": map[string]any{"output_tokens": int64(2)}}); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	useAt := strings.Index(text, `"type":"server_tool_use"`)
+	resultAt := strings.Index(text, `"type":"web_search_tool_result"`)
+	textAt := strings.Index(text, `"content_block":{"text":"","type":"text"}`)
+	if useAt < 0 || resultAt < 0 || textAt < 0 || !(useAt < resultAt && resultAt < textAt) {
+		t.Fatalf("expected server_tool_use -> result -> text, got:\n%s", text)
+	}
+	if !strings.Contains(text, "rust tutorials") || !strings.Contains(text, `"web_search_requests":1`) {
+		t.Fatalf("missing query or usage:\n%s", text)
+	}
+}
+
+func TestWebMessagesStreamKeepsThinkingBeforeServerWebSearch(t *testing.T) {
+	options := webSearchResponseOptions(t)
+	options.AnthropicThinking = true
+	var output bytes.Buffer
+	stream := newWebMessagesStream(&output, "resp_test", "grok-chat-fast", 3, options)
+	if err := stream.Delta("reasoning", "Need sources."); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Delta("text", "Here you go."); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{
+		{"url": "https://doc.rust-lang.org", "title": "The Rust Book"},
+	}}
+	if err := stream.Finish(parsed, map[string]any{"usage": map[string]any{"output_tokens": int64(2)}}); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	thinkingAt := strings.Index(text, `"type":"thinking"`)
+	useAt := strings.Index(text, `"type":"server_tool_use"`)
+	resultAt := strings.Index(text, `"type":"web_search_tool_result"`)
+	textAt := strings.Index(text, `"content_block":{"text":"","type":"text"}`)
+	if thinkingAt < 0 || useAt < 0 || resultAt < 0 || textAt < 0 || !(thinkingAt < useAt && useAt < resultAt && resultAt < textAt) {
+		t.Fatalf("expected thinking -> server_tool_use -> result -> text, got:\n%s", text)
+	}
+}
+
+func TestWebMessagesStreamAppliesStopSequenceAfterServerWebSearch(t *testing.T) {
+	options := webSearchResponseOptions(t)
+	options.StopSequences = []string{"STOP"}
+	var output bytes.Buffer
+	stream := newWebMessagesStream(&output, "resp_test", "grok-chat-fast", 3, options)
+	if err := stream.Delta("text", "ABCST"); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Delta("text", "OPXYZ"); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parsedChat{ServerTools: 1, SearchSources: []map[string]any{{"url": "https://example.com", "title": "Example"}}}
+	if err := stream.Finish(parsed, map[string]any{"usage": map[string]any{"output_tokens": int64(2)}}); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if strings.Contains(text, "XYZ") || !strings.Contains(text, `"text":"ABC"`) || !strings.Contains(text, `"stop_reason":"stop_sequence"`) || !strings.Contains(text, `"stop_sequence":"STOP"`) {
+		t.Fatalf("stream stop sequence = %s", text)
+	}
+	useAt := strings.Index(text, `"type":"server_tool_use"`)
+	resultAt := strings.Index(text, `"type":"web_search_tool_result"`)
+	textAt := strings.Index(text, `"content_block":{"text":"","type":"text"}`)
+	if useAt < 0 || resultAt < 0 || textAt < 0 || !(useAt < resultAt && resultAt < textAt) {
+		t.Fatalf("web search blocks are out of order: %s", text)
+	}
+}
+
+func webSearchResponseOptions(t *testing.T) conversation.ResponseOptions {
+	t.Helper()
+	_, options, err := conversation.ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"stream":true,
+		"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+		"tool_choice":{"type":"tool","name":"web_search"}
+	}`), "grok-chat-fast", conversation.OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return options
 }
 
 func TestToolStreamSieveHandlesSplitXML(t *testing.T) {

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/searchresult"
 )
 
 func TestParseToolConfigurationSupportsChatAndResponsesSchemas(t *testing.T) {
@@ -362,6 +363,15 @@ func TestWebMessagesStreamAppliesStopSequenceAfterServerWebSearch(t *testing.T) 
 	}
 }
 
+func TestWebMessagesStreamRejectsOversizedDeferredText(t *testing.T) {
+	var output bytes.Buffer
+	stream := newWebMessagesStream(&output, "resp_test", "grok-chat-fast", 3, conversation.ResponseOptions{AnthropicWebSearch: true})
+	err := stream.Delta("text", strings.Repeat("x", (8<<20)+1))
+	if err == nil || !strings.Contains(err.Error(), "缓冲") {
+		t.Fatalf("oversized deferred text error = %v", err)
+	}
+}
+
 func webSearchResponseOptions(t *testing.T) conversation.ResponseOptions {
 	t.Helper()
 	_, options, err := conversation.ConvertRequestWithOptions([]byte(`{
@@ -420,6 +430,103 @@ func TestSearchSourcesAndServerToolsAreDeduplicated(t *testing.T) {
 	}
 }
 
+func TestWebMessagesUsageDoesNotCountNonSearchServerTools(t *testing.T) {
+	parsed := parsedChat{
+		ServerTools:   3,
+		SearchSources: []map[string]any{{"url": "https://example.com", "title": "Example"}},
+	}
+	if got := webMessagesSearchRequests(parsed); got != 1 {
+		t.Fatalf("web_search_requests = %d, want 1", got)
+	}
+}
+
+func TestCollectServerToolCountsOnlyNamedWebSearchForAnthropicUsage(t *testing.T) {
+	parsed := &parsedChat{}
+	webCard := map[string]any{
+		"rolloutId": "web-1", "messageTag": "tool_usage_card",
+		"token": `<xai:tool_usage_card><xai:tool_name>web_search</xai:tool_name><xai:tool_args>{"query":"x"}</xai:tool_args></xai:tool_usage_card>`,
+	}
+	collectServerTool(parsed, webCard)
+	collectServerTool(parsed, webCard)
+	collectServerTool(parsed, map[string]any{
+		"rolloutId": "image-1", "messageTag": "tool_usage_card",
+		"token": `<xai:tool_usage_card><xai:tool_name>search_images</xai:tool_name></xai:tool_usage_card>`,
+	})
+	collectServerTool(parsed, map[string]any{
+		"rolloutId": "web-2", "messageTag": "tool_usage_card", "toolName": "web_search",
+	})
+	if parsed.ServerTools != 3 || parsed.WebSearchTools != 2 || webMessagesSearchRequests(*parsed) != 2 {
+		t.Fatalf("server=%d web=%d usage=%d", parsed.ServerTools, parsed.WebSearchTools, webMessagesSearchRequests(*parsed))
+	}
+}
+
+func TestCollectServerToolEnrichesEarlierUnknownCard(t *testing.T) {
+	parsed := &parsedChat{}
+	collectServerTool(parsed, map[string]any{
+		"rolloutId": "web-late", "messageTag": "tool_usage_card",
+	})
+	collectServerTool(parsed, map[string]any{
+		"rolloutId": "web-late", "messageTag": "tool_usage_card",
+		"token": `<xai:tool_usage_card><xai:tool_name>web_search</xai:tool_name></xai:tool_usage_card>`,
+	})
+	if parsed.ServerTools != 1 || parsed.WebSearchTools != 1 || webMessagesSearchRequests(*parsed) != 1 {
+		t.Fatalf("server=%d web=%d usage=%d", parsed.ServerTools, parsed.WebSearchTools, webMessagesSearchRequests(*parsed))
+	}
+}
+
+func TestCollectServerToolDistinguishesTokenCardsWithoutRolloutID(t *testing.T) {
+	parsed := &parsedChat{}
+	for _, name := range []string{"web_search", "search_images"} {
+		collectServerTool(parsed, map[string]any{
+			"messageStepId": 1.0, "messageTag": "tool_usage_card",
+			"token": `<xai:tool_usage_card><xai:tool_name>` + name + `</xai:tool_name></xai:tool_usage_card>`,
+		})
+	}
+	if parsed.ServerTools != 2 || parsed.WebSearchTools != 1 {
+		t.Fatalf("server=%d web=%d", parsed.ServerTools, parsed.WebSearchTools)
+	}
+}
+
+func TestCollectServerToolBoundsTrackingState(t *testing.T) {
+	parsed := &parsedChat{}
+	for index := 0; index < maxTrackedServerTools+10; index++ {
+		collectServerTool(parsed, map[string]any{
+			"rolloutId": "web-" + strconv.Itoa(index), "messageTag": "tool_usage_card", "toolName": "web_search",
+		})
+	}
+	if len(parsed.serverToolKeys) != maxTrackedServerTools || len(parsed.webSearchKeys) != maxTrackedServerTools || parsed.ServerTools != maxTrackedServerTools || parsed.WebSearchTools != maxTrackedServerTools {
+		t.Fatalf("server keys=%d web keys=%d server=%d web=%d", len(parsed.serverToolKeys), len(parsed.webSearchKeys), parsed.ServerTools, parsed.WebSearchTools)
+	}
+}
+
+func TestCollectSearchSourcesNormalizesFiltersAndBoundsInput(t *testing.T) {
+	results := make([]any, 0, searchresult.MaxResults+12)
+	results = append(results,
+		map[string]any{"url": "javascript:alert(1)", "title": "Script"},
+		map[string]any{"url": "https://user:secret@example.com/private", "title": "Credential"},
+	)
+	for index := 0; index < searchresult.MaxResults+10; index++ {
+		results = append(results, map[string]any{
+			"url":   "HTTPS://Example.COM/" + strconv.Itoa(index),
+			"title": strings.Repeat("界", searchresult.MaxTitleRunes+10),
+		})
+	}
+	parsed := &parsedChat{}
+	collectSearchSources(parsed, map[string]any{"webSearchResults": map[string]any{"results": results}})
+	if len(parsed.SearchSources) != searchresult.MaxResults || len(parsed.sourceKeys) != searchresult.MaxResults {
+		t.Fatalf("sources=%d keys=%d, want %d", len(parsed.SearchSources), len(parsed.sourceKeys), searchresult.MaxResults)
+	}
+	first := parsed.SearchSources[0]
+	if first["url"] != "https://example.com/0" || utf8.RuneCountInString(first["title"].(string)) != searchresult.MaxTitleRunes {
+		t.Fatalf("first normalized source = %#v", first)
+	}
+	for _, source := range parsed.SearchSources {
+		if strings.Contains(source["url"].(string), "@") || strings.HasPrefix(source["url"].(string), "javascript:") {
+			t.Fatalf("unsafe source retained: %#v", source)
+		}
+	}
+}
+
 func TestGeneratedImageURLsCollectAllCandidates(t *testing.T) {
 	parsed := &parsedChat{}
 	frame := map[string]any{"result": map[string]any{"response": map[string]any{
@@ -463,5 +570,22 @@ func TestGrokRenderCitationBecomesMarkdownAndAnnotation(t *testing.T) {
 	annotation := parsed.Annotations[0]
 	if annotation["title"] != "Example" || annotation["start_index"] != 6 || annotation["end_index"] != len(delta) {
 		t.Fatalf("annotation = %#v", annotation)
+	}
+}
+
+func TestGrokRenderCitationRejectsUnsafeURLs(t *testing.T) {
+	for _, rawURL := range []string{
+		"javascript:alert(1)",
+		"file:///etc/passwd",
+		"https://user:secret@example.com/private",
+		"/relative/path",
+	} {
+		parsed := &parsedChat{cardCache: map[string]map[string]any{
+			"cite_unsafe": {"id": "cite_unsafe", "url": rawURL},
+		}}
+		replacement, annotation := renderChatCard(parsed, "cite_unsafe", "render_inline_citation")
+		if replacement != "" || annotation != nil {
+			t.Fatalf("unsafe citation %q rendered as %q, %#v", rawURL, replacement, annotation)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Claude Code runs its `WebSearch` client tool through a secondary `/v1/messages` request containing Anthropic's hosted `web_search_*` tool. This PR makes both Grok Build and Grok Web return the structured Anthropic server-tool lifecycle Claude Code expects:

- `server_tool_use` with `name=web_search` and the normalized query
- `web_search_tool_result` with bounded, sanitized `web_search_result` entries
- ordered streaming events: `thinking -> server_tool_use -> result -> text`
- `usage.server_tool_use.web_search_requests`

### Provider coverage

- **Grok Build / CLI:** maps Responses `web_search_call` items and annotations into Anthropic Messages JSON/SSE.
- **Grok Web:** maps native search cards/sources into the same JSON/SSE shape, including `unavailable` when a forced search cannot run.

### Compatibility guarantees

- Main-session client function `WebSearch` remains a client function and still produces normal `tool_use`.
- `/v1/responses` pass-through remains unchanged.
- Hosted search only appears in Messages responses when the request explicitly declared `web_search_*` and `tool_choice != none`.
- Optional search does not fabricate a server-tool call; forced hosted search gets a stable `unavailable` result if the upstream completes without a search call.
- Client functions mixed with hosted search are not incorrectly forced by hosted `tool_choice=required`.
- Generic Grok server tools such as `search_images` and `chatroom_send` are not counted as web-search requests and do not emit hosted search blocks.

## Hardening

- Buffers search-enabled text so streaming preserves Anthropic block order even when upstream text arrives first; delayed text is capped at 8 MiB with residual-safe bounds checks.
- Filters empty/repeated search calls, caps each response at 32 calls (including before final envelope dedupe), and merges final envelopes with early calls instead of replacing already-emitted state.
- Accepts at most 50 results per search, including after same-ID source merges.
- Truncates queries to 4096 and titles to 512 Unicode code points.
- Accepts only absolute HTTP(S) result URLs; rejects relative, credential-bearing, active-scheme, control-character, and oversized URLs.
- Applies the same URL boundary to inline citations and strips ESC, control, bidi, and Unicode format characters from titles.
- Revalidates URL size after normalization/escaping and deduplicates canonical URLs.
- Uses SHA-256-based stable fallback IDs and normalizes even pre-prefixed untrusted upstream IDs.
- Retains the user query only for explicit hosted-search requests; ordinary Messages requests do not retain prompt text in response options.
- Tracks at most 1024 upstream tool cards and separately classifies true `web_search` usage, including later frames that enrich the same rollout.
- Uses a SHA-256 token digest when upstream tool-card events lack a rollout ID, avoiding raw token retention.
- Avoids untrusted capacity arithmetic in content allocation paths (CodeQL size overflow).

## Test plan

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./cmd/grok2api`
- [x] `go test ./internal/infra/provider/searchresult -run '^$' -fuzz '^FuzzNormalizeURL$' -fuzztime=5s` — ~2.1M executions PASS
- [x] Build CLI adapter integration: Anthropic request -> captured Responses payload -> synthetic `web_search_call` -> Anthropic blocks
- [x] Grok Web adapter integration with local upstream fixture, both non-streaming and streaming
- [x] Regression coverage for privacy gates, `tool_choice:none`, optional vs forced search, mixed client/hosted tools, stop sequences, thinking order, early/final call merging, missing IDs, unsafe citations/URLs, Unicode controls, limits, duplicates, usage classification, unavailable fallback, and CodeQL allocation bounds
- [x] Rebased onto latest `main` (includes SSRF remote-image hardening from #652)

## Notes

- No Claude Code client changes are required.
- No additional HTTP fetch is performed for result titles.
- `encrypted_content` is intentionally not synthesized; Claude Code's secondary WebSearch path consumes title/URL results.
- Windows ThreadSanitizer could not start because it failed to reserve its address space (error 87); this is an environment limitation, not a test failure.
- `docs/` under the local worktree remains untracked and is not part of this PR.