### PR TITLE
feat: enhance remote image handling with new validation and fetching logic

### DIFF
--- a/backend/internal/infra/egress/pinnedclient.go
+++ b/backend/internal/infra/egress/pinnedclient.go
@@ -1,0 +1,94 @@
+package egress
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+
+	xproxy "golang.org/x/net/proxy"
+)
+
+// DoPinnedHTTPS sends a request whose URL host is an already validated IP
+// address while preserving serverName for TLS verification. Keeping this
+// transport separate from the shared browser client prevents a later DNS
+// lookup or a pooled connection from reopening an SSRF validation gap.
+func (l *Lease) DoPinnedHTTPS(request *http.Request, serverName string) (*http.Response, error) {
+	if l == nil {
+		return nil, errors.New("出口租约未初始化")
+	}
+	if request == nil || request.URL == nil || request.URL.Scheme != "https" || request.URL.Port() != "443" {
+		return nil, errors.New("固定地址请求必须使用 HTTPS 443")
+	}
+	address, err := netip.ParseAddr(request.URL.Hostname())
+	if err != nil {
+		return nil, errors.New("固定地址请求必须使用 IP 主机")
+	}
+	address = address.Unmap()
+	if !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() || address.IsMulticast() || address.IsUnspecified() {
+		return nil, errors.New("固定地址请求必须使用公网 IP")
+	}
+	serverName = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(serverName)), ".")
+	hostURL, err := url.Parse("https://" + request.Host)
+	if err != nil || strings.TrimSuffix(strings.ToLower(hostURL.Hostname()), ".") != serverName {
+		return nil, errors.New("固定地址请求的 Host 与 TLS ServerName 不一致")
+	}
+	client, err := newPinnedHTTPSClient(l.ProxyURL, serverName, nil)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(request)
+}
+
+func newPinnedHTTPSClient(proxyURL, serverName string, tlsConfig *tls.Config) (*http.Client, error) {
+	serverName = strings.TrimSuffix(strings.TrimSpace(serverName), ".")
+	if serverName == "" {
+		return nil, errors.New("TLS ServerName 不能为空")
+	}
+	direct := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	tlsConfig.ServerName = serverName
+	transport := &http.Transport{
+		Proxy:                 nil,
+		DialContext:           direct.DialContext,
+		ForceAttemptHTTP2:     true,
+		DisableKeepAlives:     true,
+		TLSClientConfig:       tlsConfig,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
+	if strings.TrimSpace(proxyURL) != "" {
+		parsed, err := url.Parse(proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("解析固定地址出口代理: %w", err)
+		}
+		switch strings.ToLower(parsed.Scheme) {
+		case "http", "https":
+			transport.Proxy = http.ProxyURL(parsed)
+		case "socks4", "socks4a", "socks5", "socks5h":
+			dialer, err := xproxy.FromURL(parsed, direct)
+			if err != nil {
+				return nil, fmt.Errorf("创建固定地址 SOCKS 代理: %w", err)
+			}
+			transport.DialContext = dialContext(dialer)
+		default:
+			return nil, fmt.Errorf("固定地址请求不支持代理协议 %q", parsed.Scheme)
+		}
+	}
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
+}

--- a/backend/internal/infra/egress/pinnedclient_test.go
+++ b/backend/internal/infra/egress/pinnedclient_test.go
@@ -1,0 +1,148 @@
+package egress
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPinnedHTTPSClientPreservesHostAndTLSServerName(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Host != "example.com" {
+			t.Errorf("Host = %q", request.Host)
+		}
+		_, _ = io.WriteString(writer, "ok")
+	}))
+	defer server.Close()
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+	client, err := newPinnedHTTPSClient("", "example.com", &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/image.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "example.com"
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, readErr := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if readErr != nil || string(body) != "ok" {
+		t.Fatalf("body=%q err=%v", body, readErr)
+	}
+}
+
+func TestPinnedHTTPSClientHTTPProxyConnectsToPinnedIP(t *testing.T) {
+	connected := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		connected <- request.Host
+		http.Error(writer, "stop", http.StatusBadGateway)
+	}))
+	defer proxyServer.Close()
+	client, err := newPinnedHTTPSClient(proxyServer.URL, "images.example.test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodGet, "https://93.184.216.34:443/image.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "images.example.test"
+	_, _ = client.Do(request)
+	select {
+	case host := <-connected:
+		if host != "93.184.216.34:443" {
+			t.Fatalf("proxy CONNECT host = %q", host)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxy did not receive CONNECT")
+	}
+}
+
+func TestPinnedHTTPSClientSOCKS5HReceivesPinnedIP(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = io.WriteString(writer, "ok")
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamAddress := serverURL.Host
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	requestedHost := make(chan string, 1)
+	proxyDone := make(chan error, 1)
+	go func() { proxyDone <- serveSOCKS5TunnelOnce(listener, upstreamAddress, requestedHost) }()
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+	client, err := newPinnedHTTPSClient("socks5h://"+listener.Addr().String(), "example.com", &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, port, err := net.SplitHostPort(upstreamAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:"+port+"/image.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "example.com"
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	select {
+	case host := <-requestedHost:
+		if host != "127.0.0.1" {
+			t.Fatalf("SOCKS target host = %q", host)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SOCKS proxy did not receive target")
+	}
+	select {
+	case err := <-proxyDone:
+		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "closed") && !strings.Contains(strings.ToLower(err.Error()), "reset by peer") {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SOCKS proxy did not finish")
+	}
+}
+
+func TestLeaseDoPinnedHTTPSRejectsHostnameTarget(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "https://images.example.test:443/image.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&Lease{}).DoPinnedHTTPS(request, "images.example.test"); err == nil {
+		t.Fatal("hostname target was accepted")
+	}
+}
+
+func TestLeaseDoPinnedHTTPSRejectsPrivateTarget(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "https://127.0.0.1:443/image.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "images.example.test"
+	if _, err := (&Lease{}).DoPinnedHTTPS(request, "images.example.test"); err == nil {
+		t.Fatal("private target was accepted")
+	}
+}

--- a/backend/internal/infra/provider/web/attachments.go
+++ b/backend/internal/infra/provider/web/attachments.go
@@ -39,6 +39,17 @@ type uploadedFile struct {
 	URI string
 }
 
+type remoteImageTarget struct {
+	originalURL *url.URL
+	fetchURL    *url.URL
+	serverName  string
+	hostHeader  string
+}
+
+type remoteImageResolver interface {
+	LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error)
+}
+
 // prepareChatAttachments 在同一账号和出口租约内解析、下载并上传对话图片。
 func (a *Adapter) prepareChatAttachments(ctx context.Context, cfg Config, lease *egress.Lease, token string, inputs []string) ([]string, error) {
 	if len(inputs) == 0 {
@@ -80,19 +91,20 @@ func (a *Adapter) loadChatImage(ctx context.Context, lease *egress.Lease, input 
 	if strings.HasPrefix(strings.ToLower(input), "data:") {
 		return parseChatImageDataURI(input, maxBytes)
 	}
-	parsed, err := validateRemoteImageURL(ctx, input)
+	target, err := validateRemoteImageURL(ctx, input)
 	if err != nil {
 		return provider.ImageInput{}, err
 	}
 	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, parsed.String(), nil)
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, target.fetchURL.String(), nil)
 	if err != nil {
 		return provider.ImageInput{}, err
 	}
+	request.Host = target.hostHeader
 	// 外部图片地址不接收 SSO 或 Cloudflare Cookie，避免把上游凭据泄漏给第三方。
 	request.Header = remoteImageHeaders(lease.UserAgent)
-	response, err := lease.Do(request)
+	response, err := lease.DoPinnedHTTPS(request, target.serverName)
 	if err != nil {
 		return provider.ImageInput{}, fmt.Errorf("下载对话图片: %w", err)
 	}
@@ -111,7 +123,7 @@ func (a *Adapter) loadChatImage(ctx context.Context, lease *egress.Lease, input 
 	if err != nil {
 		return provider.ImageInput{}, err
 	}
-	return provider.ImageInput{Filename: imageFilename(parsed, mimeType), MIMEType: mimeType, Data: raw}, nil
+	return provider.ImageInput{Filename: imageFilename(target.originalURL, mimeType), MIMEType: mimeType, Data: raw}, nil
 }
 
 func remoteImageHeaders(userAgent string) http.Header {
@@ -166,7 +178,11 @@ func supportedChatImageMIME(value string) bool {
 	}
 }
 
-func validateRemoteImageURL(ctx context.Context, raw string) (*url.URL, error) {
+func validateRemoteImageURL(ctx context.Context, raw string) (*remoteImageTarget, error) {
+	return validateRemoteImageURLWithResolver(ctx, raw, net.DefaultResolver)
+}
+
+func validateRemoteImageURLWithResolver(ctx context.Context, raw string, resolver remoteImageResolver) (*remoteImageTarget, error) {
 	if len(raw) == 0 || len(raw) > maxRemoteImageURLBytes {
 		return nil, fmt.Errorf("%w: URL 为空或过长", errInvalidChatImage)
 	}
@@ -183,21 +199,27 @@ func validateRemoteImageURL(ctx context.Context, raw string) (*url.URL, error) {
 		if !publicRemoteImageAddress(address) {
 			return nil, fmt.Errorf("%w: URL 指向非公网地址", errInvalidChatImage)
 		}
-		return parsed, nil
+		return newRemoteImageTarget(parsed, host, address), nil
 	}
 	resolveCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	addresses, err := net.DefaultResolver.LookupIPAddr(resolveCtx, host)
+	addresses, err := resolver.LookupNetIP(resolveCtx, "ip", host)
 	if err != nil || len(addresses) == 0 {
 		return nil, fmt.Errorf("%w: 无法解析图片主机", errInvalidChatImage)
 	}
-	for _, value := range addresses {
-		address, ok := netip.AddrFromSlice(value.IP)
-		if !ok || !publicRemoteImageAddress(address.Unmap()) {
+	for _, address := range addresses {
+		if !publicRemoteImageAddress(address.Unmap()) {
 			return nil, fmt.Errorf("%w: URL 解析到非公网地址", errInvalidChatImage)
 		}
 	}
-	return parsed, nil
+	return newRemoteImageTarget(parsed, host, addresses[0].Unmap()), nil
+}
+
+func newRemoteImageTarget(original *url.URL, serverName string, address netip.Addr) *remoteImageTarget {
+	fetchURL := *original
+	fetchURL.Host = net.JoinHostPort(address.String(), "443")
+	fetchURL.Fragment = ""
+	return &remoteImageTarget{originalURL: original, fetchURL: &fetchURL, serverName: serverName, hostHeader: original.Host}
 }
 
 func publicRemoteImageAddress(address netip.Addr) bool {

--- a/backend/internal/infra/provider/web/attachments_test.go
+++ b/backend/internal/infra/provider/web/attachments_test.go
@@ -1,0 +1,57 @@
+package web
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+)
+
+type rebindingImageResolver struct {
+	calls int
+}
+
+func (r *rebindingImageResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	r.calls++
+	if r.calls == 1 {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+}
+
+func TestRemoteImageTargetPinsFirstValidatedResolution(t *testing.T) {
+	resolver := &rebindingImageResolver{}
+	target, err := validateRemoteImageURLWithResolver(context.Background(), "https://images.example.test/photo.png?size=large", resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+	if target.originalURL.Host != "images.example.test" || target.fetchURL.Host != "93.184.216.34:443" {
+		t.Fatalf("target = %#v", target)
+	}
+	if target.hostHeader != "images.example.test" || target.serverName != "images.example.test" {
+		t.Fatalf("host=%q serverName=%q", target.hostHeader, target.serverName)
+	}
+	if target.fetchURL.Path != "/photo.png" || target.fetchURL.RawQuery != "size=large" {
+		t.Fatalf("fetch URL = %s", target.fetchURL)
+	}
+}
+
+func TestRemoteImageTargetRejectsAnyPrivateResolution(t *testing.T) {
+	resolver := staticImageResolver{addresses: []netip.Addr{
+		netip.MustParseAddr("93.184.216.34"),
+		netip.MustParseAddr("10.0.0.8"),
+	}}
+	if _, err := validateRemoteImageURLWithResolver(context.Background(), "https://images.example.test/photo.png", resolver); err == nil {
+		t.Fatal("mixed public and private DNS result was accepted")
+	}
+}
+
+type staticImageResolver struct {
+	addresses []netip.Addr
+}
+
+func (r staticImageResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return append([]netip.Addr(nil), r.addresses...), nil
+}

--- a/backend/internal/infra/provider/web/protocol_test.go
+++ b/backend/internal/infra/provider/web/protocol_test.go
@@ -159,7 +159,7 @@ func TestRemoteChatImageURLBlocksPrivateNetworks(t *testing.T) {
 			t.Fatalf("unsafe image URL accepted: %s", value)
 		}
 	}
-	if value, err := validateRemoteImageURL(context.Background(), "https://8.8.8.8/image.png"); err != nil || value.Hostname() != "8.8.8.8" {
+	if value, err := validateRemoteImageURL(context.Background(), "https://8.8.8.8/image.png"); err != nil || value.originalURL.Hostname() != "8.8.8.8" || value.fetchURL.Hostname() != "8.8.8.8" {
 		t.Fatalf("public image URL rejected: value=%v err=%v", value, err)
 	}
 }

--- a/frontend/src/features/media/gallery-page.tsx
+++ b/frontend/src/features/media/gallery-page.tsx
@@ -103,10 +103,12 @@ export function GalleryPage() {
 
 function ImageCard({ image, locale }: { image: MediaAssetDTO; locale: string }) {
   const { t } = useTranslation();
+  // 管理端图库与 API 同源，使用相对路径避免依赖未配置或仅对外可用的公共地址。
+  const imageURL = `/v1/media/images/${encodeURIComponent(image.id)}`;
   return (
-    <a href={image.url} target="_blank" rel="noreferrer" className="group overflow-hidden rounded-lg bg-card transition-colors hover:bg-secondary/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+    <a href={imageURL} target="_blank" rel="noreferrer" className="group overflow-hidden rounded-lg bg-card transition-colors hover:bg-secondary/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
       <div className="aspect-square overflow-hidden bg-muted">
-        <img src={image.url} alt={image.id} loading="lazy" className="size-full object-cover transition-transform duration-200 group-hover:scale-[1.02]" />
+        <img src={imageURL} alt={image.id} loading="lazy" className="size-full object-cover transition-transform duration-200 group-hover:scale-[1.02]" />
       </div>
       <div className="space-y-2 p-3 text-xs">
         <div className="flex min-w-0 items-center justify-between gap-2">


### PR DESCRIPTION
## Summary

Harden remote image downloads against DNS changes between URL validation and connection establishment.

## Changes

- Resolve and validate remote image hosts once.
- Connect only to the validated public IP.
- Preserve the original HTTP Host and TLS SNI.
- Reject hostname, private, loopback, and link-local connection targets at the egress layer.
- Support pinned connections through direct, HTTP/HTTPS, SOCKS4, and SOCKS5 proxies.
- Keep redirects and connection reuse disabled for remote image downloads.
- Apply the protection to chat images, Messages, image editing, and video reference images.

## Test plan

- [x] DNS resolution is performed once.
- [x] Mixed public/private DNS results are rejected.
- [x] Original Host and TLS SNI are preserved.
- [x] HTTP proxy CONNECT uses the pinned IP.
- [x] SOCKS5H receives the pinned IP instead of the hostname.
- [x] Private and hostname connection targets are rejected.
- [x] `go test ./...` passes.
- [x] `git diff --check` passes.