### PR TITLE
fix: backfill missing Console runtime settings

### DIFF
--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -272,9 +272,12 @@ func applyDomainConfig(base config.Config, value settingsdomain.Config) config.C
 		MediaConcurrency: value.ProviderWeb.MediaConcurrency, AllowNSFW: value.ProviderWeb.AllowNSFW,
 		RecoveryBackoffBase: config.Duration(value.ProviderWeb.RecoveryBackoffBase), RecoveryBackoffMax: config.Duration(value.ProviderWeb.RecoveryBackoffMax),
 	}
-	base.Provider.Console = config.ConsoleProviderConfig{
-		BaseURL: value.ProviderConsole.BaseURL, UserAgent: value.ProviderConsole.UserAgent,
-		ChatTimeout: config.Duration(value.ProviderConsole.ChatTimeout),
+	// Console 是后续版本新增的完整配置段；旧 JSON 整段缺失时沿用代码默认值。
+	if value.ProviderConsole != (settingsdomain.ProviderConsoleConfig{}) {
+		base.Provider.Console = config.ConsoleProviderConfig{
+			BaseURL: value.ProviderConsole.BaseURL, UserAgent: value.ProviderConsole.UserAgent,
+			ChatTimeout: config.Duration(value.ProviderConsole.ChatTimeout),
+		}
 	}
 	randomDelay := time.Duration(-1)
 	if value.Batch.RandomDelay != nil {

--- a/backend/internal/application/settings/service_test.go
+++ b/backend/internal/application/settings/service_test.go
@@ -221,6 +221,32 @@ func TestLoadPersistedBackfillsMissingServerConcurrency(t *testing.T) {
 	}
 }
 
+func TestLoadPersistedBackfillsMissingConsoleSection(t *testing.T) {
+	cfg := testConfig(t)
+	value := toDomainConfig(cfg)
+	value.ProviderConsole = settingsdomain.ProviderConsoleConfig{}
+	repository := &runtimeSettingsRepositoryStub{value: value, found: true}
+
+	loaded, _, _, err := LoadPersisted(context.Background(), cfg, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Provider.Console != cfg.Provider.Console {
+		t.Fatalf("console = %#v, want %#v", loaded.Provider.Console, cfg.Provider.Console)
+	}
+}
+
+func TestLoadPersistedRejectsPartiallyInvalidConsoleSection(t *testing.T) {
+	cfg := testConfig(t)
+	value := toDomainConfig(cfg)
+	value.ProviderConsole.BaseURL = ""
+	repository := &runtimeSettingsRepositoryStub{value: value, found: true}
+
+	if _, _, _, err := LoadPersisted(context.Background(), cfg, repository); err == nil {
+		t.Fatal("partially invalid Console settings were accepted")
+	}
+}
+
 func TestReloadPersistedAppliesOnlyNewerVersion(t *testing.T) {
 	cfg := testConfig(t)
 	updatedAt := time.Now().UTC()


### PR DESCRIPTION
- preserve the default request concurrency when legacy settings omit Server
- restore the built-in Console configuration when the section is absent
- reject partially corrupted Console settings instead of masking errors
- add regression coverage for legacy runtime settings