### PR TITLE
feat: align Grok Build 0.2.101 protocol and client compatibility

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
@@ -49,7 +50,6 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/backend/internal/application/gateway/failure_test.go
+++ b/backend/internal/application/gateway/failure_test.go
@@ -1,8 +1,12 @@
 package gateway
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 )
 
 func TestHTTPUpstreamFailureClassifiesBuildForbiddenBodies(t *testing.T) {
@@ -39,5 +43,24 @@ func TestHTTPUpstreamFailureClassifiesBuildForbiddenBodies(t *testing.T) {
 				t.Fatalf("failure = %#v", failure)
 			}
 		})
+	}
+}
+
+func TestRetryableResponseHonorsUpstreamRetryVeto(t *testing.T) {
+	response := &provider.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{"X-Should-Retry": {"false"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":"invalid request history"}`)),
+	}
+	if isRetryableResponse(response) {
+		t.Fatal("x-should-retry:false 必须禁止换账号重试")
+	}
+	response.Header.Set("X-Should-Retry", "true")
+	if !isRetryableResponse(response) {
+		t.Fatal("x-should-retry:true 不应覆盖现有状态码重试策略")
+	}
+	response.Header.Set("X-Should-Retry", "unknown")
+	if !isRetryableResponse(response) {
+		t.Fatal("未知 x-should-retry 值应按未提供处理")
 	}
 }

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -42,6 +42,7 @@ const responseOwnershipTTL = 30 * 24 * time.Hour
 const finalizationTimeout = 5 * time.Second
 const textBillingReservationTTL = 2 * time.Hour
 const mediaBillingReservationTTL = 24 * time.Hour
+const modelCatalogRefreshTimeout = 30 * time.Second
 
 var freeQuotaUsagePattern = regexp.MustCompile(`(?i)tokens\s*\(actual/limit\)\s*:\s*([0-9]+)\s*/\s*([0-9]+)`)
 
@@ -90,6 +91,10 @@ type routeResolver interface {
 	GetByProviderUpstream(ctx context.Context, providerValue accountdomain.Provider, upstreamModel string) (modeldomain.Route, error)
 }
 
+type accountModelSyncer interface {
+	SyncAccount(ctx context.Context, accountID uint64) (int, error)
+}
+
 // Service 负责模型路由、账号选择、故障切换与审计收口。
 type Service struct {
 	models         routeResolver
@@ -110,6 +115,8 @@ type Service struct {
 	rateLimitMu    sync.Mutex
 	rateLimits     map[string]teamModelRateLimit
 	rateLimitTeams map[uint64]string
+	modelSyncMu    sync.Mutex
+	modelSyncing   map[uint64]struct{}
 }
 
 type teamModelRateLimit struct {
@@ -132,6 +139,7 @@ func NewService(models routeResolver, audits auditRecorder, accounts *accountapp
 		models: models, audits: audits, accounts: accounts, clientKeys: clientKeys, providers: providers,
 		selector: selector, responses: responses, logger: slog.Default(),
 		rateLimits: make(map[string]teamModelRateLimit), rateLimitTeams: make(map[uint64]string),
+		modelSyncing: make(map[uint64]struct{}),
 	}
 	service.UpdateMaxAttempts(maxAttempts)
 	return service
@@ -524,6 +532,9 @@ attemptLoop:
 			continue
 		}
 	handleResponse:
+		if response.ModelCatalogChanged {
+			s.queueAccountModelSync(credential.ID)
+		}
 		if response.StatusCode == http.StatusUnauthorized {
 			response.Body.Close()
 			if credential.AuthType == accountdomain.AuthTypeSSO {
@@ -574,7 +585,7 @@ attemptLoop:
 		}
 		egressForbidden := s.providers.RetryForbiddenAsEgress(credential.Provider) && response.StatusCode == http.StatusForbidden
 		finalEgressForbidden := egressForbidden && (attempt > 0 || attempt+1 >= attempts)
-		if isRetryable(response.StatusCode) && !finalEgressForbidden {
+		if isRetryableResponse(response) && !finalEgressForbidden {
 			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
 			body, _ := readRetryableBody(response.Body)
 			if egressForbidden {
@@ -777,6 +788,43 @@ attemptLoop:
 	return nil, fmt.Errorf("%w: %w", ErrNoAvailableAccount, lastErr)
 }
 
+func (s *Service) queueAccountModelSync(accountID uint64) {
+	syncer, ok := s.models.(accountModelSyncer)
+	if !ok || accountID == 0 {
+		return
+	}
+	s.modelSyncMu.Lock()
+	if s.modelSyncing == nil {
+		s.modelSyncing = make(map[uint64]struct{})
+	}
+	if _, exists := s.modelSyncing[accountID]; exists {
+		s.modelSyncMu.Unlock()
+		return
+	}
+	s.modelSyncing[accountID] = struct{}{}
+	s.modelSyncMu.Unlock()
+
+	go func() {
+		defer func() {
+			s.modelSyncMu.Lock()
+			delete(s.modelSyncing, accountID)
+			s.modelSyncMu.Unlock()
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), modelCatalogRefreshTimeout)
+		defer cancel()
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		count, err := syncer.SyncAccount(ctx, accountID)
+		if err != nil {
+			logger.Warn("model_etag_refresh_failed", "account_id", accountID, "error", err)
+			return
+		}
+		logger.Info("model_etag_refresh_completed", "account_id", accountID, "models", count)
+	}()
+}
+
 func rewriteAliasedModel(body []byte, publicModel, reasoningEffort string, operation audit.Operation) ([]byte, error) {
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -957,6 +1005,13 @@ func (b *finalizingBody) Close() error {
 
 func isRetryable(status int) bool {
 	return status == 402 || status == 403 || status == 429 || status >= 500
+}
+
+func isRetryableResponse(response *provider.Response) bool {
+	if response == nil || !isRetryable(response.StatusCode) {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(response.Header.Get("X-Should-Retry")), "false")
 }
 
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,54 @@ import (
 	"github.com/chenyme/grok2api/backend/internal/infra/security"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 )
+
+func TestQueueAccountModelSyncDeduplicatesConcurrentETagRefresh(t *testing.T) {
+	resolver := &etagSyncResolver{started: make(chan uint64, 2), release: make(chan struct{})}
+	service := &Service{models: resolver, logger: slog.Default(), modelSyncing: make(map[uint64]struct{})}
+	service.queueAccountModelSync(42)
+	service.queueAccountModelSync(42)
+	select {
+	case accountID := <-resolver.started:
+		if accountID != 42 {
+			t.Fatalf("account id = %d", accountID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("模型 ETag 刷新未启动")
+	}
+	if calls := resolver.calls.Load(); calls != 1 {
+		t.Fatalf("concurrent sync calls = %d", calls)
+	}
+	close(resolver.release)
+}
+
+type etagSyncResolver struct {
+	calls   atomic.Int64
+	started chan uint64
+	release chan struct{}
+}
+
+func (r *etagSyncResolver) SyncAccount(_ context.Context, accountID uint64) (int, error) {
+	r.calls.Add(1)
+	r.started <- accountID
+	<-r.release
+	return 1, nil
+}
+
+func (r *etagSyncResolver) Get(context.Context, uint64) (modeldomain.Route, error) {
+	return modeldomain.Route{}, repository.ErrNotFound
+}
+
+func (r *etagSyncResolver) GetByPublicID(context.Context, string) (modeldomain.Route, error) {
+	return modeldomain.Route{}, repository.ErrNotFound
+}
+
+func (r *etagSyncResolver) GetByPublicIDCandidates(context.Context, string) ([]modeldomain.Route, error) {
+	return nil, repository.ErrNotFound
+}
+
+func (r *etagSyncResolver) GetByProviderUpstream(context.Context, account.Provider, string) (modeldomain.Route, error) {
+	return modeldomain.Route{}, repository.ErrNotFound
+}
 
 func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/domain/account/account.go
+++ b/backend/internal/domain/account/account.go
@@ -178,6 +178,9 @@ type QuotaRecoveryEvent struct {
 type BillingHistoryEntry struct {
 	Year         int
 	Month        int
+	PeriodType   string
+	PeriodStart  string
+	PeriodEnd    string
 	IncludedUsed float64
 	OnDemandUsed float64
 	TotalUsed    float64
@@ -195,6 +198,7 @@ type Billing struct {
 	PrepaidBalance       float64
 	CreditUsagePercent   float64
 	IsUnifiedBillingUser bool
+	OnDemandEnabled      *bool
 	TopUpMethod          string
 	UsagePeriodType      string
 	UsagePeriodStart     string

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -21,8 +21,8 @@ const (
 	StatsigModeManual             = "manual"
 	StatsigModeURL                = "url"
 	DefaultStatsigSignerURL       = "https://grok.wodf.de/sign"
-	RecommendedBuildClientVersion = "0.2.99"
-	RecommendedBuildUserAgent     = "grok-shell/0.2.99 (linux; x86_64)"
+	RecommendedBuildClientVersion = "0.2.101"
+	RecommendedBuildUserAgent     = "grok-shell/0.2.101 (linux; x86_64)"
 
 	maxServerBodyBytes    = 256 << 20
 	maxRequestTimeout     = 24 * time.Hour

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -64,13 +64,13 @@ bootstrapAdmin:
 
 func TestDefaultGrokBuildClientVersionMatchesLocalBaseline(t *testing.T) {
 	build := defaultConfig().Provider.Build
-	if RecommendedBuildClientVersion != "0.2.99" {
+	if RecommendedBuildClientVersion != "0.2.101" {
 		t.Fatalf("recommended clientVersion = %q", RecommendedBuildClientVersion)
 	}
 	if build.ClientVersion != RecommendedBuildClientVersion {
 		t.Fatalf("clientVersion = %q", build.ClientVersion)
 	}
-	if RecommendedBuildUserAgent != "grok-shell/0.2.99 (linux; x86_64)" {
+	if RecommendedBuildUserAgent != "grok-shell/0.2.101 (linux; x86_64)" {
 		t.Fatalf("recommended userAgent = %q", RecommendedBuildUserAgent)
 	}
 	if build.UserAgent != RecommendedBuildUserAgent {

--- a/backend/internal/infra/egress/buildclient_test.go
+++ b/backend/internal/infra/egress/buildclient_test.go
@@ -54,7 +54,7 @@ func TestNewBuildClientRejectsUnsupportedProxyScheme(t *testing.T) {
 
 func TestBuildClientRoutesThroughSOCKS5HWithRemoteDNS(t *testing.T) {
 	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.Header.Get("User-Agent") != "grok-shell/0.2.99 (linux; x86_64)" {
+		if request.Header.Get("User-Agent") != "grok-shell/0.2.101 (linux; x86_64)" {
 			t.Errorf("User-Agent = %q", request.Header.Get("User-Agent"))
 		}
 		writer.Header().Set("Connection", "close")
@@ -84,7 +84,7 @@ func TestBuildClientRoutesThroughSOCKS5HWithRemoteDNS(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.Close = true
-	request.Header.Set("User-Agent", "grok-shell/0.2.99 (linux; x86_64)")
+	request.Header.Set("User-Agent", "grok-shell/0.2.101 (linux; x86_64)")
 	response, err := client.Do(request)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -838,7 +838,7 @@ func (r *AccountRepository) SaveBilling(ctx context.Context, value account.Billi
 	if err != nil {
 		return err
 	}
-	row := billingModel{AccountID: value.AccountID, PlanCode: truncate(value.PlanCode, 100), PlanName: truncate(value.PlanName, 160), MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, TopUpMethod: truncate(value.TopUpMethod, 100), UsagePeriodType: truncate(value.UsagePeriodType, 100), UsagePeriodStart: truncate(value.UsagePeriodStart, 64), UsagePeriodEnd: truncate(value.UsagePeriodEnd, 64), BillingPeriodStart: truncate(value.BillingPeriodStart, 64), BillingPeriodEnd: truncate(value.BillingPeriodEnd, 64), HistoryJSON: string(history), SyncedAt: value.SyncedAt}
+	row := billingModel{AccountID: value.AccountID, PlanCode: truncate(value.PlanCode, 100), PlanName: truncate(value.PlanName, 160), MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, OnDemandEnabled: value.OnDemandEnabled, TopUpMethod: truncate(value.TopUpMethod, 100), UsagePeriodType: truncate(value.UsagePeriodType, 100), UsagePeriodStart: truncate(value.UsagePeriodStart, 64), UsagePeriodEnd: truncate(value.UsagePeriodEnd, 64), BillingPeriodStart: truncate(value.BillingPeriodStart, 64), BillingPeriodEnd: truncate(value.BillingPeriodEnd, 64), HistoryJSON: string(history), SyncedAt: value.SyncedAt}
 	return r.db.db.WithContext(ctx).Save(&row).Error
 }
 

--- a/backend/internal/infra/persistence/relational/mapping.go
+++ b/backend/internal/infra/persistence/relational/mapping.go
@@ -133,7 +133,7 @@ func accountIdentity(value account.Credential) string {
 func toBillingDomain(value billingModel) account.Billing {
 	var history []account.BillingHistoryEntry
 	_ = json.Unmarshal([]byte(value.HistoryJSON), &history)
-	return account.Billing{AccountID: value.AccountID, PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, History: history, SyncedAt: value.SyncedAt}
+	return account.Billing{AccountID: value.AccountID, PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, OnDemandEnabled: value.OnDemandEnabled, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, History: history, SyncedAt: value.SyncedAt}
 }
 
 func toModelDomain(value modelRouteModel) model.Route {

--- a/backend/internal/infra/persistence/relational/models.go
+++ b/backend/internal/infra/persistence/relational/models.go
@@ -107,16 +107,17 @@ type quotaWindowModel struct {
 func (quotaWindowModel) TableName() string { return "account_quota_windows" }
 
 type billingModel struct {
-	AccountID            uint64        `gorm:"primaryKey"`
-	PlanCode             string        `gorm:"size:100;check:chk_billing_plan_code,length(plan_code) <= 100"`
-	PlanName             string        `gorm:"size:160;check:chk_billing_plan_name,length(plan_name) <= 160"`
-	MonthlyLimit         float64       `gorm:"not null;default:0;check:chk_billing_monthly_limit,monthly_limit >= 0"`
-	Used                 float64       `gorm:"not null;default:0;check:chk_billing_used,used >= 0"`
-	OnDemandCap          float64       `gorm:"not null;default:0;check:chk_billing_on_demand_cap,on_demand_cap >= 0"`
-	OnDemandUsed         float64       `gorm:"not null;default:0;check:chk_billing_on_demand_used,on_demand_used >= 0"`
-	PrepaidBalance       float64       `gorm:"not null;default:0;check:chk_billing_prepaid_balance,prepaid_balance >= 0"`
-	CreditUsagePercent   float64       `gorm:"not null;default:0;check:chk_billing_credit_usage_percent,credit_usage_percent >= 0"`
-	IsUnifiedBillingUser bool          `gorm:"not null;default:false"`
+	AccountID            uint64  `gorm:"primaryKey"`
+	PlanCode             string  `gorm:"size:100;check:chk_billing_plan_code,length(plan_code) <= 100"`
+	PlanName             string  `gorm:"size:160;check:chk_billing_plan_name,length(plan_name) <= 160"`
+	MonthlyLimit         float64 `gorm:"not null;default:0;check:chk_billing_monthly_limit,monthly_limit >= 0"`
+	Used                 float64 `gorm:"not null;default:0;check:chk_billing_used,used >= 0"`
+	OnDemandCap          float64 `gorm:"not null;default:0;check:chk_billing_on_demand_cap,on_demand_cap >= 0"`
+	OnDemandUsed         float64 `gorm:"not null;default:0;check:chk_billing_on_demand_used,on_demand_used >= 0"`
+	PrepaidBalance       float64 `gorm:"not null;default:0;check:chk_billing_prepaid_balance,prepaid_balance >= 0"`
+	CreditUsagePercent   float64 `gorm:"not null;default:0;check:chk_billing_credit_usage_percent,credit_usage_percent >= 0"`
+	IsUnifiedBillingUser bool    `gorm:"not null;default:false"`
+	OnDemandEnabled      *bool
 	TopUpMethod          string        `gorm:"size:100;check:chk_billing_top_up_method,length(top_up_method) <= 100"`
 	UsagePeriodType      string        `gorm:"size:100;check:chk_billing_usage_period_type,length(usage_period_type) <= 100"`
 	UsagePeriodStart     string        `gorm:"size:64;check:chk_billing_usage_period_start,length(usage_period_start) <= 64"`

--- a/backend/internal/infra/persistence/relational/repository_test.go
+++ b/backend/internal/infra/persistence/relational/repository_test.go
@@ -330,10 +330,11 @@ func TestAccountRepositoryPersistsObservedBuildBillingFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
+	onDemandEnabled := false
 	if err := repo.UpdateObservedModel(context.Background(), credential.ID, "grok-4.5-build-free", now); err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.SaveBilling(context.Background(), account.Billing{AccountID: credential.ID, IsUnifiedBillingUser: true, TopUpMethod: "TOP_UP_METHOD_SAVED_PAYMENT_METHOD", UsagePeriodType: "USAGE_PERIOD_TYPE_WEEKLY", UsagePeriodStart: "2026-07-12T00:00:00Z", UsagePeriodEnd: "2026-07-19T00:00:00Z", History: []account.BillingHistoryEntry{{Year: 2026, Month: 6}}, SyncedAt: now}); err != nil {
+	if err := repo.SaveBilling(context.Background(), account.Billing{AccountID: credential.ID, IsUnifiedBillingUser: true, OnDemandEnabled: &onDemandEnabled, TopUpMethod: "TOP_UP_METHOD_SAVED_PAYMENT_METHOD", UsagePeriodType: "USAGE_PERIOD_TYPE_WEEKLY", UsagePeriodStart: "2026-07-12T00:00:00Z", UsagePeriodEnd: "2026-07-19T00:00:00Z", History: []account.BillingHistoryEntry{{Year: 2026, Month: 6}}, SyncedAt: now}); err != nil {
 		t.Fatal(err)
 	}
 	storedCredential, err := repo.Get(context.Background(), credential.ID)
@@ -341,7 +342,7 @@ func TestAccountRepositoryPersistsObservedBuildBillingFields(t *testing.T) {
 		t.Fatalf("credential = %#v, err = %v", storedCredential, err)
 	}
 	billing, err := repo.GetBilling(context.Background(), credential.ID)
-	if err != nil || !billing.IsUnifiedBillingUser || billing.TopUpMethod != "TOP_UP_METHOD_SAVED_PAYMENT_METHOD" || billing.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || billing.UsagePeriodEnd != "2026-07-19T00:00:00Z" || len(billing.History) != 1 {
+	if err != nil || !billing.IsUnifiedBillingUser || billing.OnDemandEnabled == nil || *billing.OnDemandEnabled || billing.TopUpMethod != "TOP_UP_METHOD_SAVED_PAYMENT_METHOD" || billing.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || billing.UsagePeriodEnd != "2026-07-19T00:00:00Z" || len(billing.History) != 1 {
 		t.Fatalf("billing = %#v, err = %v", billing, err)
 	}
 }

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
@@ -33,25 +36,27 @@ type Config struct {
 
 // Adapter 实现 Grok Build CLI Responses、模型、Billing 与 OAuth 协议。
 type Adapter struct {
-	cfgMu      sync.RWMutex
-	cfg        Config
-	http       *http.Client
-	oauth      *oauthClient
-	cipher     *security.Cipher
-	base       http.RoundTripper
-	identityMu sync.Mutex
-	identities map[uint64]clientIdentity
-}
-
-type clientIdentity struct {
-	agentID   string
-	sessionID string
+	cfgMu       sync.RWMutex
+	cfg         Config
+	http        *http.Client
+	oauth       *oauthClient
+	cipher      *security.Cipher
+	base        http.RoundTripper
+	agentID     string
+	modelsMu    sync.Mutex
+	modelsETags map[uint64]string
 }
 
 func NewAdapter(cfg Config, cipher *security.Cipher) *Adapter {
 	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, ForceAttemptHTTP2: true, MaxIdleConns: 256, MaxIdleConnsPerHost: 128, MaxConnsPerHost: 256, IdleConnTimeout: 90 * time.Second, TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 30 * time.Second}
 	httpClient := &http.Client{Transport: transport}
-	return &Adapter{cfg: cfg, http: httpClient, oauth: newOAuthClient(httpClient), cipher: cipher, base: transport, identities: make(map[uint64]clientIdentity)}
+	// 官方 CLI 使用持久化机器身份。网关不采集机器指纹，改为每个后端
+	// 进程生成一个随机 UUID，在进程生命周期内作为统一 Agent 身份。
+	agentID := uuid.NewString()
+	return &Adapter{
+		cfg: cfg, http: httpClient, oauth: newOAuthClient(httpClient), cipher: cipher, base: transport,
+		agentID: agentID, modelsETags: make(map[uint64]string),
+	}
 }
 
 func (a *Adapter) SetEgress(manager *infraegress.Manager) {
@@ -135,6 +140,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 	if err := normalizeGzipResponse(resp); err != nil {
 		return nil, err
 	}
+	modelCatalogChanged := a.modelCatalogChanged(request.Credential.ID, resp.Header.Get("x-models-etag"))
 	responsesOperation := request.Operation == "" || request.Operation == conversation.OperationResponses
 	if responsesOperation && toolCompatibility != nil {
 		if warnings := toolCompatibility.warningHeader(); warnings != "" {
@@ -194,15 +200,15 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 				if diagnostic == nil {
 					return nil, convertErr
 				}
-				return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: diagnostic.Header.Clone(), Body: io.NopCloser(bytes.NewReader(data)), UpstreamURL: req.URL.String(), Diagnostic: diagnostic}, nil
+				return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: diagnostic.Header.Clone(), Body: io.NopCloser(bytes.NewReader(data)), UpstreamURL: req.URL.String(), Diagnostic: diagnostic, ModelCatalogChanged: modelCatalogChanged}, nil
 			}
 			resp.Body = io.NopCloser(bytes.NewReader(converted))
 			resp.Header.Set("Content-Length", strconv.Itoa(len(converted)))
 			resp.Header.Set("Content-Type", "application/json")
-			return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: resp.Header.Clone(), Body: resp.Body, UpstreamURL: req.URL.String(), Diagnostic: diagnostic}, nil
+			return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: resp.Header.Clone(), Body: resp.Body, UpstreamURL: req.URL.String(), Diagnostic: diagnostic, ModelCatalogChanged: modelCatalogChanged}, nil
 		}
 	}
-	return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: resp.Header.Clone(), Body: resp.Body, UpstreamURL: req.URL.String()}, nil
+	return &provider.Response{StatusCode: resp.StatusCode, Status: resp.Status, Header: resp.Header.Clone(), Body: resp.Body, UpstreamURL: req.URL.String(), ModelCatalogChanged: modelCatalogChanged}, nil
 }
 
 // invalidResponsesResponse 将本地协议校验错误转换为标准 OpenAI 错误响应，避免触发上游账号重试。
@@ -282,7 +288,40 @@ func (a *Adapter) ListModels(ctx context.Context, credential account.Credential)
 			models = append(models, item.ID)
 		}
 	}
+	a.recordModelsETag(credential.ID, resp.Header.Get("ETag"))
 	return models, nil
+}
+
+func (a *Adapter) recordModelsETag(accountID uint64, etag string) {
+	etag = strings.TrimSpace(etag)
+	if etag == "" {
+		return
+	}
+	a.modelsMu.Lock()
+	if a.modelsETags == nil {
+		a.modelsETags = make(map[uint64]string)
+	}
+	a.modelsETags[accountID] = etag
+	a.modelsMu.Unlock()
+}
+
+func (a *Adapter) modelCatalogChanged(accountID uint64, etag string) bool {
+	etag = strings.TrimSpace(etag)
+	if etag == "" {
+		return false
+	}
+	a.modelsMu.Lock()
+	defer a.modelsMu.Unlock()
+	if a.modelsETags == nil {
+		a.modelsETags = make(map[uint64]string)
+	}
+	current := a.modelsETags[accountID]
+	if current == "" {
+		// 进程重启后内存中没有目录基线。让 Gateway 补一次账号级
+		// /models 同步；同步成功后 recordModelsETag 会建立基线。
+		return true
+	}
+	return current != etag
 }
 
 func (a *Adapter) GetBilling(ctx context.Context, credential account.Credential) (account.Billing, error) {
@@ -290,36 +329,13 @@ func (a *Adapter) GetBilling(ctx context.Context, credential account.Credential)
 	if err != nil {
 		return account.Billing{}, err
 	}
-	monthly, err := a.getBilling(ctx, credential, accessToken, "")
+	billing, err := a.getBilling(ctx, credential, accessToken, "format=credits")
 	if err != nil {
 		return account.Billing{}, err
 	}
-	monthly.AccountID = credential.ID
-	if credits, creditsErr := a.getBilling(ctx, credential, accessToken, "format=credits"); creditsErr == nil {
-		monthly = mergeBillingSnapshots(monthly, credits)
-	}
-	monthly.SyncedAt = time.Now().UTC()
-	return monthly, nil
-}
-
-// mergeBillingSnapshots 合并套餐 credits 与 /usage 使用的当前限额周期，周周期优先作为恢复时间。
-func mergeBillingSnapshots(monthly, credits account.Billing) account.Billing {
-	if monthly.PlanCode == "" {
-		monthly.PlanCode = credits.PlanCode
-	}
-	if monthly.PlanName == "" {
-		monthly.PlanName = credits.PlanName
-	}
-	monthly.OnDemandCap = credits.OnDemandCap
-	monthly.OnDemandUsed = credits.OnDemandUsed
-	monthly.PrepaidBalance = credits.PrepaidBalance
-	monthly.CreditUsagePercent = credits.CreditUsagePercent
-	monthly.IsUnifiedBillingUser = credits.IsUnifiedBillingUser
-	monthly.TopUpMethod = credits.TopUpMethod
-	monthly.UsagePeriodType = credits.UsagePeriodType
-	monthly.UsagePeriodStart = credits.UsagePeriodStart
-	monthly.UsagePeriodEnd = credits.UsagePeriodEnd
-	return monthly
+	billing.AccountID = credential.ID
+	billing.SyncedAt = time.Now().UTC()
+	return billing, nil
 }
 
 func (a *Adapter) RefreshCredential(ctx context.Context, credential account.Credential) (provider.RefreshedCredential, error) {
@@ -370,38 +386,28 @@ func (a *Adapter) MarshalCredentials(values []provider.CredentialSeed) ([]byte, 
 
 func (a *Adapter) applyHeaders(req *http.Request, credential account.Credential, accessToken, model, promptCacheKey string, trace bool) error {
 	cfg := a.config()
-	identity, err := a.clientIdentity(credential.ID)
-	if err != nil {
-		return err
-	}
-	requestID, err := randomHex(16)
-	if err != nil {
-		return err
-	}
-	conversationID := strings.TrimSpace(promptCacheKey)
-	if conversationID == "" {
-		conversationID, err = randomHex(16)
-		if err != nil {
-			return err
-		}
-	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("X-XAI-Token-Auth", cfg.TokenAuth)
 	req.Header.Set("x-grok-client-version", cfg.ClientVersion)
 	req.Header.Set("x-grok-client-identifier", cfg.ClientIdentifier)
-	req.Header.Set("x-grok-client-surface", "tui")
-	req.Header.Set("x-grok-client-name", cfg.ClientIdentifier)
-	req.Header.Set("x-grok-agent-id", identity.agentID)
-	req.Header.Set("x-grok-session-id", identity.sessionID)
-	req.Header.Set("x-grok-conv-id", conversationID)
-	req.Header.Set("x-grok-req-id", requestID)
-	req.Header.Set("x-grok-conversation-id", conversationID)
-	req.Header.Set("x-grok-session-id-legacy", identity.sessionID)
-	req.Header.Set("x-grok-request-id", requestID)
-	if credential.UserID != "" {
-		req.Header.Set("x-userid", credential.UserID)
-	}
+	req.Header.Set("x-grok-client-mode", "headless")
+
 	if trace {
+		requestID := uuid.NewString()
+		sessionID, err := grokSessionID(promptCacheKey)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("x-authenticateresponse", "authenticate-response")
+		req.Header.Set("x-grok-agent-id", a.agentID)
+		req.Header.Set("x-grok-session-id", sessionID)
+		req.Header.Set("x-grok-conv-id", sessionID)
+		req.Header.Set("x-grok-req-id", requestID)
+		// 网关无法从无状态 API 请求可靠恢复 CLI prompt index；该字段在
+		// 官方协议中可选，因此不伪造 x-grok-turn-idx。
+		if credential.UserID != "" {
+			req.Header.Set("x-grok-user-id", credential.UserID)
+		}
 		traceID, traceErr := randomHex(16)
 		if traceErr != nil {
 			return traceErr
@@ -411,7 +417,13 @@ func (a *Adapter) applyHeaders(req *http.Request, credential account.Credential,
 			return spanErr
 		}
 		req.Header.Set("traceparent", "00-"+traceID+"-"+spanID+"-01")
-		req.Header.Set("tracestate", "")
+	} else {
+		if credential.UserID != "" {
+			req.Header.Set("x-userid", credential.UserID)
+		}
+		if credential.Email != "" {
+			req.Header.Set("x-email", credential.Email)
+		}
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Accept-Encoding", "gzip")
@@ -422,23 +434,19 @@ func (a *Adapter) applyHeaders(req *http.Request, credential account.Credential,
 	return nil
 }
 
-func (a *Adapter) clientIdentity(accountID uint64) (clientIdentity, error) {
-	a.identityMu.Lock()
-	defer a.identityMu.Unlock()
-	if value, ok := a.identities[accountID]; ok {
-		return value, nil
+func grokSessionID(promptCacheKey string) (string, error) {
+	key := strings.TrimSpace(promptCacheKey)
+	if key != "" {
+		if parsed, err := uuid.Parse(key); err == nil {
+			return parsed.String(), nil
+		}
+		return uuid.NewHash(sha256.New(), uuid.NameSpaceURL, []byte("grok2api:session:"+key), 8).String(), nil
 	}
-	agentID, err := randomHex(16)
+	value, err := uuid.NewV7()
 	if err != nil {
-		return clientIdentity{}, err
+		return "", err
 	}
-	sessionID, err := randomUUID()
-	if err != nil {
-		return clientIdentity{}, err
-	}
-	value := clientIdentity{agentID: agentID, sessionID: sessionID}
-	a.identities[accountID] = value
-	return value, nil
+	return value.String(), nil
 }
 
 func injectPromptCacheKey(body []byte, clientKey string) ([]byte, error) {
@@ -463,17 +471,6 @@ func randomHex(bytesLength int) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(value), nil
-}
-
-func randomUUID() (string, error) {
-	value := make([]byte, 16)
-	if _, err := rand.Read(value); err != nil {
-		return "", err
-	}
-	value[6] = (value[6] & 0x0f) | 0x40
-	value[8] = (value[8] & 0x3f) | 0x80
-	hexValue := hex.EncodeToString(value)
-	return hexValue[0:8] + "-" + hexValue[8:12] + "-" + hexValue[12:16] + "-" + hexValue[16:20] + "-" + hexValue[20:], nil
 }
 
 func normalizeGzipResponse(response *http.Response) error {

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -8,8 +8,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
@@ -29,22 +32,30 @@ func TestForwardResponseMatchesGrokBuildHeadersAndPreservesReasoning(t *testing.
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/responses" {
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
 		}
-		if r.Header.Get("Authorization") != "Bearer access-token" || r.Header.Get("x-grok-client-version") != "0.2.99" || r.Header.Get("x-grok-client-identifier") != "grok-shell" || r.Header.Get("User-Agent") != "grok-shell/0.2.99 (linux; x86_64)" || r.Header.Get("x-grok-conv-id") != "isolated-key" {
+		if r.Header.Get("Authorization") != "Bearer access-token" || r.Header.Get("X-XAI-Token-Auth") != "xai-grok-cli" || r.Header.Get("x-authenticateresponse") != "authenticate-response" || r.Header.Get("x-grok-client-version") != "0.2.101" || r.Header.Get("x-grok-client-identifier") != "grok-shell" || r.Header.Get("x-grok-client-mode") != "headless" || r.Header.Get("User-Agent") != "grok-shell/0.2.101 (linux; x86_64)" {
 			t.Fatalf("headers = %#v", r.Header)
 		}
 		requestID := r.Header.Get("x-grok-req-id")
 		sessionID := r.Header.Get("x-grok-session-id")
-		if r.Header.Get("x-grok-client-surface") != "tui" || r.Header.Get("x-grok-client-name") != "grok-shell" || len(r.Header.Get("x-grok-agent-id")) != 32 || len(sessionID) != 36 {
+		expectedSessionID, err := grokSessionID("isolated-key")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requestUUID, requestErr := uuid.Parse(requestID)
+		agentUUID, agentErr := uuid.Parse(r.Header.Get("x-grok-agent-id"))
+		if requestErr != nil || requestUUID.Version() != uuid.Version(4) || agentErr != nil || agentUUID.Version() != uuid.Version(4) || sessionID != expectedSessionID || r.Header.Get("x-grok-conv-id") != sessionID {
 			t.Fatalf("client identity headers = %#v", r.Header)
 		}
-		if r.Header.Get("x-grok-conversation-id") != "isolated-key" || len(requestID) != 32 || r.Header.Get("x-grok-request-id") != requestID || r.Header.Get("x-grok-session-id-legacy") != sessionID {
-			t.Fatalf("request identity headers = %#v", r.Header)
+		for _, legacy := range []string{"x-grok-client-surface", "x-grok-client-name", "x-grok-conversation-id", "x-grok-session-id-legacy", "x-grok-request-id"} {
+			if r.Header.Get(legacy) != "" {
+				t.Fatalf("legacy header %s = %q", legacy, r.Header.Get(legacy))
+			}
 		}
-		if r.Header.Get("x-userid") != "user-123" || r.Header.Get("Accept-Encoding") != "gzip" || len(r.Header.Get("traceparent")) != 55 {
+		if r.Header.Get("x-grok-user-id") != "user-123" || r.Header.Get("x-userid") != "" || r.Header.Get("Accept-Encoding") != "gzip" || len(r.Header.Get("traceparent")) != 55 {
 			t.Fatalf("protocol headers = %#v", r.Header)
 		}
-		if values, ok := r.Header["Tracestate"]; !ok || len(values) != 1 || values[0] != "" {
-			t.Fatalf("tracestate = %#v", values)
+		if _, ok := r.Header["Tracestate"]; ok {
+			t.Fatalf("tracestate = %#v", r.Header["Tracestate"])
 		}
 		body, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(body, &captured); err != nil {
@@ -67,7 +78,7 @@ func TestForwardResponseMatchesGrokBuildHeadersAndPreservesReasoning(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	adapter := NewAdapter(Config{BaseURL: "https://api.x.ai/v1", ClientVersion: "0.2.99", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.99 (linux; x86_64)"}, cipher)
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1", ClientVersion: "0.2.101", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.101 (linux; x86_64)"}, cipher)
 	adapter.http.Transport = transport
 	response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
 		Credential: account.Credential{ID: 7, UserID: "user-123", EncryptedAccessToken: encrypted}, Method: http.MethodPost, Path: "/responses",
@@ -84,6 +95,167 @@ func TestForwardResponseMatchesGrokBuildHeadersAndPreservesReasoning(t *testing.
 	}
 }
 
+func TestListModelsUsesOfficialMetadataHeaders(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1", ClientVersion: "0.2.101", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.101 (linux; x86_64)"}, cipher)
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/v1/models" || request.Header.Get("Authorization") != "Bearer access-token" || request.Header.Get("X-XAI-Token-Auth") != "xai-grok-cli" || request.Header.Get("x-grok-client-version") != "0.2.101" || request.Header.Get("x-grok-client-identifier") != "grok-shell" || request.Header.Get("x-grok-client-mode") != "headless" || request.Header.Get("User-Agent") != "grok-shell/0.2.101 (linux; x86_64)" {
+			t.Fatalf("headers = %#v", request.Header)
+		}
+		if request.Header.Get("x-userid") != "user-123" || request.Header.Get("x-email") != "user@example.com" || request.Header.Get("x-grok-user-id") != "" || request.Header.Get("x-authenticateresponse") != "" || request.Header.Get("x-grok-session-id") != "" {
+			t.Fatalf("metadata headers = %#v", request.Header)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"data":[{"id":"grok-4.5"}]}`)), Request: request}, nil
+	})
+	models, err := adapter.ListModels(context.Background(), account.Credential{UserID: "user-123", Email: "user@example.com", EncryptedAccessToken: encrypted})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 1 || models[0] != "grok-4.5" {
+		t.Fatalf("models = %#v", models)
+	}
+}
+
+func TestModelCatalogETagSignalsMissingOrChangedCatalogBaseline(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	modelETag := `"catalog-v1"`
+	responseETag := modelETag
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1"}, cipher)
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		body := `{"id":"resp_1","status":"completed","output":[]}`
+		if request.URL.Path == "/v1/models" {
+			header.Set("ETag", modelETag)
+			body = `{"data":[{"id":"grok-4.5"}]}`
+		} else {
+			header.Set("x-models-etag", responseETag)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: header, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+	})
+	credential := account.Credential{ID: 42, EncryptedAccessToken: encrypted}
+	if !adapter.modelCatalogChanged(43, `"catalog-v1"`) {
+		t.Fatal("缺少进程内目录基线时应补一次账号模型同步")
+	}
+	if _, err := adapter.ListModels(context.Background(), credential); err != nil {
+		t.Fatal(err)
+	}
+	forward := func() *provider.Response {
+		response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+			Credential: credential, Method: http.MethodPost, Path: "/responses", Body: []byte(`{}`), Operation: conversation.OperationResponses,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		return response
+	}
+	if response := forward(); response.ModelCatalogChanged {
+		t.Fatal("与最近模型同步相同的 ETag 不应触发刷新")
+	}
+	responseETag = `"catalog-v2"`
+	if response := forward(); !response.ModelCatalogChanged {
+		t.Fatal("推理响应报告新 ETag 时应触发账号模型刷新")
+	}
+	modelETag = responseETag
+	if _, err := adapter.ListModels(context.Background(), credential); err != nil {
+		t.Fatal(err)
+	}
+	if response := forward(); response.ModelCatalogChanged {
+		t.Fatal("成功同步新目录后不应继续重复触发刷新")
+	}
+}
+
+func TestGetBillingUsesCreditsEndpointOnce(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1", ClientVersion: "0.2.101", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.101 (linux; x86_64)"}, cipher)
+	calls := 0
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls++
+		if request.URL.Path != "/v1/billing" || request.URL.Query().Get("format") != "credits" {
+			t.Fatalf("billing request = %s", request.URL.String())
+		}
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"config":{"creditUsagePercent":25,"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-07-01T00:00:00Z","end":"2026-07-08T00:00:00Z"}}}`)), Request: request}, nil
+	})
+	billing, err := adapter.GetBilling(context.Background(), account.Credential{ID: 7, EncryptedAccessToken: encrypted})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || billing.AccountID != 7 || billing.CreditUsagePercent != 25 || billing.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || billing.SyncedAt.IsZero() {
+		t.Fatalf("calls=%d billing=%#v", calls, billing)
+	}
+}
+
+func TestGrokSessionIDFollowsConversationIdentity(t *testing.T) {
+	explicit := "019f6b02-5bae-7cf3-b26e-73e85c861749"
+	if value, err := grokSessionID(explicit); err != nil || value != explicit {
+		t.Fatalf("explicit session = %q, %v", value, err)
+	}
+	first, err := grokSessionID("client-conversation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := grokSessionID("client-conversation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := uuid.Parse(first)
+	if err != nil || parsed.Version() != uuid.Version(8) || first != second {
+		t.Fatalf("derived sessions = %q %q, %v", first, second, err)
+	}
+	generated, err := grokSessionID("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err = uuid.Parse(generated)
+	if err != nil || parsed.Version() != uuid.Version(7) {
+		t.Fatalf("generated session = %q, %v", generated, err)
+	}
+}
+
+func TestInferenceIdentityIsConversationScopedNotAccountScoped(t *testing.T) {
+	adapter := NewAdapter(Config{ClientVersion: "0.2.101", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.101 (linux; x86_64)"}, nil)
+	build := func(accountID uint64, conversation string) http.Header {
+		request := httptest.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", nil)
+		if err := adapter.applyHeaders(request, account.Credential{ID: accountID}, "token", "grok-4.5", conversation, true); err != nil {
+			t.Fatal(err)
+		}
+		return request.Header
+	}
+	first := build(1, "conversation-a")
+	second := build(2, "conversation-a")
+	third := build(1, "conversation-b")
+	if first.Get("x-grok-agent-id") != second.Get("x-grok-agent-id") || first.Get("x-grok-session-id") != second.Get("x-grok-session-id") {
+		t.Fatalf("same conversation identity changed across accounts: first=%#v second=%#v", first, second)
+	}
+	if first.Get("x-grok-req-id") == second.Get("x-grok-req-id") {
+		t.Fatalf("request ID was reused: %q", first.Get("x-grok-req-id"))
+	}
+	if first.Get("x-grok-session-id") == third.Get("x-grok-session-id") {
+		t.Fatalf("different conversations shared session ID: %q", first.Get("x-grok-session-id"))
+	}
+}
+
 func TestForwardResponseSupportsResourceMethodsAndQuery(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {
@@ -93,7 +265,7 @@ func TestForwardResponseSupportsResourceMethodsAndQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1", ClientVersion: "0.2.99", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.99 (linux; x86_64)"}, cipher)
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1", ClientVersion: "0.2.101", ClientIdentifier: "grok-shell", TokenAuth: "xai-grok-cli", UserAgent: "grok-shell/0.2.101 (linux; x86_64)"}, cipher)
 	methods := []string{http.MethodGet, http.MethodDelete}
 	next := 0
 	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -171,7 +343,7 @@ func TestForwardResponseDecodesExplicitGzipResponse(t *testing.T) {
 	}
 }
 
-func TestForwardResponseRejectsHostedToolSearchBeforeUpstream(t *testing.T) {
+func TestForwardResponseDowngradesServerToolSearchBeforeUpstream(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {
 		t.Fatal(err)
@@ -182,8 +354,19 @@ func TestForwardResponseRejectsHostedToolSearchBeforeUpstream(t *testing.T) {
 	}
 	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1"}, cipher)
 	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
-		t.Fatalf("不支持的服务端 Tool Search 不应请求上游: %s", request.URL)
-		return nil, nil
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if _, exists := payload["tools"]; exists {
+			t.Fatalf("server tool_search 未从上游请求移除: %#v", payload)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Status: "200 OK",
+			Header:  http.Header{"Content-Type": []string{"application/json"}},
+			Body:    io.NopCloser(strings.NewReader(`{"id":"resp_search"}`)),
+			Request: request,
+		}, nil
 	})
 
 	response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
@@ -196,21 +379,18 @@ func TestForwardResponseRejectsHostedToolSearchBeforeUpstream(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusBadRequest {
+	if response.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", response.StatusCode)
 	}
-	var payload struct {
-		Error struct {
-			Type  string `json:"type"`
-			Param string `json:"param"`
-			Code  string `json:"code"`
-		} `json:"error"`
+	if !strings.Contains(response.Header.Get("X-Grok2API-Compatibility-Warnings"), "server_tool_search_eager_loaded") {
+		t.Fatalf("compatibility warnings = %q", response.Header.Get("X-Grok2API-Compatibility-Warnings"))
 	}
+	var payload map[string]any
 	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload.Error.Type != "invalid_request_error" || payload.Error.Param != "tools[0].execution" || payload.Error.Code != "unsupported_parameter" {
-		t.Fatalf("error = %#v", payload.Error)
+	if payload["id"] != "resp_search" {
+		t.Fatalf("response = %#v", payload)
 	}
 }
 
@@ -293,7 +473,11 @@ func TestForwardResponsePreservesClaudeCodeMessagesOptions(t *testing.T) {
 		if payload["instructions"] != "legacy system" || payload["store"] != false || payload["reasoning"].(map[string]any)["effort"] != "high" || payload["prompt_cache_key"] != "messages-cache-key" {
 			t.Fatalf("upstream payload = %#v", payload)
 		}
-		if request.Header.Get("x-grok-conv-id") != "messages-cache-key" {
+		expectedSessionID, err := grokSessionID("messages-cache-key")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if request.Header.Get("x-grok-conv-id") != expectedSessionID || request.Header.Get("x-grok-session-id") != expectedSessionID {
 			t.Fatalf("prompt cache headers = %#v", request.Header)
 		}
 		return &http.Response{
@@ -352,6 +536,10 @@ func TestForwardResponseMapsClaudeCodeWebSearchEndToEnd(t *testing.T) {
 		if len(tools) != 1 || tools[0].(map[string]any)["type"] != "web_search" || payload["tool_choice"] != "required" {
 			t.Fatalf("upstream web search payload = %#v", payload)
 		}
+		domains := tools[0].(map[string]any)["filters"].(map[string]any)["allowed_domains"].([]any)
+		if len(domains) != 1 || domains[0] != "doc.rust-lang.org" {
+			t.Fatalf("upstream web search filters = %#v", tools[0])
+		}
 		return &http.Response{
 			StatusCode: http.StatusOK, Status: "200 OK", Header: http.Header{"Content-Type": []string{"application/json"}},
 			Body: io.NopCloser(strings.NewReader(`{
@@ -360,7 +548,7 @@ func TestForwardResponseMapsClaudeCodeWebSearchEndToEnd(t *testing.T) {
 					{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"rust tutorials","sources":[{"url":"https://doc.rust-lang.org"}]}},
 					{"type":"message","content":[{"type":"output_text","text":"Here you go.","annotations":[{"type":"url_citation","url":"https://doc.rust-lang.org","title":"The Rust Book"}]}]}
 				],
-				"usage":{"input_tokens":7,"output_tokens":5,"total_tokens":12}
+					"usage":{"input_tokens":7,"output_tokens":5,"total_tokens":12,"cost_in_usd_ticks":12000,"context_details":{"input_tokens":6,"output_tokens":4}}
 			}`)),
 			Request: request,
 		}, nil
@@ -373,7 +561,7 @@ func TestForwardResponseMapsClaudeCodeWebSearchEndToEnd(t *testing.T) {
 		Body: []byte(`{
 			"model":"public","max_tokens":256,
 			"messages":[{"role":"user","content":"Perform a web search for the query: rust tutorials"}],
-			"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}],
+			"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8,"allowed_domains":["doc.rust-lang.org"]}],
 			"tool_choice":{"type":"tool","name":"web_search"}
 		}`),
 	})
@@ -401,6 +589,10 @@ func TestForwardResponseMapsClaudeCodeWebSearchEndToEnd(t *testing.T) {
 	if serverUsage["web_search_requests"] != float64(1) || payload["stop_reason"] != "end_turn" {
 		t.Fatalf("messages web search usage = %#v", payload)
 	}
+	usage := payload["usage"].(map[string]any)
+	if usage["cost_in_usd_ticks"] != float64(12000) || usage["context_details"].(map[string]any)["input_tokens"] != float64(6) {
+		t.Fatalf("messages upstream usage = %#v", usage)
+	}
 }
 
 func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
@@ -418,12 +610,20 @@ func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
 		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
 			t.Fatal(err)
 		}
-		if payload["prompt_cache_key"] != "chat-cache-key" || request.Header.Get("x-grok-conv-id") != "chat-cache-key" {
+		expectedSessionID, err := grokSessionID("chat-cache-key")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if payload["prompt_cache_key"] != "chat-cache-key" || request.Header.Get("x-grok-conv-id") != expectedSessionID || request.Header.Get("x-grok-session-id") != expectedSessionID {
 			t.Fatalf("prompt cache request: payload=%#v headers=%#v", payload, request.Header)
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK, Status: "200 OK", Header: http.Header{"Content-Type": []string{"application/json"}},
-			Body:    io.NopCloser(strings.NewReader(`{"id":"resp_1","model":"grok-4.5","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}`)),
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"resp_1","model":"grok-4.5","status":"completed",
+				"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],
+				"usage":{"input_tokens":11,"output_tokens":2,"cost_in_usd_ticks":7000,"context_details":{"input_tokens":10,"output_tokens":2}}
+			}`)),
 			Request: request,
 		}, nil
 	})
@@ -440,5 +640,13 @@ func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", response.StatusCode)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	usage := payload["usage"].(map[string]any)
+	if payload["object"] != "chat.completion" || usage["prompt_tokens"] != float64(11) || usage["cost_in_usd_ticks"] != float64(7000) || usage["context_details"].(map[string]any)["input_tokens"] != float64(10) {
+		t.Fatalf("chat response = %#v", payload)
 	}
 }

--- a/backend/internal/infra/provider/cli/billing.go
+++ b/backend/internal/infra/provider/cli/billing.go
@@ -27,6 +27,10 @@ func parseBilling(data []byte) (account.Billing, error) {
 			planName = outerName
 		}
 	}
+	onDemandEnabled := optionalBool(firstValue(root, "onDemandEnabled", "on_demand_enabled"))
+	if onDemandEnabled == nil {
+		onDemandEnabled = optionalBool(firstValue(original, "onDemandEnabled", "on_demand_enabled"))
+	}
 	result := account.Billing{
 		PlanCode:             planCode,
 		PlanName:             planName,
@@ -37,6 +41,7 @@ func parseBilling(data []byte) (account.Billing, error) {
 		PrepaidBalance:       numberValue(firstValue(root, "prepaidBalance", "prepaid_balance")),
 		CreditUsagePercent:   numberValue(firstValue(root, "creditUsagePercent", "credit_usage_percent")),
 		IsUnifiedBillingUser: boolValue(firstValue(root, "isUnifiedBillingUser", "is_unified_billing_user")),
+		OnDemandEnabled:      onDemandEnabled,
 		TopUpMethod:          stringValue(firstValue(root, "topUpMethod", "top_up_method")),
 		BillingPeriodStart:   stringValue(firstValue(root, "billingPeriodStart", "billing_period_start")),
 		BillingPeriodEnd:     stringValue(firstValue(root, "billingPeriodEnd", "billing_period_end")),
@@ -54,9 +59,16 @@ func parseBilling(data []byte) (account.Billing, error) {
 				continue
 			}
 			cycle, _ := entry["billingCycle"].(map[string]any)
+			period, _ := entry["period"].(map[string]any)
 			result.History = append(result.History, account.BillingHistoryEntry{
-				Year: int(numberValue(cycle["year"])), Month: int(numberValue(cycle["month"])),
-				IncludedUsed: numberValue(entry["includedUsed"]), OnDemandUsed: numberValue(entry["onDemandUsed"]), TotalUsed: numberValue(entry["totalUsed"]),
+				Year:         int(numberValue(cycle["year"])),
+				Month:        int(numberValue(cycle["month"])),
+				PeriodType:   stringValue(period["type"]),
+				PeriodStart:  stringValue(period["start"]),
+				PeriodEnd:    stringValue(period["end"]),
+				IncludedUsed: numberValue(entry["includedUsed"]),
+				OnDemandUsed: numberValue(entry["onDemandUsed"]),
+				TotalUsed:    numberValue(entry["totalUsed"]),
 			})
 		}
 	}
@@ -76,9 +88,17 @@ func boolValue(value any) bool {
 	return result
 }
 
+func optionalBool(value any) *bool {
+	result, ok := value.(bool)
+	if !ok {
+		return nil
+	}
+	return &result
+}
+
 func planValues(values map[string]any) (string, string) {
-	code := stringValue(firstValue(values, "planCode", "plan_code", "subscriptionTier", "subscription_tier", "tier"))
-	name := stringValue(firstValue(values, "planName", "plan_name", "subscriptionName", "subscription_name"))
+	code := stringValue(firstValue(values, "planCode", "plan_code", "tier"))
+	name := stringValue(firstValue(values, "planName", "plan_name", "subscriptionName", "subscription_name", "subscriptionTier", "subscription_tier"))
 	for _, key := range []string{"plan", "subscription", "membership"} {
 		value, ok := values[key]
 		if !ok {

--- a/backend/internal/infra/provider/cli/billing_test.go
+++ b/backend/internal/infra/provider/cli/billing_test.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"testing"
-
-	"github.com/chenyme/grok2api/backend/internal/domain/account"
 )
 
 func TestParseBillingMonthlyPayload(t *testing.T) {
@@ -41,24 +39,14 @@ func TestParseBillingMatchesObservedBuildPayloads(t *testing.T) {
 		t.Fatalf("monthly = %#v", monthly)
 	}
 
-	credits, err := parseBilling([]byte(`{"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-07-08T00:00:00+00:00","end":"2026-07-15T00:00:00+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0},"topUpMethod":"TOP_UP_METHOD_SAVED_PAYMENT_METHOD","billingPeriodStart":"2026-07-08T00:00:00+00:00","billingPeriodEnd":"2026-07-15T00:00:00+00:00"}}`))
+	credits, err := parseBilling([]byte(`{"onDemandEnabled":false,"subscriptionTier":"SuperGrok Heavy","config":{"creditUsagePercent":42.5,"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-07-08T00:00:00+00:00","end":"2026-07-15T00:00:00+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0},"topUpMethod":"TOP_UP_METHOD_SAVED_PAYMENT_METHOD","history":[{"period":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-07-01T00:00:00Z","end":"2026-07-08T00:00:00Z"},"onDemandUsed":{"val":120}}]}}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !credits.IsUnifiedBillingUser || credits.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || credits.UsagePeriodEnd != "2026-07-15T00:00:00+00:00" || credits.TopUpMethod != "TOP_UP_METHOD_SAVED_PAYMENT_METHOD" {
+	if !credits.IsUnifiedBillingUser || credits.OnDemandEnabled == nil || *credits.OnDemandEnabled || credits.CreditUsagePercent != 42.5 || credits.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || credits.UsagePeriodEnd != "2026-07-15T00:00:00+00:00" || credits.TopUpMethod != "TOP_UP_METHOD_SAVED_PAYMENT_METHOD" || credits.PlanCode != "" || credits.PlanName != "SuperGrok Heavy" {
 		t.Fatalf("credits = %#v", credits)
 	}
-}
-
-func TestMergeBillingSnapshotsUsesWeeklyUsagePeriod(t *testing.T) {
-	monthly := mergeBillingSnapshots(
-		account.Billing{MonthlyLimit: 15_000, Used: 197, CreditUsagePercent: 1.313, BillingPeriodStart: "2026-07-01T00:00:00Z", BillingPeriodEnd: "2026-08-01T00:00:00Z"},
-		account.Billing{CreditUsagePercent: 5, UsagePeriodType: "USAGE_PERIOD_TYPE_WEEKLY", UsagePeriodStart: "2026-07-12T04:52:00Z", UsagePeriodEnd: "2026-07-19T04:52:00Z"},
-	)
-	if monthly.MonthlyLimit != 15_000 || monthly.Used != 197 || monthly.CreditUsagePercent != 5 {
-		t.Fatalf("merged billing = %#v", monthly)
-	}
-	if monthly.UsagePeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || monthly.UsagePeriodEnd != "2026-07-19T04:52:00Z" || monthly.BillingPeriodEnd != "2026-08-01T00:00:00Z" {
-		t.Fatalf("usage period = %#v", monthly)
+	if len(credits.History) != 1 || credits.History[0].PeriodType != "USAGE_PERIOD_TYPE_WEEKLY" || credits.History[0].PeriodStart != "2026-07-01T00:00:00Z" || credits.History[0].PeriodEnd != "2026-07-08T00:00:00Z" || credits.History[0].OnDemandUsed != 120 {
+		t.Fatalf("credits history = %#v", credits.History)
 	}
 }

--- a/backend/internal/infra/provider/cli/normalize.go
+++ b/backend/internal/infra/provider/cli/normalize.go
@@ -37,6 +37,7 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 		payload["text"] = encoded
 		delete(payload, "response_format")
 	}
+	patchReasoningTextTypes(payload)
 	compatibility, err := normalizeResponsesTools(payload)
 	if err != nil {
 		return nil, nil, err
@@ -46,6 +47,43 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 		return nil, nil, err
 	}
 	return normalized, compatibility, nil
+}
+
+// patchReasoningTextTypes 对齐官方 CLI 的序列化后修补：Responses 上游要求
+// reasoning.content[*] 必须携带 type=reasoning_text，即使部分客户端只发送 text。
+func patchReasoningTextTypes(payload map[string]json.RawMessage) {
+	raw := payload["input"]
+	if isEmptyJSON(raw) {
+		return
+	}
+	var items []any
+	if json.Unmarshal(raw, &items) != nil {
+		return // 字符串输入或其他合法简写不需要处理。
+	}
+	changed := false
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok || item["type"] != "reasoning" {
+			continue
+		}
+		content, ok := item["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawContent := range content {
+			value, ok := rawContent.(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, exists := value["type"]; !exists {
+				value["type"] = "reasoning_text"
+				changed = true
+			}
+		}
+	}
+	if changed {
+		payload["input"] = mustJSON(items)
+	}
 }
 
 func normalizeResponseFormat(raw json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/infra/provider/cli/normalize_test.go
+++ b/backend/internal/infra/provider/cli/normalize_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNormalizeResponsesRequest(t *testing.T) {
-	body := []byte(`{"model":"public-model","input":[{"type":"reasoning","id":"old","encrypted_content":"cipher"},{"role":"user","content":"hello"}],"prompt_cache_key":"official-key","response_format":{"type":"json_object"}}`)
+	body := []byte(`{"model":"public-model","input":[{"type":"reasoning","id":"old","encrypted_content":"cipher","content":[{"text":"thought"}]},{"role":"user","content":"hello"}],"prompt_cache_key":"official-key","response_format":{"type":"json_object"}}`)
 	normalized, _, err := normalizeResponsesRequest(body, "grok-4.5")
 	if err != nil {
 		t.Fatal(err)
@@ -26,6 +26,10 @@ func TestNormalizeResponsesRequest(t *testing.T) {
 	input := payload["input"].([]any)
 	if len(input) != 2 || input[0].(map[string]any)["encrypted_content"] != "cipher" {
 		t.Fatalf("reasoning 回放项未保留: %#v", input)
+	}
+	reasoningContent := input[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if reasoningContent["type"] != "reasoning_text" || reasoningContent["text"] != "thought" {
+		t.Fatalf("reasoning content discriminator 未修补: %#v", reasoningContent)
 	}
 	text := payload["text"].(map[string]any)
 	if text["format"] == nil || payload["response_format"] != nil {

--- a/backend/internal/infra/provider/cli/responses_advanced_test.go
+++ b/backend/internal/infra/provider/cli/responses_advanced_test.go
@@ -125,6 +125,27 @@ func TestResponsesCustomToolStreamUsesCustomEvents(t *testing.T) {
 	}
 }
 
+func TestResponsesCustomGrammarDowngradesWithoutRejectingRequest(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"run",
+		"tools":[{"type":"custom","name":"code","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}}]
+	}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tool := request["tools"].([]any)[0].(map[string]any)
+	if tool["type"] != "function" || tool["name"] != "code" {
+		t.Fatalf("tool = %#v", tool)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "custom_tool_format_downgraded") {
+		t.Fatalf("compatibility = %#v", compatibility)
+	}
+}
+
 func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"search",
@@ -167,17 +188,47 @@ func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 		t.Fatalf("compatibility warnings = %q", compatibility.warningHeader())
 	}
 
-	for _, restricted := range []string{
-		`{"filters":{"allowed_domains":["example.com"]}}`,
-		`{"allowed_domains":["example.com"]}`,
-		`{"search_content_types":["image"]}`,
+	for _, supported := range []string{
+		`"filters":{"allowed_domains":["example.com"]}`,
+		`"allowed_domains":["example.com"]`,
 	} {
-		_, _, err = normalizeResponsesRequest([]byte(`{
-			"model":"public","input":"search","tools":[{"type":"web_search",`+strings.TrimPrefix(strings.TrimSuffix(restricted, "}"), "{")+`}]
+		normalized, compatibility, err = normalizeResponsesRequest([]byte(`{
+			"model":"public","input":"search","tools":[{"type":"web_search",`+supported+`}]
 		}`), "grok-4.5")
-		requestErr, ok := err.(*responsesRequestError)
-		if !ok || requestErr.Code != "unsupported_parameter" {
-			t.Fatalf("restricted web search error = %#v", err)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request = nil
+		if err := json.Unmarshal(normalized, &request); err != nil {
+			t.Fatal(err)
+		}
+		tool = request["tools"].([]any)[0].(map[string]any)
+		domains := tool["filters"].(map[string]any)["allowed_domains"].([]any)
+		if len(domains) != 1 || domains[0] != "example.com" {
+			t.Fatalf("allowed_domains 未保留: %#v", tool)
+		}
+		if strings.Contains(supported, `"allowed_domains"`) && !strings.Contains(supported, `"filters"`) && (compatibility == nil || !strings.Contains(compatibility.warningHeader(), "web_search_allowed_domains_normalized")) {
+			t.Fatalf("top-level allowed_domains warning = %#v", compatibility)
+		}
+	}
+
+	for _, restricted := range []string{
+		`"search_content_types":["image"]`,
+		`"filters":{"blocked_domains":["example.com"]}`,
+	} {
+		normalized, compatibility, err = normalizeResponsesRequest([]byte(`{
+			"model":"public","input":"search","tools":[{"type":"web_search",`+restricted+`}]
+		}`), "grok-4.5")
+		if err != nil {
+			t.Fatal(err)
+		}
+		request = nil
+		if err := json.Unmarshal(normalized, &request); err != nil {
+			t.Fatal(err)
+		}
+		tool = request["tools"].([]any)[0].(map[string]any)
+		if len(tool) != 1 || tool["type"] != "web_search" || compatibility == nil || compatibility.warningHeader() == "" {
+			t.Fatalf("restricted web search should downgrade: tool=%#v compatibility=%#v", tool, compatibility)
 		}
 	}
 
@@ -193,11 +244,14 @@ func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 	if err := json.Unmarshal(normalized, &request); err != nil {
 		t.Fatal(err)
 	}
-	if _, exists := request["tools"]; exists || request["tool_choice"] != "none" {
+	if _, exists := request["tools"]; exists {
 		t.Fatalf("disabled web search request = %#v", request)
 	}
+	if _, exists := request["tool_choice"]; exists {
+		t.Fatalf("disabled web search tool_choice = %#v", request["tool_choice"])
+	}
 	warnings := compatibility.warningHeader()
-	if !strings.Contains(warnings, "web_search_disabled_no_external_access") || !strings.Contains(warnings, "web_search_tool_choice_disabled") {
+	if !strings.Contains(warnings, "web_search_disabled_no_external_access") || !strings.Contains(warnings, "tool_choice_without_tools_ignored") {
 		t.Fatalf("compatibility warnings = %q", warnings)
 	}
 
@@ -235,21 +289,31 @@ func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 	if err := json.Unmarshal(normalized, &request); err != nil {
 		t.Fatal(err)
 	}
-	if _, exists := request["tools"]; exists || request["tool_choice"] != "none" {
+	if _, exists := request["tools"]; exists {
 		t.Fatalf("disabled automatic web search request = %#v", request)
 	}
+	if _, exists := request["tool_choice"]; exists {
+		t.Fatalf("disabled automatic web search tool_choice = %#v", request["tool_choice"])
+	}
 
-	_, _, err = normalizeResponsesRequest([]byte(`{
+	normalized, compatibility, err = normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"search",
 		"tools":[{"type":"web_search","unknown_control":true}]
 	}`), "grok-4.5")
-	requestErr, ok := err.(*responsesRequestError)
-	if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].unknown_control" {
-		t.Fatalf("unknown web search option error = %#v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request = nil
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tool = request["tools"].([]any)[0].(map[string]any)
+	if len(tool) != 1 || tool["type"] != "web_search" || compatibility == nil || !strings.Contains(compatibility.warningHeader(), "web_search_unknown_controls_ignored") {
+		t.Fatalf("unknown web search option should downgrade: tool=%#v compatibility=%#v", tool, compatibility)
 	}
 }
 
-func TestResponsesBuild0299NativeAndUnsupportedToolMatrix(t *testing.T) {
+func TestResponsesBuild02101NativeAndUnsupportedToolMatrix(t *testing.T) {
 	native := []string{"x_search", "image_generation", "collections_search", "file_search", "code_execution", "code_interpreter", "mcp", "shell"}
 	for _, kind := range native {
 		t.Run("native_"+kind, func(t *testing.T) {
@@ -285,22 +349,32 @@ func TestResponsesBuild0299NativeAndUnsupportedToolMatrix(t *testing.T) {
 			body := []byte(`{"model":"public","input":"hello","tools":[{"type":"` + kind + `"}]}`)
 			_, _, err := normalizeResponsesRequest(body, "grok-4.5")
 			requestErr, ok := err.(*responsesRequestError)
-			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "0.2.99") {
+			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "0.2.101") {
 				t.Fatalf("error = %#v", err)
 			}
 		})
 	}
 }
 
-func TestResponsesHostedToolChoiceRequiresSingleMatchingTool(t *testing.T) {
-	_, _, err := normalizeResponsesRequest([]byte(`{
+func TestResponsesHostedToolChoiceNarrowsToMatchingTool(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"draw",
 		"tools":[{"type":"image_generation"},{"type":"web_search"}],
 		"tool_choice":{"type":"image_generation"}
 	}`), "grok-4.5")
-	requestErr, ok := err.(*responsesRequestError)
-	if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tool_choice" {
-		t.Fatalf("error = %#v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tools := request["tools"].([]any)
+	if len(tools) != 1 || tools[0].(map[string]any)["type"] != "image_generation" || request["tool_choice"] != "required" {
+		t.Fatalf("request = %#v", request)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "hosted_tool_choice_tools_narrowed") {
+		t.Fatalf("compatibility = %#v", compatibility)
 	}
 }
 

--- a/backend/internal/infra/provider/cli/responses_codex_tools.go
+++ b/backend/internal/infra/provider/cli/responses_codex_tools.go
@@ -19,7 +19,7 @@ func (c *responsesToolCompatibility) normalizeShellTool(tool map[string]any, par
 	return c.normalizeNativeTool(tool, param)
 }
 
-// normalizeLegacyLocalShellTool 将旧 Codex local_shell 升级为 0.2.99 原生 local shell 环境。
+// normalizeLegacyLocalShellTool 将旧 Codex local_shell 升级为 0.2.101 原生 local shell 环境。
 func (c *responsesToolCompatibility) normalizeLegacyLocalShellTool(tool map[string]any, param string) ([]any, error) {
 	if c.nativeShell || c.legacyLocalShell {
 		return nil, &responsesRequestError{
@@ -27,13 +27,8 @@ func (c *responsesToolCompatibility) normalizeLegacyLocalShellTool(tool map[stri
 			Param:   param + ".type", Code: "invalid_parameter",
 		}
 	}
-	for key := range tool {
-		if key != "type" {
-			return nil, &responsesRequestError{
-				Message: "旧版 local_shell 不支持额外配置字段",
-				Param:   param + "." + key, Code: "unsupported_parameter",
-			}
-		}
+	if len(tool) > 1 {
+		c.addWarning("legacy_local_shell_controls_ignored")
 	}
 	c.legacyLocalShell = true
 	c.changed = true
@@ -45,20 +40,9 @@ func (c *responsesToolCompatibility) normalizeLegacyLocalShellTool(tool map[stri
 }
 
 // normalizeApplyPatchTool 将客户端执行的 apply_patch 包装为严格 function。
-func (c *responsesToolCompatibility) normalizeApplyPatchTool(tool map[string]any, namespace, param string) ([]any, error) {
-	if namespace != "" {
-		return nil, &responsesRequestError{
-			Message: "namespace 内暂不支持 apply_patch",
-			Param:   param + ".type", Code: "unsupported_parameter",
-		}
-	}
-	for key := range tool {
-		if key != "type" {
-			return nil, &responsesRequestError{
-				Message: "apply_patch 不接受自定义字段",
-				Param:   param + "." + key, Code: "unsupported_parameter",
-			}
-		}
+func (c *responsesToolCompatibility) normalizeApplyPatchTool(tool map[string]any, param string) ([]any, error) {
+	if len(tool) > 1 {
+		c.addWarning("apply_patch_controls_ignored")
 	}
 	identity := responsesToolIdentity{Kind: responsesApplyPatchTool, Name: "apply_patch"}
 	c.changed = true
@@ -202,7 +186,7 @@ func legacyShellAction(value any, param string) (map[string]any, error) {
 		return nil, &responsesRequestError{Message: "local_shell_call.action 必须是对象", Param: param, Code: "invalid_parameter"}
 	}
 	if kind := strings.TrimSpace(stringField(action, "type")); kind != "" && kind != "exec" {
-		return nil, &responsesRequestError{Message: "local_shell_call.action.type 只支持 exec", Param: param + ".type", Code: "unsupported_parameter"}
+		return nil, &responsesRequestError{Message: "local_shell_call.action.type 必须是 exec", Param: param + ".type", Code: "invalid_parameter"}
 	}
 	command, err := legacyShellCommand(action, param)
 	if err != nil {
@@ -343,7 +327,7 @@ func validEnvironmentName(value string) bool {
 
 func (c *responsesToolCompatibility) normalizeAdditionalToolsInput(item map[string]any, param string) (map[string]any, []any, []any, error) {
 	if role := strings.TrimSpace(stringField(item, "role")); role != "" && role != "developer" {
-		return nil, nil, nil, &responsesRequestError{Message: "additional_tools.role 只支持 developer", Param: param + ".role", Code: "unsupported_parameter"}
+		c.addWarning("additional_tools_role_approximated")
 	}
 	tools, ok := item["tools"].([]any)
 	if !ok {

--- a/backend/internal/infra/provider/cli/responses_codex_tools_test.go
+++ b/backend/internal/infra/provider/cli/responses_codex_tools_test.go
@@ -10,13 +10,13 @@ import (
 func TestLegacyLocalShellUsesNativeLocalShellAndRestoresJSON(t *testing.T) {
 	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"show cwd",
-		"tools":[{"type":"local_shell"}],
+		"tools":[{"type":"local_shell","timeout_ms":30000}],
 		"tool_choice":{"type":"local_shell"}
 	}`), "grok-4.5")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compatibility == nil || !compatibility.legacyLocalShell {
+	if compatibility == nil || !compatibility.legacyLocalShell || !strings.Contains(compatibility.warningHeader(), "legacy_local_shell_controls_ignored") {
 		t.Fatal("legacy local_shell 未启用兼容层")
 	}
 	var request map[string]any
@@ -92,13 +92,13 @@ func TestRequestRejectsAmbiguousShellDeclarations(t *testing.T) {
 func TestApplyPatchToolRequestHistoryAndJSONResponse(t *testing.T) {
 	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"edit file",
-		"tools":[{"type":"apply_patch"}],
+		"tools":[{"type":"apply_patch","strict":false}],
 		"tool_choice":{"type":"apply_patch"}
 	}`), "grok-4.5")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compatibility == nil {
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "apply_patch_controls_ignored") {
 		t.Fatal("apply_patch 未启用兼容层")
 	}
 	var request map[string]any
@@ -194,16 +194,19 @@ func TestApplyPatchStreamBuffersFunctionProtocolAndRestoresItems(t *testing.T) {
 }
 
 func TestAdditionalToolsAndCompactionBoundaryRemainVisible(t *testing.T) {
-	normalized, _, err := normalizeResponsesRequest([]byte(`{
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","tools":[{"type":"function","name":"lookup","description":"old","parameters":{"type":"object"}}],
 		"input":[
 			{"type":"compaction_trigger"},
-			{"type":"additional_tools","role":"developer","tools":[{"type":"function","name":"lookup","description":"new","parameters":{"type":"object"}},{"type":"apply_patch"}]},
+			{"type":"additional_tools","role":"user","tools":[{"type":"function","name":"lookup","description":"new","parameters":{"type":"object"}},{"type":"apply_patch"}]},
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
 		]
 	}`), "grok-4.5")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "additional_tools_role_approximated") {
+		t.Fatalf("compatibility = %#v", compatibility)
 	}
 	var request map[string]any
 	if err := json.Unmarshal(normalized, &request); err != nil {

--- a/backend/internal/infra/provider/cli/responses_custom.go
+++ b/backend/internal/infra/provider/cli/responses_custom.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 )
 
-// normalizeCustomTool 将任意字符串输入包装为普通函数；grammar 约束无法等价表达时明确拒绝。
+// normalizeCustomTool 将任意字符串输入包装为普通函数；无法等价表达的 format
+// 仅降级为纯文本输入，避免客户端因可选约束整次请求失败。
 func (c *responsesToolCompatibility) normalizeCustomTool(tool map[string]any, namespace, param string) ([]any, error) {
 	name := strings.TrimSpace(stringField(tool, "name"))
 	if name == "" {
@@ -13,11 +14,12 @@ func (c *responsesToolCompatibility) normalizeCustomTool(tool map[string]any, na
 	}
 	if format, exists := tool["format"]; exists {
 		formatObject, ok := format.(map[string]any)
-		if !ok || (stringField(formatObject, "type") != "" && stringField(formatObject, "type") != "text") {
-			return nil, &responsesRequestError{
-				Message: "Grok Build 无法等价模拟 custom tool grammar",
-				Param:   param + ".format", Code: "unsupported_parameter",
-			}
+		if !ok {
+			return nil, &responsesRequestError{Message: "custom tool format 必须是对象", Param: param + ".format", Code: "invalid_parameter"}
+		}
+		if kind := stringField(formatObject, "type"); kind != "" && kind != "text" {
+			c.changed = true
+			c.addWarning("custom_tool_format_downgraded")
 		}
 	}
 	identity := responsesToolIdentity{Kind: responsesCustomTool, Namespace: namespace, Name: name}

--- a/backend/internal/infra/provider/cli/responses_history.go
+++ b/backend/internal/infra/provider/cli/responses_history.go
@@ -40,6 +40,17 @@ func (c *responsesToolCompatibility) normalizeInputItems(items []any) ([]any, []
 			if callID == "" {
 				return nil, nil, nil, &responsesRequestError{Message: param + ".call_id 不能为空", Param: param + ".call_id", Code: "invalid_parameter"}
 			}
+			execution := strings.ToLower(strings.TrimSpace(stringField(item, "execution")))
+			if execution == "" || execution == "server" {
+				c.serverSearchEager = true
+				c.changed = true
+				c.addWarning("server_tool_search_history_approximated")
+				rewritten = append(rewritten, compatibilityBoundaryMessage("A server-side tool search occurred here; selected tools are made available directly."))
+				continue
+			}
+			if execution != "client" {
+				return nil, nil, nil, &responsesRequestError{Message: "tool_search_call.execution 必须是 client 或 server", Param: param + ".execution", Code: "invalid_parameter"}
+			}
 			arguments, err := encodeFunctionArguments(item["arguments"])
 			if err != nil {
 				return nil, nil, nil, &responsesRequestError{Message: param + ".arguments 无法编码", Param: param + ".arguments", Code: "invalid_parameter"}
@@ -51,8 +62,8 @@ func (c *responsesToolCompatibility) normalizeInputItems(items []any) ([]any, []
 			c.changed = true
 		case "tool_search_output":
 			execution := strings.ToLower(strings.TrimSpace(stringField(item, "execution")))
-			if execution != "client" {
-				return nil, nil, nil, &responsesRequestError{Message: "Grok Build 只兼容客户端 tool_search_output", Param: param + ".execution", Code: "unsupported_parameter"}
+			if execution != "" && execution != "client" && execution != "server" {
+				return nil, nil, nil, &responsesRequestError{Message: "tool_search_output.execution 必须是 client 或 server", Param: param + ".execution", Code: "invalid_parameter"}
 			}
 			callID := strings.TrimSpace(stringField(item, "call_id"))
 			if callID == "" {
@@ -71,10 +82,14 @@ func (c *responsesToolCompatibility) normalizeInputItems(items []any) ([]any, []
 			}
 			visibleTools = append(visibleTools, cloneJSONArray(tools)...)
 			c.changed = true
-			rewritten = append(rewritten, map[string]any{
-				"type": "function_call_output", "call_id": callID,
-				"output": fmt.Sprintf("Tool search completed; %d selected tool definitions are now available.", len(tools)),
-			})
+			message := fmt.Sprintf("Tool search completed; %d selected tool definitions are now available.", len(tools))
+			if execution == "client" {
+				rewritten = append(rewritten, map[string]any{"type": "function_call_output", "call_id": callID, "output": message})
+			} else {
+				c.serverSearchEager = true
+				c.addWarning("server_tool_search_history_approximated")
+				rewritten = append(rewritten, compatibilityBoundaryMessage(message))
+			}
 		case "custom_tool_call":
 			name := strings.TrimSpace(stringField(item, "name"))
 			if name == "" {

--- a/backend/internal/infra/provider/cli/responses_tool_choice.go
+++ b/backend/internal/infra/provider/cli/responses_tool_choice.go
@@ -11,6 +11,15 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 	if isEmptyJSON(raw) {
 		return nil
 	}
+	if len(normalizedTools) == 0 {
+		delete(payload, "tool_choice")
+		c.changed = true
+		c.addWarning("tool_choice_without_tools_ignored")
+		if c.serverSearchEager {
+			c.addWarning("server_tool_search_choice_downgraded")
+		}
+		return nil
+	}
 	var choice any
 	if err := json.Unmarshal(raw, &choice); err != nil {
 		return &responsesRequestError{Message: "tool_choice 格式无效", Param: "tool_choice", Code: "invalid_parameter"}
@@ -33,6 +42,12 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 	}
 	if kind == "tool_search" {
 		if c.clientSearchTool == nil {
+			if c.serverSearchEager {
+				payload["tool_choice"] = mustJSON("auto")
+				c.changed = true
+				c.addWarning("server_tool_search_choice_downgraded")
+				return nil
+			}
 			return &responsesRequestError{Message: "tool_choice 引用了未声明的 tool_search", Param: "tool_choice", Code: "invalid_parameter"}
 		}
 		object = map[string]any{
@@ -72,11 +87,14 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 		return nil
 	}
 	if normalizedKind := normalizeHostedToolChoiceKind(kind); normalizedKind != "" {
-		if !hasSingleToolType(normalizedTools, normalizedKind) {
-			return &responsesRequestError{
-				Message: "Grok Build 仅能在请求中只有一个匹配工具时兼容 hosted tool_choice",
-				Param:   "tool_choice", Code: "unsupported_parameter",
-			}
+		matching := toolsOfType(normalizedTools, normalizedKind)
+		if len(matching) == 0 {
+			return &responsesRequestError{Message: "tool_choice 引用了未声明的 hosted tool", Param: "tool_choice", Code: "invalid_parameter"}
+		}
+		if len(matching) != len(normalizedTools) {
+			// 上游只支持 required，收窄本轮可见工具即可保持“指定该类工具”的语义。
+			payload["tools"] = mustJSON(matching)
+			c.addWarning("hosted_tool_choice_tools_narrowed")
 		}
 		payload["tool_choice"] = mustJSON("required")
 		c.changed = true
@@ -116,4 +134,15 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 	c.changed = true
 	payload["tool_choice"] = mustJSON(object)
 	return nil
+}
+
+func toolsOfType(tools []any, kind string) []any {
+	matching := make([]any, 0)
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if ok && stringField(tool, "type") == kind {
+			matching = append(matching, rawTool)
+		}
+	}
+	return matching
 }

--- a/backend/internal/infra/provider/cli/responses_tool_declarations.go
+++ b/backend/internal/infra/provider/cli/responses_tool_declarations.go
@@ -58,8 +58,12 @@ func normalizeResponsesTools(payload map[string]json.RawMessage) (*responsesTool
 	normalizedTools = dedupeNormalizedTools(normalizedTools)
 	if len(normalizedTools) > 0 {
 		payload["tools"] = mustJSON(normalizedTools)
-	} else if hasTools && compatibility.webSearchDisabled {
+	} else if hasTools {
 		delete(payload, "tools")
+		if _, exists := payload["parallel_tool_calls"]; exists {
+			delete(payload, "parallel_tool_calls")
+			compatibility.addWarning("parallel_tool_calls_without_tools_ignored")
+		}
 		compatibility.changed = true
 	}
 	if err := compatibility.normalizeToolChoice(payload, normalizedTools); err != nil {
@@ -90,10 +94,9 @@ func (c *responsesToolCompatibility) normalizeClientToolSearchParallel(payload m
 		}
 	}
 	if parallel {
-		return &responsesRequestError{
-			Message: "客户端 tool_search 暂不支持并行工具调用",
-			Param:   "parallel_tool_calls", Code: "unsupported_parameter",
-		}
+		payload["parallel_tool_calls"] = mustJSON(false)
+		c.changed = true
+		c.addWarning("client_tool_search_forced_serial")
 	}
 	return nil
 }
@@ -111,6 +114,7 @@ func decodeOptionalArray(raw json.RawMessage, param string) ([]any, bool, error)
 
 func inspectToolSearch(tools []any) (bool, error) {
 	clientSearch := false
+	serverSearch := false
 	for index, rawTool := range tools {
 		tool, ok := rawTool.(map[string]any)
 		if !ok {
@@ -122,16 +126,20 @@ func inspectToolSearch(tools []any) (bool, error) {
 		param := fmt.Sprintf("tools[%d]", index)
 		execution := strings.ToLower(strings.TrimSpace(stringField(tool, "execution")))
 		if execution == "" || execution == "server" {
-			return false, &responsesRequestError{
-				Message: "Grok Build 上游不支持服务端 tool_search；请使用 execution: \"client\"",
-				Param:   param + ".execution", Code: "unsupported_parameter",
+			if clientSearch {
+				return false, &responsesRequestError{Message: "单次请求不能混用 client 与 server tool_search", Param: param + ".execution", Code: "invalid_parameter"}
 			}
+			serverSearch = true
+			continue
 		}
 		if execution != "client" {
-			return false, &responsesRequestError{Message: "tool_search.execution 只支持 client", Param: param + ".execution", Code: "unsupported_parameter"}
+			return false, &responsesRequestError{Message: "tool_search.execution 必须是 client 或 server", Param: param + ".execution", Code: "invalid_parameter"}
 		}
 		if clientSearch {
 			return false, &responsesRequestError{Message: "单次请求只能声明一个客户端 tool_search", Param: param, Code: "invalid_parameter"}
+		}
+		if serverSearch {
+			return false, &responsesRequestError{Message: "单次请求不能混用 client 与 server tool_search", Param: param + ".execution", Code: "invalid_parameter"}
 		}
 		clientSearch = true
 	}
@@ -152,10 +160,8 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 		}
 		deferred, _ := tool["defer_loading"].(bool)
 		if deferred && !clientSearch && !force {
-			return nil, &responsesRequestError{
-				Message: "defer_loading: true 需要 execution: \"client\" 的 tool_search",
-				Param:   param + ".defer_loading", Code: "invalid_parameter",
-			}
+			c.changed = true
+			c.addWarning("orphan_deferred_tool_loaded")
 		}
 		if deferred && clientSearch && !force {
 			c.changed = true
@@ -198,7 +204,7 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 				return nil, &responsesRequestError{Message: childParam + " 必须是对象", Param: childParam, Code: "invalid_parameter"}
 			}
 			if stringField(child, "type") != "function" {
-				return nil, &responsesRequestError{Message: "namespace 内只支持 function 工具", Param: childParam + ".type", Code: "unsupported_parameter"}
+				return nil, &responsesRequestError{Message: "namespace.tools 只能包含 function 工具", Param: childParam + ".type", Code: "invalid_parameter"}
 			}
 			items, err := c.normalizeTool(child, name, clientSearch, force, childParam)
 			if err != nil {
@@ -209,7 +215,18 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 		return converted, nil
 	case "tool_search":
 		if force {
-			return nil, &responsesRequestError{Message: "tool_search_output.tools 不能再次声明 tool_search", Param: param, Code: "unsupported_parameter"}
+			c.changed = true
+			c.addWarning("nested_tool_search_ignored")
+			return nil, nil
+		}
+		execution := strings.ToLower(strings.TrimSpace(stringField(tool, "execution")))
+		if execution == "" || execution == "server" {
+			// Build 上游没有服务端 Tool Search。将已声明的延迟工具提前展开，
+			// 比让 Codex 因一个可选优化能力整次失败更符合兼容层语义。
+			c.serverSearchEager = true
+			c.changed = true
+			c.addWarning("server_tool_search_eager_loaded")
+			return nil, nil
 		}
 		c.changed = true
 		c.addWarning("client_tool_search_emulated")
@@ -227,7 +244,7 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 	case "local_shell":
 		return c.normalizeLegacyLocalShellTool(tool, param)
 	case "apply_patch":
-		return c.normalizeApplyPatchTool(tool, namespace, param)
+		return c.normalizeApplyPatchTool(tool, param)
 	case "x_search", "image_generation", "collections_search", "file_search", "code_execution", "code_interpreter":
 		return c.normalizeNativeTool(tool, param)
 	case "computer_use_preview":

--- a/backend/internal/infra/provider/cli/responses_tool_state.go
+++ b/backend/internal/infra/provider/cli/responses_tool_state.go
@@ -40,6 +40,7 @@ type responsesToolCompatibility struct {
 	deferredSurfaces  []string
 	clientSearchTool  map[string]any
 	clientSearchParam string
+	serverSearchEager bool
 	streamCalls       map[string]*responsesStreamCall
 	legacyLocalShell  bool
 	nativeShell       bool

--- a/backend/internal/infra/provider/cli/responses_tool_types.go
+++ b/backend/internal/infra/provider/cli/responses_tool_types.go
@@ -21,7 +21,7 @@ var nativeHostedToolChoiceTypes = map[string]string{
 	"local_shell":                   "shell",
 }
 
-// webSearchCompatibilityFields 是 Codex/OpenAI 新版声明中已知、但 0.2.99 上游会以
+// webSearchCompatibilityFields 是 Codex/OpenAI 新版声明中已知、但 0.2.101 上游会以
 // "Argument not supported" 拒绝的控制字段。Build 只能降级为其原生最小搜索工具。
 var webSearchCompatibilityFields = map[string]struct{}{
 	"external_web_access":  {},
@@ -29,24 +29,23 @@ var webSearchCompatibilityFields = map[string]struct{}{
 	"search_content_types": {},
 	"search_context_size":  {},
 	"user_location":        {},
-	"filters":              {},
-	"allowed_domains":      {},
 	"max_search_results":   {},
 	"safe_search":          {},
 }
 
-// normalizeNativeTool 保留 0.2.99 已确认支持的工具，并拒绝只属于 Tool Search 的延迟字段。
-func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, param string) ([]any, error) {
-	if _, exists := tool["defer_loading"]; exists {
-		return nil, &responsesRequestError{
-			Message: "该工具类型不支持 defer_loading",
-			Param:   param + ".defer_loading", Code: "unsupported_parameter",
-		}
+// normalizeNativeTool 保留 0.2.101 已确认支持的工具，并拒绝只属于 Tool Search 的延迟字段。
+func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, _ string) ([]any, error) {
+	converted := cloneJSONObject(tool)
+	if _, exists := converted["defer_loading"]; exists {
+		delete(converted, "defer_loading")
+		c.changed = true
+		c.addWarning("orphan_deferred_tool_loaded")
 	}
-	return []any{cloneJSONValue(tool)}, nil
+	return []any{converted}, nil
 }
 
-// normalizeWebSearchTool 将 Codex/OpenAI 新版搜索声明降级为 0.2.99 支持的最小 web_search。
+// normalizeWebSearchTool 保留 0.2.101 原生支持的 allowed_domains 约束，
+// 并将无法等价表达的新版控制字段安全降级。
 func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any, kind, param string) ([]any, error) {
 	if external, exists := tool["external_web_access"]; exists {
 		enabled, ok := external.(bool)
@@ -54,7 +53,7 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 			return nil, &responsesRequestError{Message: "external_web_access 必须是布尔值", Param: param + ".external_web_access", Code: "invalid_parameter"}
 		}
 		if !enabled {
-			// 0.2.99 不能表达“只允许索引、禁止外网”。发送最小 web_search
+			// 0.2.101 不能表达“只允许索引、禁止外网”。发送最小 web_search
 			// 会扩大客户端授权，因此直接移除该搜索工具，形成安全的能力子集。
 			c.webSearchDisabled = true
 			c.changed = true
@@ -62,17 +61,9 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 			return nil, nil
 		}
 	}
-	if filters, exists := tool["filters"]; exists && hasNonEmptyWebSearchConstraint(filters) {
-		return nil, &responsesRequestError{
-			Message: "Grok Build 0.2.99 无法保证 web_search filters 约束",
-			Param:   param + ".filters", Code: "unsupported_parameter",
-		}
-	}
-	if domains, exists := tool["allowed_domains"]; exists && hasNonEmptyWebSearchConstraint(domains) {
-		return nil, &responsesRequestError{
-			Message: "Grok Build 0.2.99 无法保证 allowed_domains 约束",
-			Param:   param + ".allowed_domains", Code: "unsupported_parameter",
-		}
+	filters, err := c.normalizeWebSearchFilters(tool, param)
+	if err != nil {
+		return nil, err
 	}
 	if contentTypes, exists := tool["search_content_types"]; exists {
 		values, ok := contentTypes.([]any)
@@ -81,10 +72,8 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 		}
 		for _, value := range values {
 			if value != "text" {
-				return nil, &responsesRequestError{
-					Message: "Grok Build 0.2.99 只能兼容文本 Web Search",
-					Param:   param + ".search_content_types", Code: "unsupported_parameter",
-				}
+				c.changed = true
+				c.addWarning("web_search_non_text_content_ignored")
 			}
 		}
 	}
@@ -92,11 +81,18 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 		if key == "type" {
 			continue
 		}
+		if key == "filters" {
+			continue
+		}
+		if key == "allowed_domains" {
+			c.changed = true
+			c.addWarning("web_search_allowed_domains_normalized")
+			continue
+		}
 		if _, compatible := webSearchCompatibilityFields[key]; !compatible {
-			return nil, &responsesRequestError{
-				Message: "Grok Build 0.2.99 不支持该 web_search 字段",
-				Param:   param + "." + key, Code: "unsupported_parameter",
-			}
+			c.changed = true
+			c.addWarning("web_search_unknown_controls_ignored")
+			continue
 		}
 		c.changed = true
 		c.addWarning("web_search_controls_downgraded")
@@ -104,41 +100,91 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 	if kind == "web_search" && len(tool) == 1 {
 		return []any{cloneJSONValue(tool)}, nil
 	}
-	c.changed = true
-	return []any{map[string]any{"type": "web_search"}}, nil
+	converted := map[string]any{"type": "web_search"}
+	if filters != nil {
+		converted["filters"] = filters
+	}
+	if kind != "web_search" || len(tool) != len(converted) {
+		c.changed = true
+	}
+	return []any{converted}, nil
 }
 
-func hasNonEmptyWebSearchConstraint(value any) bool {
-	if value == nil {
-		return false
-	}
-	switch typed := value.(type) {
-	case []any:
-		return len(typed) > 0
-	case map[string]any:
-		for _, item := range typed {
-			if hasNonEmptyWebSearchConstraint(item) {
-				return true
+func (c *responsesToolCompatibility) normalizeWebSearchFilters(tool map[string]any, param string) (map[string]any, error) {
+	var nestedDomains []any
+	if rawFilters, exists := tool["filters"]; exists && rawFilters != nil {
+		filters, ok := rawFilters.(map[string]any)
+		if !ok {
+			return nil, &responsesRequestError{Message: "web_search filters 必须是对象", Param: param + ".filters", Code: "invalid_parameter"}
+		}
+		for key := range filters {
+			if key != "allowed_domains" {
+				c.changed = true
+				c.addWarning("web_search_filters_downgraded")
 			}
 		}
-		return false
-	case string:
-		return strings.TrimSpace(typed) != ""
-	case bool:
-		return typed
-	default:
-		return true
+		if rawDomains, exists := filters["allowed_domains"]; exists {
+			values, err := normalizeAllowedDomains(rawDomains, param+".filters.allowed_domains")
+			if err != nil {
+				return nil, err
+			}
+			nestedDomains = values
+		}
 	}
+
+	var topLevelDomains []any
+	if rawDomains, exists := tool["allowed_domains"]; exists {
+		values, err := normalizeAllowedDomains(rawDomains, param+".allowed_domains")
+		if err != nil {
+			return nil, err
+		}
+		topLevelDomains = values
+	}
+	if len(nestedDomains) > 0 && len(topLevelDomains) > 0 && !sameStringValues(nestedDomains, topLevelDomains) {
+		return nil, &responsesRequestError{Message: "web_search allowed_domains 声明冲突", Param: param + ".allowed_domains", Code: "invalid_parameter"}
+	}
+	domains := nestedDomains
+	if len(domains) == 0 {
+		domains = topLevelDomains
+	}
+	if len(domains) == 0 {
+		return nil, nil
+	}
+	return map[string]any{"allowed_domains": cloneJSONValue(domains)}, nil
+}
+
+func normalizeAllowedDomains(value any, param string) ([]any, error) {
+	values, ok := value.([]any)
+	if !ok {
+		return nil, &responsesRequestError{Message: "allowed_domains 必须是字符串数组", Param: param, Code: "invalid_parameter"}
+	}
+	for index, value := range values {
+		domain, ok := value.(string)
+		if !ok || strings.TrimSpace(domain) == "" {
+			return nil, &responsesRequestError{Message: "allowed_domains 必须包含有效域名", Param: fmt.Sprintf("%s[%d]", param, index), Code: "invalid_parameter"}
+		}
+	}
+	return values, nil
+}
+
+func sameStringValues(left, right []any) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 // normalizeMCPTool 支持客户端 Tool Search 延迟加载整个 MCP server 定义。
 func (c *responsesToolCompatibility) normalizeMCPTool(tool map[string]any, clientSearch, force bool, param string) ([]any, error) {
 	deferred, _ := tool["defer_loading"].(bool)
 	if deferred && !clientSearch && !force {
-		return nil, &responsesRequestError{
-			Message: "MCP defer_loading: true 需要 execution: \"client\" 的 tool_search",
-			Param:   param + ".defer_loading", Code: "invalid_parameter",
-		}
+		c.changed = true
+		c.addWarning("orphan_deferred_tool_loaded")
 	}
 	if deferred && clientSearch && !force {
 		label := strings.TrimSpace(stringField(tool, "server_label"))
@@ -162,21 +208,13 @@ func (c *responsesToolCompatibility) normalizeMCPTool(tool map[string]any, clien
 
 func unsupportedBuildToolError(kind, param string) error {
 	return &responsesRequestError{
-		Message: fmt.Sprintf("Grok Build 0.2.99 不支持 tools.type=%q", kind),
+		Message: fmt.Sprintf("Grok Build 0.2.101 不支持 tools.type=%q", kind),
 		Param:   param + ".type", Code: "unsupported_parameter",
 	}
 }
 
 func normalizeHostedToolChoiceKind(kind string) string {
 	return nativeHostedToolChoiceTypes[kind]
-}
-
-func hasSingleToolType(tools []any, kind string) bool {
-	if len(tools) != 1 {
-		return false
-	}
-	tool, ok := tools[0].(map[string]any)
-	return ok && stringField(tool, "type") == kind
 }
 
 func hasToolType(tools []any, kind string) bool {

--- a/backend/internal/infra/provider/cli/responses_tools_test.go
+++ b/backend/internal/infra/provider/cli/responses_tools_test.go
@@ -130,36 +130,118 @@ func TestNormalizeResponsesRequestLoadsClientToolSearchOutput(t *testing.T) {
 	}
 }
 
-func TestNormalizeResponsesRequestRejectsHostedToolSearch(t *testing.T) {
-	_, _, err := normalizeResponsesRequest([]byte(`{
-		"model":"public","input":"hello",
-		"tools":[{"type":"tool_search"}]
+func TestNormalizeResponsesRequestLoadsServerToolSearchHistory(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"public",
+		"input":[
+			{"type":"tool_search_call","execution":"server","call_id":"search_1","arguments":{"goal":"shipping"}},
+			{"type":"tool_search_output","execution":"server","call_id":"search_1","status":"completed","tools":[
+				{"type":"function","name":"get_eta","defer_loading":true,"parameters":{"type":"object"}}
+			]}
+		]
 	}`), "grok-4.5")
-	requestErr, ok := err.(*responsesRequestError)
-	if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].execution" {
-		t.Fatalf("error = %#v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tools := request["tools"].([]any)
+	if len(tools) != 1 || tools[0].(map[string]any)["name"] != "get_eta" || tools[0].(map[string]any)["defer_loading"] != nil {
+		t.Fatalf("tools = %#v", tools)
+	}
+	items := request["input"].([]any)
+	if len(items) != 2 || items[0].(map[string]any)["role"] != "developer" || items[1].(map[string]any)["role"] != "developer" {
+		t.Fatalf("history = %#v", items)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "server_tool_search_history_approximated") {
+		t.Fatalf("compatibility = %#v", compatibility)
 	}
 }
 
-func TestNormalizeResponsesRequestRejectsParallelClientToolSearch(t *testing.T) {
-	_, _, err := normalizeResponsesRequest([]byte(`{
+func TestNormalizeResponsesRequestEagerLoadsServerToolSearch(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[
+			{"type":"function","name":"lookup","defer_loading":true,"parameters":{"type":"object"}},
+			{"type":"tool_search"}
+		],
+		"tool_choice":{"type":"tool_search"}
+	}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	tools := payload["tools"].([]any)
+	if len(tools) != 1 || tools[0].(map[string]any)["name"] != "lookup" || tools[0].(map[string]any)["defer_loading"] != nil || payload["tool_choice"] != "auto" {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "server_tool_search_eager_loaded") || !strings.Contains(compatibility.warningHeader(), "server_tool_search_choice_downgraded") {
+		t.Fatalf("compatibility = %#v", compatibility)
+	}
+}
+
+func TestNormalizeResponsesRequestDropsEmptyServerToolSearchChoice(t *testing.T) {
+	normalized, _, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[{"type":"tool_search"}],
+		"tool_choice":{"type":"tool_search"},
+		"parallel_tool_calls":true
+	}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["tools"]; exists {
+		t.Fatalf("tools = %#v", payload["tools"])
+	}
+	if _, exists := payload["tool_choice"]; exists {
+		t.Fatalf("tool_choice = %#v", payload["tool_choice"])
+	}
+	if _, exists := payload["parallel_tool_calls"]; exists {
+		t.Fatalf("parallel_tool_calls = %#v", payload["parallel_tool_calls"])
+	}
+}
+
+func TestNormalizeResponsesRequestSerializesParallelClientToolSearch(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"hello","parallel_tool_calls":true,
 		"tools":[{"type":"tool_search","execution":"client"}]
 	}`), "grok-4.5")
-	requestErr, ok := err.(*responsesRequestError)
-	if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "parallel_tool_calls" {
-		t.Fatalf("error = %#v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["parallel_tool_calls"] != false || compatibility == nil || !strings.Contains(compatibility.warningHeader(), "client_tool_search_forced_serial") {
+		t.Fatalf("payload=%#v compatibility=%#v", payload, compatibility)
 	}
 }
 
-func TestNormalizeResponsesRequestRejectsDeferredToolWithoutSearch(t *testing.T) {
-	_, _, err := normalizeResponsesRequest([]byte(`{
+func TestNormalizeResponsesRequestLoadsDeferredToolWithoutSearch(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"hello",
 		"tools":[{"type":"function","name":"lookup","defer_loading":true,"parameters":{"type":"object"}}]
 	}`), "grok-4.5")
-	requestErr, ok := err.(*responsesRequestError)
-	if !ok || requestErr.Code != "invalid_parameter" || requestErr.Param != "tools[0].defer_loading" {
-		t.Fatalf("error = %#v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	tool := payload["tools"].([]any)[0].(map[string]any)
+	if tool["name"] != "lookup" || tool["defer_loading"] != nil || compatibility == nil || !strings.Contains(compatibility.warningHeader(), "orphan_deferred_tool_loaded") {
+		t.Fatalf("tool=%#v compatibility=%#v", tool, compatibility)
 	}
 }
 

--- a/backend/internal/infra/provider/conversation/chat_request.go
+++ b/backend/internal/infra/provider/conversation/chat_request.go
@@ -9,49 +9,93 @@ import (
 )
 
 // convertChatRequest 将 Chat Completions 请求完整转换为标准 Responses 输入。
-func convertChatRequest(body []byte, model string) ([]byte, error) {
+func convertChatRequest(body []byte, model string) ([]byte, ResponseOptions, error) {
 	var source map[string]json.RawMessage
 	if err := json.Unmarshal(body, &source); err != nil {
-		return nil, fmt.Errorf("解析 Chat Completions 请求: %w", err)
+		return nil, ResponseOptions{}, fmt.Errorf("解析 Chat Completions 请求: %w", err)
 	}
 	var messages []chatMessage
 	if err := json.Unmarshal(source["messages"], &messages); err != nil || len(messages) == 0 {
-		return nil, errors.New("messages 必须是非空数组")
+		return nil, ResponseOptions{}, errors.New("messages 必须是非空数组")
 	}
 	input, err := convertChatMessages(messages)
 	if err != nil {
-		return nil, err
+		return nil, ResponseOptions{}, err
 	}
 	target := map[string]json.RawMessage{"model": mustJSON(model), "input": mustJSON(input)}
-	copyFields(target, source, "stream", "temperature", "top_p", "presence_penalty", "frequency_penalty", "seed", "user", "parallel_tool_calls", "metadata", "store", "service_tier", "stop")
+	copyFields(target, source, "stream", "temperature", "top_p", "parallel_tool_calls", "metadata", "store", "service_tier")
+	if raw := source["user"]; !isEmptyJSON(raw) {
+		var user string
+		if json.Unmarshal(raw, &user) != nil || strings.TrimSpace(user) == "" {
+			return nil, ResponseOptions{}, errors.New("user 必须是非空字符串")
+		}
+		target["safety_identifier"] = mustJSON(strings.TrimSpace(user))
+	}
+	stopSequences, err := parseChatStopSequences(source["stop"])
+	if err != nil {
+		return nil, ResponseOptions{}, err
+	}
 	if raw := firstJSON(source["max_completion_tokens"], source["max_tokens"]); !isEmptyJSON(raw) {
 		target["max_output_tokens"] = raw
 	}
 	if raw := source["response_format"]; !isEmptyJSON(raw) {
 		format, err := convertResponseFormat(raw)
 		if err != nil {
-			return nil, err
+			return nil, ResponseOptions{}, err
 		}
 		target["text"] = mustJSON(map[string]json.RawMessage{"format": format})
 	}
 	if raw := source["reasoning_effort"]; !isEmptyJSON(raw) {
 		target["reasoning"] = mustJSON(map[string]json.RawMessage{"effort": raw})
 	}
+	var tools []any
 	if raw := source["tools"]; !isEmptyJSON(raw) {
-		tools, err := convertChatTools(raw)
+		tools, err = convertChatTools(raw)
 		if err != nil {
-			return nil, err
+			return nil, ResponseOptions{}, err
 		}
+	}
+	if !isEmptyJSON(source["web_search_options"]) && !containsToolType(tools, "web_search") {
+		tools = append(tools, map[string]any{"type": "web_search"})
+	}
+	if len(tools) > 0 {
 		target["tools"] = mustJSON(tools)
 	}
 	if raw := source["tool_choice"]; !isEmptyJSON(raw) {
 		choice, err := convertChatToolChoice(raw)
 		if err != nil {
-			return nil, err
+			return nil, ResponseOptions{}, err
 		}
 		target["tool_choice"] = choice
 	}
-	return json.Marshal(target)
+	converted, err := json.Marshal(target)
+	return converted, ResponseOptions{StopSequences: stopSequences}, err
+}
+
+func parseChatStopSequences(raw json.RawMessage) ([]string, error) {
+	if isEmptyJSON(raw) {
+		return nil, nil
+	}
+	var single string
+	if json.Unmarshal(raw, &single) == nil {
+		if single == "" {
+			return nil, errors.New("stop 不能为空")
+		}
+		return []string{single}, nil
+	}
+	var values []string
+	if json.Unmarshal(raw, &values) != nil || len(values) == 0 {
+		return nil, errors.New("stop 必须是字符串或非空字符串数组")
+	}
+	if len(values) > 4 {
+		return nil, errors.New("stop 最多包含 4 个序列")
+	}
+	for index, value := range values {
+		if value == "" {
+			return nil, fmt.Errorf("stop[%d] 不能为空", index)
+		}
+	}
+	return values, nil
 }
 
 type chatMessage struct {
@@ -163,10 +207,14 @@ func convertAssistantToolCalls(raw json.RawMessage) ([]any, error) {
 	}
 	result := make([]any, 0, len(calls))
 	for _, call := range calls {
-		if strings.TrimSpace(call.ID) == "" || strings.TrimSpace(call.Function.Name) == "" || !json.Valid([]byte(call.Function.Arguments)) {
-			return nil, errors.New("assistant.tool_calls 缺少有效 id、name 或 arguments")
+		if strings.TrimSpace(call.ID) == "" || strings.TrimSpace(call.Function.Name) == "" {
+			return nil, errors.New("assistant.tool_calls 缺少有效 id 或 name")
 		}
-		result = append(result, map[string]any{"type": "function_call", "call_id": call.ID, "name": call.Function.Name, "arguments": call.Function.Arguments})
+		arguments := call.Function.Arguments
+		if arguments == "" {
+			arguments = "{}"
+		}
+		result = append(result, map[string]any{"type": "function_call", "call_id": call.ID, "name": call.Function.Name, "arguments": arguments})
 	}
 	return result, nil
 }
@@ -183,7 +231,21 @@ func convertChatTools(raw json.RawMessage) ([]any, error) {
 		if typeName != "function" {
 			var value any
 			_ = json.Unmarshal(mustJSON(tool), &value)
-			result = append(result, value)
+			object, _ := value.(map[string]any)
+			switch typeName {
+			case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
+				converted := map[string]any{"type": "web_search"}
+				if filters, ok := object["filters"].(map[string]any); ok {
+					if domains, exists := filters["allowed_domains"]; exists {
+						converted["filters"] = map[string]any{"allowed_domains": domains}
+					}
+				} else if domains, exists := object["allowed_domains"]; exists {
+					converted["filters"] = map[string]any{"allowed_domains": domains}
+				}
+				result = append(result, converted)
+			default:
+				result = append(result, value)
+			}
 			continue
 		}
 		var function map[string]any
@@ -194,6 +256,16 @@ func convertChatTools(raw json.RawMessage) ([]any, error) {
 		result = append(result, function)
 	}
 	return result, nil
+}
+
+func containsToolType(tools []any, kind string) bool {
+	for _, raw := range tools {
+		tool, ok := raw.(map[string]any)
+		if ok && tool["type"] == kind {
+			return true
+		}
+	}
+	return false
 }
 
 func convertChatToolChoice(raw json.RawMessage) (json.RawMessage, error) {

--- a/backend/internal/infra/provider/conversation/chat_response.go
+++ b/backend/internal/infra/provider/conversation/chat_response.go
@@ -21,11 +21,16 @@ func chatResponse(value parsedResponse) map[string]any {
 			})
 		}
 		message["tool_calls"] = calls
+	} else if value.Refusal != "" {
+		finishReason = "content_filter"
 	} else if value.Status == "incomplete" {
 		finishReason = "length"
 	}
 	if value.Refusal != "" {
 		message["refusal"] = value.Refusal
+	}
+	if len(value.Annotations) > 0 {
+		message["annotations"] = value.Annotations
 	}
 	id := strings.Replace(value.ID, "resp_", "chatcmpl_", 1)
 	return map[string]any{
@@ -36,10 +41,20 @@ func chatResponse(value parsedResponse) map[string]any {
 }
 
 func chatUsage(value responseUsage) map[string]any {
+	total := value.TotalTokens
+	if total == 0 {
+		total = value.InputTokens + value.OutputTokens
+	}
 	return map[string]any{
 		"prompt_tokens": value.InputTokens, "completion_tokens": value.OutputTokens,
-		"total_tokens":              value.InputTokens + value.OutputTokens,
-		"prompt_tokens_details":     map[string]any{"cached_tokens": value.InputTokensDetails.CachedTokens},
-		"completion_tokens_details": map[string]any{"reasoning_tokens": value.OutputTokensDetails.ReasoningTokens},
+		"total_tokens":               total,
+		"prompt_tokens_details":      map[string]any{"cached_tokens": value.InputTokensDetails.CachedTokens},
+		"completion_tokens_details":  map[string]any{"reasoning_tokens": value.OutputTokensDetails.ReasoningTokens},
+		"cost_in_usd_ticks":          value.CostInUSDTicks,
+		"num_sources_used":           value.NumSourcesUsed,
+		"num_server_side_tools_used": value.NumServerSideToolsUsed,
+		"context_details": map[string]any{
+			"input_tokens": value.ContextDetails.InputTokens, "output_tokens": value.ContextDetails.OutputTokens,
+		},
 	}
 }

--- a/backend/internal/infra/provider/conversation/chat_stream.go
+++ b/backend/internal/infra/provider/conversation/chat_stream.go
@@ -1,7 +1,6 @@
 package conversation
 
 import (
-	"encoding/json"
 	"io"
 	"strings"
 )
@@ -15,7 +14,14 @@ func (c *streamConverter) startChat() error {
 }
 
 func (c *streamConverter) textDeltaChat(delta string) error {
-	return c.chatDelta(map[string]any{"content": delta})
+	emit, matched := c.stopFilter.Push(delta)
+	if matched != "" {
+		c.stopSequence = matched
+	}
+	if emit == "" {
+		return nil
+	}
+	return c.chatDelta(map[string]any{"content": emit})
 }
 
 func (c *streamConverter) chatDelta(delta map[string]any) error {
@@ -28,11 +34,14 @@ func (c *streamConverter) chatDelta(delta map[string]any) error {
 	})
 }
 
-func (c *streamConverter) toolStartChat(item responseItem, outputIndex int) error {
+func (c *streamConverter) toolStartChat(item responseItem, _ int) error {
 	if err := c.start(); err != nil {
 		return err
 	}
-	tool := streamTool{Index: outputIndex, ID: item.CallID, Name: item.Name, Arguments: item.Arguments}
+	if _, exists := c.tools[item.ID]; exists {
+		return nil
+	}
+	tool := streamTool{Index: len(c.tools), ID: item.CallID, Name: item.Name, Arguments: item.Arguments}
 	c.tools[item.ID] = tool
 	return c.chatDelta(map[string]any{"tool_calls": []any{map[string]any{
 		"index": tool.Index, "id": tool.ID, "type": "function", "function": map[string]any{"name": tool.Name, "arguments": ""},
@@ -70,9 +79,18 @@ func (c *streamConverter) toolArgumentsDoneChat(itemID, arguments string) error 
 }
 
 func (c *streamConverter) doneChat(status string) error {
+	if c.stopSequence == "" {
+		if pending := c.stopFilter.Flush(); pending != "" {
+			if err := c.chatDelta(map[string]any{"content": pending}); err != nil {
+				return err
+			}
+		}
+	}
 	finishReason := "stop"
 	if len(c.tools) > 0 {
 		finishReason = "tool_calls"
+	} else if c.refused {
+		finishReason = "content_filter"
 	} else if status == "incomplete" {
 		finishReason = "length"
 	}
@@ -88,9 +106,23 @@ func (c *streamConverter) doneChat(status string) error {
 }
 
 func (c *streamConverter) streamErrorChat(data []byte) error {
-	if err := c.writeData(json.RawMessage(data)); err != nil {
+	if err := c.writeData(map[string]any{"error": normalizeOpenAIStreamError(streamErrorValue(data))}); err != nil {
 		return err
 	}
 	_, err := io.WriteString(c.writer, "data: [DONE]\n\n")
 	return err
+}
+
+func normalizeOpenAIStreamError(value any) map[string]any {
+	result := map[string]any{"message": "Upstream request failed", "type": "api_error"}
+	if object, ok := value.(map[string]any); ok {
+		for _, key := range []string{"message", "type", "code", "param"} {
+			if field, exists := object[key]; exists && field != nil {
+				result[key] = field
+			}
+		}
+	} else if message, ok := value.(string); ok && strings.TrimSpace(message) != "" {
+		result["message"] = message
+	}
+	return result
 }

--- a/backend/internal/infra/provider/conversation/conversation_test.go
+++ b/backend/internal/infra/provider/conversation/conversation_test.go
@@ -9,8 +9,10 @@ import (
 
 func TestConvertChatRequestToResponses(t *testing.T) {
 	body := []byte(`{
-		"model":"public-chat","stream":true,"max_completion_tokens":512,
-		"messages":[
+			"model":"public-chat","stream":true,"max_completion_tokens":512,
+			"user":"client-user","presence_penalty":0,"frequency_penalty":0,
+			"web_search_options":{"search_context_size":"medium"},
+			"messages":[
 			{"role":"system","content":"be concise"},
 			{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AA=="}}]},
 			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"x\"}"}}]},
@@ -27,8 +29,11 @@ func TestConvertChatRequestToResponses(t *testing.T) {
 	if err := json.Unmarshal(converted, &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload["model"] != "grok-4.5" || payload["max_output_tokens"] != float64(512) || payload["stream"] != true {
+	if payload["model"] != "grok-4.5" || payload["max_output_tokens"] != float64(512) || payload["stream"] != true || payload["safety_identifier"] != "client-user" {
 		t.Fatalf("request fields = %#v", payload)
+	}
+	if _, exists := payload["user"]; exists {
+		t.Fatalf("Chat user 不应原样转发到 Responses: %#v", payload)
 	}
 	input := payload["input"].([]any)
 	if len(input) != 4 || input[2].(map[string]any)["type"] != "function_call" || input[3].(map[string]any)["type"] != "function_call_output" {
@@ -39,8 +44,107 @@ func TestConvertChatRequestToResponses(t *testing.T) {
 		t.Fatalf("image content = %#v", content)
 	}
 	tools := payload["tools"].([]any)
-	if tools[0].(map[string]any)["name"] != "lookup" || tools[0].(map[string]any)["type"] != "function" {
+	if len(tools) != 2 || tools[0].(map[string]any)["name"] != "lookup" || tools[0].(map[string]any)["type"] != "function" || tools[1].(map[string]any)["type"] != "web_search" {
 		t.Fatalf("tools = %#v", tools)
+	}
+}
+
+func TestConvertChatIgnoresSamplingFieldsWithoutResponsesEquivalent(t *testing.T) {
+	body := []byte(`{
+		"model":"public","messages":[{"role":"user","content":"hi"}],
+		"presence_penalty":0.5,"frequency_penalty":-0.5,"seed":42
+	}`)
+	converted, _, err := ConvertRequestWithOptions(body, "grok-4.5", OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"presence_penalty", "frequency_penalty", "seed"} {
+		if _, exists := payload[field]; exists {
+			t.Fatalf("不受 Responses 支持的 %s 不应转发给上游: %#v", field, payload)
+		}
+	}
+}
+
+func TestConvertChatStopSequencesLocally(t *testing.T) {
+	request := []byte(`{
+		"model":"public-chat","stop":["STOP","END"],
+		"messages":[{"role":"user","content":"continue"}]
+	}`)
+	converted, options, err := ConvertRequestWithOptions(request, "grok-4.5", OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["stop"]; exists {
+		t.Fatalf("Responses 请求不应包含不受支持的 stop 字段: %#v", payload)
+	}
+	if len(options.StopSequences) != 2 || options.StopSequences[0] != "STOP" || options.StopSequences[1] != "END" {
+		t.Fatalf("stop options = %#v", options.StopSequences)
+	}
+
+	body := []byte(`{"id":"resp_1","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ABCSTOPXYZ"}]}]}`)
+	data, err := ConvertResponseJSONWithOptions(body, OperationChat, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatal(err)
+	}
+	message := response["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if message["content"] != "ABC" {
+		t.Fatalf("chat response = %#v", response)
+	}
+}
+
+func TestConvertChatPreservesOpaqueToolArgumentsHistory(t *testing.T) {
+	body := []byte(`{
+		"model":"public","messages":[
+			{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{partial"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"failed"}
+		]
+	}`)
+	converted, _, err := ConvertRequestWithOptions(body, "grok-4.5", OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	call := payload["input"].([]any)[0].(map[string]any)
+	if call["arguments"] != "{partial" {
+		t.Fatalf("function call = %#v", call)
+	}
+}
+
+func TestConvertChatStopSequencesStream(t *testing.T) {
+	stream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5","status":"in_progress"}}`, "",
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"ABCST"}`, "",
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","delta":"OPXYZ"}`, "",
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":2}}}`, "", "",
+	}, "\n")
+	converted, err := io.ReadAll(ConvertResponseStreamWithOptions(
+		io.NopCloser(strings.NewReader(stream)), OperationChat, ResponseOptions{StopSequences: []string{"STOP"}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(converted)
+	if strings.Contains(text, "STOP") || strings.Contains(text, "XYZ") || !strings.Contains(text, `"content":"ABC"`) || !strings.Contains(text, `"finish_reason":"stop"`) {
+		t.Fatalf("chat stream = %s", text)
 	}
 }
 
@@ -230,13 +334,20 @@ func TestConvertAnthropicMessagesValidatesToolRelationships(t *testing.T) {
 	}
 }
 
-func TestConvertAnthropicMessagesRejectsUnrepresentableTopK(t *testing.T) {
-	_, _, err := ConvertRequestWithOptions([]byte(`{
+func TestConvertAnthropicMessagesIgnoresUnrepresentableTopK(t *testing.T) {
+	converted, _, err := ConvertRequestWithOptions([]byte(`{
 		"model":"public","max_tokens":64,"top_k":10,
 		"messages":[{"role":"user","content":"hello"}]
 	}`), "grok-4.5", OperationMessages)
-	if err == nil || !strings.Contains(err.Error(), "top_k") {
-		t.Fatalf("error = %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["top_k"]; exists {
+		t.Fatalf("top_k 不应转发到 Responses: %#v", payload)
 	}
 }
 
@@ -251,16 +362,23 @@ func TestConvertAnthropicWebSearchControls(t *testing.T) {
 	var payload map[string]any
 	_ = json.Unmarshal(converted, &payload)
 	tool := payload["tools"].([]any)[0].(map[string]any)
-	if tool["type"] != "web_search" || tool["max_uses"] != float64(3) || len(tool["allowed_domains"].([]any)) != 1 || tool["user_location"].(map[string]any)["country"] != "US" {
+	domains := tool["filters"].(map[string]any)["allowed_domains"].([]any)
+	if tool["type"] != "web_search" || len(domains) != 1 || domains[0] != "example.com" || len(tool) != 2 {
 		t.Fatalf("tool = %#v", tool)
 	}
 
-	_, _, err = ConvertRequestWithOptions([]byte(`{
+	converted, _, err = ConvertRequestWithOptions([]byte(`{
 		"model":"public","max_tokens":64,"messages":[{"role":"user","content":"search"}],
 		"tools":[{"type":"web_search_20250305","name":"web_search","search_context_size":"high"}]
 	}`), "grok-4.5", OperationMessages)
-	if err == nil || !strings.Contains(err.Error(), "search_context_size") {
-		t.Fatalf("error = %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload = nil
+	_ = json.Unmarshal(converted, &payload)
+	tool = payload["tools"].([]any)[0].(map[string]any)
+	if len(tool) != 1 || tool["type"] != "web_search" {
+		t.Fatalf("downgraded tool = %#v", tool)
 	}
 }
 
@@ -269,10 +387,10 @@ func TestConvertResponsesJSONToChatAndMessages(t *testing.T) {
 		"id":"resp_1","object":"response","created_at":123,"model":"grok-4.5","status":"completed",
 		"output":[
 			{"type":"reasoning","summary":[{"type":"summary_text","text":"reason"}]},
-			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello","annotations":[{"type":"url_citation","url":"https://example.com","title":"Example"}]}]},
 			{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"x\"}"}
 		],
-		"usage":{"input_tokens":10,"output_tokens":5,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":1}}
+		"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":1},"cost_in_usd_ticks":158500,"num_sources_used":3,"num_server_side_tools_used":2,"context_details":{"input_tokens":9,"output_tokens":4}}
 	}`)
 	chatData, err := ConvertResponseJSON(body, OperationChat)
 	if err != nil {
@@ -285,6 +403,13 @@ func TestConvertResponsesJSONToChatAndMessages(t *testing.T) {
 	if chat["object"] != "chat.completion" || choice["finish_reason"] != "tool_calls" || message["reasoning_content"] != "reason" {
 		t.Fatalf("chat = %#v", chat)
 	}
+	if annotations := message["annotations"].([]any); len(annotations) != 1 || annotations[0].(map[string]any)["url"] != "https://example.com" {
+		t.Fatalf("chat annotations = %#v", message)
+	}
+	chatUsage := chat["usage"].(map[string]any)
+	if chatUsage["cost_in_usd_ticks"] != float64(158500) || chatUsage["num_sources_used"] != float64(3) || chatUsage["context_details"].(map[string]any)["input_tokens"] != float64(9) {
+		t.Fatalf("chat usage = %#v", chatUsage)
+	}
 
 	messagesData, err := ConvertResponseJSON(body, OperationMessages)
 	if err != nil {
@@ -295,6 +420,10 @@ func TestConvertResponsesJSONToChatAndMessages(t *testing.T) {
 	content := messages["content"].([]any)
 	if messages["type"] != "message" || messages["stop_reason"] != "tool_use" || content[1].(map[string]any)["type"] != "tool_use" {
 		t.Fatalf("messages = %#v", messages)
+	}
+	messagesUsage := messages["usage"].(map[string]any)
+	if messagesUsage["cost_in_usd_ticks"] != float64(158500) || messagesUsage["num_server_side_tools_used"] != float64(2) || messagesUsage["context_details"].(map[string]any)["output_tokens"] != float64(4) {
+		t.Fatalf("messages usage = %#v", messagesUsage)
 	}
 }
 
@@ -324,6 +453,73 @@ func TestConvertResponsesJSONToMessagesThinkingAndStop(t *testing.T) {
 	tool := content[2].(map[string]any)
 	if thinking["type"] != "thinking" || thinking["signature"] != "signature" || content[1].(map[string]any)["text"] != "ABC" || tool["id"] != "toolu_call_1" {
 		t.Fatalf("content = %#v", content)
+	}
+}
+
+func TestConvertResponsesJSONUsesRawReasoningContentBeforeSummary(t *testing.T) {
+	body := []byte(`{
+		"id":"resp_reasoning","model":"grok-4.5","status":"completed",
+		"output":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"raw thought"}],"summary":[{"type":"summary_text","text":"summary"}]}]
+	}`)
+	data, err := ConvertResponseJSON(body, OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatal(err)
+	}
+	message := response["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if message["reasoning_content"] != "raw thought" {
+		t.Fatalf("message = %#v", message)
+	}
+}
+
+func TestConvertResponsesRefusalAcrossChatAndMessages(t *testing.T) {
+	body := []byte(`{"id":"resp_refusal","status":"completed","output":[{"type":"message","content":[{"type":"refusal","refusal":"Cannot comply"}]}]}`)
+	chatData, err := ConvertResponseJSON(body, OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var chat map[string]any
+	_ = json.Unmarshal(chatData, &chat)
+	choice := chat["choices"].([]any)[0].(map[string]any)
+	if choice["finish_reason"] != "content_filter" || choice["message"].(map[string]any)["refusal"] != "Cannot comply" {
+		t.Fatalf("chat refusal = %#v", chat)
+	}
+	messagesData, err := ConvertResponseJSON(body, OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var messages map[string]any
+	_ = json.Unmarshal(messagesData, &messages)
+	if messages["stop_reason"] != "refusal" {
+		t.Fatalf("messages refusal = %#v", messages)
+	}
+}
+
+func TestConvertResponsesStreamRefusalAcrossChatAndMessages(t *testing.T) {
+	source := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_refusal","model":"grok-4.5"}}`, "",
+		`event: response.refusal.delta`,
+		`data: {"type":"response.refusal.delta","delta":"Cannot comply"}`, "",
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"status":"completed"}}`, "", "",
+	}, "\n")
+	chat, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationChat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(chat); !strings.Contains(text, `"refusal":"Cannot comply"`) || !strings.Contains(text, `"finish_reason":"content_filter"`) {
+		t.Fatalf("chat refusal stream = %s", text)
+	}
+	messages, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(source)), OperationMessages))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(messages); !strings.Contains(text, `"text":"Cannot comply"`) || !strings.Contains(text, `"stop_reason":"refusal"`) {
+		t.Fatalf("messages refusal stream = %s", text)
 	}
 }
 
@@ -414,8 +610,8 @@ func TestConvertResponsesStreamChatErrorIsTerminal(t *testing.T) {
 		t.Fatal(err)
 	}
 	value := string(converted)
-	if !strings.Contains(value, `"type":"response.failed"`) {
-		t.Fatalf("missing upstream failure: %s", value)
+	if !strings.Contains(value, `"error":{"message":"upstream failed","type":"api_error"}`) {
+		t.Fatalf("missing normalized upstream failure: %s", value)
 	}
 	if strings.Contains(value, `"finish_reason":"stop"`) {
 		t.Fatalf("error stream must not end successfully: %s", value)
@@ -425,6 +621,24 @@ func TestConvertResponsesStreamChatErrorIsTerminal(t *testing.T) {
 	}
 	if strings.Count(value, "data: [DONE]") != 1 {
 		t.Fatalf("error stream must send one terminator: %s", value)
+	}
+}
+
+func TestConvertResponsesStreamMessagesNormalizesTerminalError(t *testing.T) {
+	stream := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"message":"quota denied","code":"forbidden"}}}`, "", "",
+	}, "\n")
+	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationMessages))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(converted)
+	if !strings.Contains(text, `event: error`) || !strings.Contains(text, `"type":"permission_error"`) || !strings.Contains(text, `"message":"quota denied"`) {
+		t.Fatalf("messages error stream = %s", text)
+	}
+	if strings.Contains(text, "message_stop") {
+		t.Fatalf("failed stream must not emit message_stop: %s", text)
 	}
 }
 
@@ -486,6 +700,45 @@ func TestConvertResponsesStreamEmitsDoneOnlyToolArguments(t *testing.T) {
 	}
 }
 
+func TestConvertResponsesStreamChatUsesContiguousToolIndexes(t *testing.T) {
+	stream := strings.Join([]string{
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"reasoning_1","type":"reasoning"}}`, "",
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":2,"item":{"id":"item_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"{}"}}`, "",
+		`event: response.output_item.done`,
+		`data: {"type":"response.output_item.done","output_index":2,"item":{"id":"item_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"{}"}}`, "",
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"status":"completed"}}`, "", "",
+	}, "\n")
+	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(converted)
+	if !strings.Contains(text, `"tool_calls":[{"function":{"arguments":"","name":"Read"},"id":"call_1","index":0`) || strings.Contains(text, `"index":2`) {
+		t.Fatalf("chat tool stream = %s", text)
+	}
+}
+
+func TestConvertResponsesStreamChatPreservesAnnotations(t *testing.T) {
+	stream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.5"}}`, "",
+		`event: response.output_text.annotation.added`,
+		`data: {"type":"response.output_text.annotation.added","annotation":{"type":"url_citation","url":"https://example.com","title":"Example"}}`, "",
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"status":"completed"}}`, "", "",
+	}, "\n")
+	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(converted); !strings.Contains(text, `"annotations":[{"title":"Example","type":"url_citation","url":"https://example.com"}]`) {
+		t.Fatalf("chat annotation stream = %s", text)
+	}
+}
+
 func TestConvertResponsesStreamMessagesInputTokens(t *testing.T) {
 	stream := strings.Join([]string{
 		`event: response.created`,
@@ -493,7 +746,7 @@ func TestConvertResponsesStreamMessagesInputTokens(t *testing.T) {
 		`event: response.output_text.delta`,
 		`data: {"type":"response.output_text.delta","delta":"hello"}`, "",
 		`event: response.completed`,
-		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","usage":{"input_tokens":194,"output_tokens":7}}}`, "", "",
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.5","status":"completed","usage":{"input_tokens":194,"output_tokens":7,"cost_in_usd_ticks":9000,"context_details":{"input_tokens":180,"output_tokens":6}}}}`, "", "",
 	}, "\n")
 	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationMessages))
 	if err != nil {
@@ -503,5 +756,8 @@ func TestConvertResponsesStreamMessagesInputTokens(t *testing.T) {
 
 	if !strings.Contains(text, `"input_tokens":194`) {
 		t.Fatalf("message_delta should contain input_tokens from response.completed usage:\n%s", text)
+	}
+	if !strings.Contains(text, `"cost_in_usd_ticks":9000`) || !strings.Contains(text, `"input_tokens":180`) {
+		t.Fatalf("message_delta should retain upstream usage extensions:\n%s", text)
 	}
 }

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -28,9 +28,6 @@ func convertMessagesRequest(body []byte, model string) ([]byte, ResponseOptions,
 			return nil, ResponseOptions{}, fmt.Errorf("stop_sequences[%d] 不能为空", index)
 		}
 	}
-	if !isEmptyJSON(request.TopK) {
-		return nil, ResponseOptions{}, errors.New("Messages top_k 无法等价映射到 Responses API")
-	}
 	thinkingEnabled := false
 	if request.Thinking != nil {
 		switch request.Thinking.Type {
@@ -175,6 +172,7 @@ func convertAnthropicMessages(messages []anthropicMessage, declaredTools map[str
 	instructions := make([]string, 0)
 	pendingCalls := make(map[string]struct{})
 	usedCalls := make(map[string]struct{})
+	serverSearches := make(map[string]map[string]any)
 	for messageIndex, message := range messages {
 		role := strings.ToLower(strings.TrimSpace(message.Role))
 		if role == "system" || role == "developer" {
@@ -311,6 +309,38 @@ func convertAnthropicMessages(messages []anthropicMessage, declaredTools map[str
 					return nil, nil, fmt.Errorf("%s.data 无效", path)
 				}
 				input = append(input, map[string]any{"type": "reasoning", "encrypted_content": data})
+			case "server_tool_use":
+				if role != "assistant" {
+					continue
+				}
+				var value struct {
+					ID    string         `json:"id"`
+					Name  string         `json:"name"`
+					Input map[string]any `json:"input"`
+				}
+				encoded, _ := json.Marshal(block)
+				if json.Unmarshal(encoded, &value) != nil || value.Name != "web_search" || strings.TrimSpace(value.ID) == "" {
+					continue
+				}
+				flushMessage()
+				query, _ := value.Input["query"].(string)
+				call := map[string]any{
+					"type": "web_search_call", "id": value.ID, "status": "completed",
+					"action": map[string]any{"type": "search", "query": query},
+				}
+				serverSearches[value.ID] = call
+				input = append(input, call)
+			case "web_search_tool_result":
+				if role != "assistant" {
+					continue
+				}
+				var toolUseID string
+				_ = json.Unmarshal(block["tool_use_id"], &toolUseID)
+				call := serverSearches[strings.TrimSpace(toolUseID)]
+				if call == nil {
+					continue
+				}
+				applyAnthropicWebSearchResult(call, block["content"])
 			default:
 				return nil, nil, fmt.Errorf("当前不支持 Anthropic content.type=%q", typeName)
 			}
@@ -324,6 +354,30 @@ func convertAnthropicMessages(messages []anthropicMessage, declaredTools map[str
 		return nil, nil, errors.New("messages 必须为每个 tool_use 提供 tool_result")
 	}
 	return input, instructions, nil
+}
+
+func applyAnthropicWebSearchResult(call map[string]any, raw json.RawMessage) {
+	var results []map[string]any
+	if json.Unmarshal(raw, &results) == nil {
+		sources := make([]any, 0, len(results))
+		for _, result := range results {
+			if result["type"] != "web_search_result" {
+				continue
+			}
+			url, _ := result["url"].(string)
+			if strings.TrimSpace(url) != "" {
+				sources = append(sources, map[string]any{"type": "url", "url": strings.TrimSpace(url)})
+			}
+		}
+		if action, ok := call["action"].(map[string]any); ok && len(sources) > 0 {
+			action["sources"] = sources
+		}
+		return
+	}
+	var result map[string]any
+	if json.Unmarshal(raw, &result) == nil && result["type"] == "web_search_tool_result_error" {
+		call["status"] = "failed"
+	}
 }
 
 func anthropicSystemText(raw json.RawMessage) (string, error) {
@@ -618,28 +672,31 @@ func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (
 		switch key {
 		case "type", "name", "cache_control":
 			continue
-		case "max_uses", "allowed_domains", "blocked_domains", "user_location":
+		case "allowed_domains":
 			var value any
 			if json.Unmarshal(raw, &value) != nil {
 				return nil, fmt.Errorf("tools[%d].%s 无效", index, key)
 			}
-			if key == "allowed_domains" || key == "blocked_domains" {
-				domains, ok := value.([]any)
-				if !ok {
-					return nil, fmt.Errorf("tools[%d].%s 必须是字符串数组", index, key)
-				}
-				if len(domains) > 5 {
-					return nil, fmt.Errorf("tools[%d].%s 不能超过 5 个域名", index, key)
-				}
-				for domainIndex, domain := range domains {
-					if text, ok := domain.(string); !ok || strings.TrimSpace(text) == "" {
-						return nil, fmt.Errorf("tools[%d].%s[%d] 必须是非空字符串", index, key, domainIndex)
-					}
+			domains, ok := value.([]any)
+			if !ok {
+				return nil, fmt.Errorf("tools[%d].%s 必须是字符串数组", index, key)
+			}
+			if len(domains) > 5 {
+				return nil, fmt.Errorf("tools[%d].%s 不能超过 5 个域名", index, key)
+			}
+			for domainIndex, domain := range domains {
+				if text, ok := domain.(string); !ok || strings.TrimSpace(text) == "" {
+					return nil, fmt.Errorf("tools[%d].%s[%d] 必须是非空字符串", index, key, domainIndex)
 				}
 			}
-			converted[key] = value
+			converted["filters"] = map[string]any{"allowed_domains": value}
+		case "max_uses", "blocked_domains", "user_location", "search_context_size":
+			// Build 0.2.101 只支持 allowed_domains；其余 Anthropic
+			// 可选控制字段不转发，避免上游因未知参数拒绝整个请求。
+			continue
 		default:
-			return nil, fmt.Errorf("Grok Build 0.2.99 不支持 Anthropic web search 字段 tools[%d].%s", index, key)
+			// 对未来新增的 hosted-tool 可选字段保持向前兼容。
+			continue
 		}
 	}
 	return converted, nil

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -44,10 +44,10 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 		stopReason = "tool_use"
 	} else if value.StopSequence != "" {
 		stopReason = "stop_sequence"
-	} else if value.Status == "incomplete" {
-		stopReason = "max_tokens"
 	} else if value.Refusal != "" {
 		stopReason = "refusal"
+	} else if value.Status == "incomplete" {
+		stopReason = "max_tokens"
 	}
 	return map[string]any{
 		"id": anthropicMessageID(value.ID), "type": "message", "role": "assistant",
@@ -56,7 +56,7 @@ func messagesResponse(value parsedResponse, options ResponseOptions) map[string]
 	}
 }
 
-func applyAnthropicStopSequences(text string, sequences []string) (string, string) {
+func applyStopSequences(text string, sequences []string) (string, string) {
 	matchAt := -1
 	matched := ""
 	for _, sequence := range sequences {
@@ -108,6 +108,12 @@ func anthropicUsage(value responseUsage, webSearchRequests int) map[string]any {
 	usage := map[string]any{
 		"input_tokens": value.InputTokens, "output_tokens": value.OutputTokens,
 		"cache_creation_input_tokens": 0, "cache_read_input_tokens": value.InputTokensDetails.CachedTokens,
+		"cost_in_usd_ticks":          value.CostInUSDTicks,
+		"num_sources_used":           value.NumSourcesUsed,
+		"num_server_side_tools_used": value.NumServerSideToolsUsed,
+		"context_details": map[string]any{
+			"input_tokens": value.ContextDetails.InputTokens, "output_tokens": value.ContextDetails.OutputTokens,
+		},
 	}
 	if webSearchRequests > 0 {
 		usage["server_tool_use"] = map[string]any{"web_search_requests": webSearchRequests}
@@ -116,6 +122,11 @@ func anthropicUsage(value responseUsage, webSearchRequests int) map[string]any {
 }
 
 func anthropicErrorJSON(value any) []byte {
+	data, _ := json.Marshal(map[string]any{"type": "error", "error": normalizeAnthropicError(value)})
+	return data
+}
+
+func normalizeAnthropicError(value any) map[string]any {
 	message := "Upstream request failed"
 	errorType := "api_error"
 	if object, ok := value.(map[string]any); ok {
@@ -126,8 +137,7 @@ func anthropicErrorJSON(value any) []byte {
 	} else if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
 		message = text
 	}
-	data, _ := json.Marshal(map[string]any{"type": "error", "error": map[string]any{"type": errorType, "message": message}})
-	return data
+	return map[string]any{"type": errorType, "message": message}
 }
 
 func normalizeAnthropicErrorType(object map[string]any) string {

--- a/backend/internal/infra/provider/conversation/messages_stream.go
+++ b/backend/internal/infra/provider/conversation/messages_stream.go
@@ -269,13 +269,12 @@ func (c *streamConverter) doneMessages(status string) error {
 		stopReason = "tool_use"
 	} else if c.stopSequence != "" {
 		stopReason = "stop_sequence"
+	} else if c.refused {
+		stopReason = "refusal"
 	} else if status == "incomplete" {
 		stopReason = "max_tokens"
 	}
-	usage := map[string]any{"input_tokens": c.usage.InputTokens, "output_tokens": c.usage.OutputTokens}
-	if n := webSearchRequestCount(c.webSearch); n > 0 {
-		usage["server_tool_use"] = map[string]any{"web_search_requests": n}
-	}
+	usage := anthropicUsage(c.usage, webSearchRequestCount(c.webSearch))
 	if err := c.writeEvent("message_delta", map[string]any{
 		"type": "message_delta", "delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nullableAnthropicString(c.stopSequence)},
 		"usage": usage,
@@ -287,5 +286,5 @@ func (c *streamConverter) doneMessages(status string) error {
 }
 
 func (c *streamConverter) streamErrorMessages(data []byte) error {
-	return c.writeEvent("error", map[string]any{"type": "error", "error": map[string]any{"type": "api_error", "message": string(data)}})
+	return c.writeEvent("error", map[string]any{"type": "error", "error": normalizeAnthropicError(streamErrorValue(data))})
 }

--- a/backend/internal/infra/provider/conversation/request.go
+++ b/backend/internal/infra/provider/conversation/request.go
@@ -23,8 +23,7 @@ func ConvertRequest(body []byte, model, operation string) ([]byte, error) {
 func ConvertRequestWithOptions(body []byte, model, operation string) ([]byte, ResponseOptions, error) {
 	switch operation {
 	case OperationChat:
-		converted, err := convertChatRequest(body, model)
-		return converted, ResponseOptions{}, err
+		return convertChatRequest(body, model)
 	case OperationMessages:
 		return convertMessagesRequest(body, model)
 	default:

--- a/backend/internal/infra/provider/conversation/response.go
+++ b/backend/internal/infra/provider/conversation/response.go
@@ -48,15 +48,22 @@ type responseContent struct {
 }
 
 type responseUsage struct {
-	InputTokens        int64 `json:"input_tokens"`
-	OutputTokens       int64 `json:"output_tokens"`
-	TotalTokens        int64 `json:"total_tokens"`
-	InputTokensDetails struct {
+	InputTokens            int64 `json:"input_tokens"`
+	OutputTokens           int64 `json:"output_tokens"`
+	TotalTokens            int64 `json:"total_tokens"`
+	CostInUSDTicks         int64 `json:"cost_in_usd_ticks"`
+	NumSourcesUsed         int64 `json:"num_sources_used"`
+	NumServerSideToolsUsed int64 `json:"num_server_side_tools_used"`
+	InputTokensDetails     struct {
 		CachedTokens int64 `json:"cached_tokens"`
 	} `json:"input_tokens_details"`
 	OutputTokensDetails struct {
 		ReasoningTokens int64 `json:"reasoning_tokens"`
 	} `json:"output_tokens_details"`
+	ContextDetails struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"context_details"`
 }
 
 type parsedResponse struct {
@@ -69,6 +76,7 @@ type parsedResponse struct {
 	Refusal      string
 	Calls        []responseItem
 	WebSearch    []webSearchCall
+	Annotations  []any
 	Usage        responseUsage
 	Status       string
 	StopSequence string
@@ -79,7 +87,7 @@ func ConvertResponseJSON(body []byte, operation string) ([]byte, error) {
 	return ConvertResponseJSONWithOptions(body, operation, ResponseOptions{})
 }
 
-// ConvertResponseJSONWithOptions 按原始 Messages 请求选项恢复 thinking 与 stop sequence。
+// ConvertResponseJSONWithOptions 按下游协议选项恢复 thinking、搜索与 stop sequence。
 func ConvertResponseJSONWithOptions(body []byte, operation string, options ResponseOptions) ([]byte, error) {
 	if operation == OperationResponses {
 		return body, nil
@@ -95,8 +103,10 @@ func ConvertResponseJSONWithOptions(body []byte, operation string, options Respo
 		return body, nil
 	}
 	parsed := parseResponse(envelope)
+	if operation == OperationMessages || operation == OperationChat {
+		parsed.Text, parsed.StopSequence = applyStopSequences(parsed.Text, options.StopSequences)
+	}
 	if operation == OperationMessages {
-		parsed.Text, parsed.StopSequence = applyAnthropicStopSequences(parsed.Text, options.StopSequences)
 		if !options.AnthropicWebSearch {
 			parsed.WebSearch = nil
 		}
@@ -121,6 +131,7 @@ func parseResponse(value responseEnvelope) parsedResponse {
 		case "message":
 			annotations = append(annotations, extractMessageAnnotations(item)...)
 			for _, content := range item.Content {
+				parsed.Annotations = append(parsed.Annotations, content.Annotations...)
 				switch content.Type {
 				case "output_text":
 					parsed.Text += content.Text
@@ -129,9 +140,18 @@ func parseResponse(value responseEnvelope) parsedResponse {
 				}
 			}
 		case "reasoning":
-			for _, summary := range item.Summary {
-				parsed.Reasoning += summary.Text
+			reasoning := ""
+			for _, content := range item.Content {
+				if content.Type == "reasoning_text" {
+					reasoning += content.Text
+				}
 			}
+			if reasoning == "" {
+				for _, summary := range item.Summary {
+					reasoning += summary.Text
+				}
+			}
+			parsed.Reasoning += reasoning
 			if item.Encrypted != "" {
 				parsed.Signature = item.Encrypted
 			}

--- a/backend/internal/infra/provider/conversation/server_web_search_test.go
+++ b/backend/internal/infra/provider/conversation/server_web_search_test.go
@@ -283,6 +283,37 @@ func TestConvertAnthropicWebSearchToolChoiceRequired(t *testing.T) {
 	}
 }
 
+func TestConvertAnthropicWebSearchHistoryBackToResponses(t *testing.T) {
+	converted, _, err := ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"server_tool_use","id":"ws_1","name":"web_search","input":{"query":"rust docs"}},
+				{"type":"web_search_tool_result","tool_use_id":"ws_1","content":[{"type":"web_search_result","title":"Rust","url":"https://doc.rust-lang.org"}]},
+				{"type":"text","text":"Use the Rust docs."}
+			]},
+			{"role":"user","content":"continue"}
+		]
+	}`), "grok-4.5", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	input := payload["input"].([]any)
+	if len(input) != 3 {
+		t.Fatalf("input = %#v", input)
+	}
+	call := input[0].(map[string]any)
+	action := call["action"].(map[string]any)
+	sources := action["sources"].([]any)
+	if call["type"] != "web_search_call" || call["id"] != "ws_1" || action["query"] != "rust docs" || sources[0].(map[string]any)["url"] != "https://doc.rust-lang.org" {
+		t.Fatalf("web search history = %#v", call)
+	}
+}
+
 func TestClientWebSearchFunctionNotPromoted(t *testing.T) {
 	converted, _, err := ConvertRequestWithOptions([]byte(`{
 		"model":"public","max_tokens":64,

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -17,7 +17,7 @@ func ConvertResponseStream(source io.ReadCloser, operation string) io.ReadCloser
 	return ConvertResponseStreamWithOptions(source, operation, ResponseOptions{})
 }
 
-// ConvertResponseStreamWithOptions 按原始 Messages 请求选项生成有序 Anthropic SSE。
+// ConvertResponseStreamWithOptions 按下游协议选项生成 Chat 或 Anthropic SSE。
 func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, options ResponseOptions) io.ReadCloser {
 	if operation == OperationResponses {
 		return source
@@ -59,6 +59,7 @@ type streamConverter struct {
 	options           ResponseOptions
 	stopFilter        *anthropicStreamStopFilter
 	stopSequence      string
+	refused           bool
 }
 
 type streamTool struct {
@@ -225,6 +226,23 @@ func (c *streamConverter) handle(event string, data []byte) error {
 			return c.bufferSearchText(delta)
 		}
 		return c.textDelta(delta)
+	case "response.refusal.delta":
+		var delta string
+		_ = json.Unmarshal(root["delta"], &delta)
+		c.refused = true
+		if c.operation == OperationChat {
+			return c.chatDelta(map[string]any{"refusal": delta})
+		}
+		return c.textDeltaMessages(delta)
+	case "response.output_text.annotation.added":
+		if c.operation != OperationChat {
+			return nil
+		}
+		var annotation any
+		if json.Unmarshal(root["annotation"], &annotation) != nil || annotation == nil {
+			return nil
+		}
+		return c.chatDelta(map[string]any{"annotations": []any{annotation}})
 	case "response.reasoning_summary_text.delta":
 		var delta string
 		_ = json.Unmarshal(root["delta"], &delta)
@@ -235,6 +253,9 @@ func (c *streamConverter) handle(event string, data []byte) error {
 	case "response.reasoning_text.delta":
 		var delta string
 		_ = json.Unmarshal(root["delta"], &delta)
+		if c.operation == OperationChat {
+			return c.chatDelta(map[string]any{"reasoning_content": delta})
+		}
 		if c.operation == OperationMessages {
 			return c.thinkingDelta(delta)
 		}
@@ -396,6 +417,25 @@ func (c *streamConverter) finish() error {
 		return nil
 	}
 	return c.done("")
+}
+
+func streamErrorValue(data []byte) any {
+	var root map[string]any
+	if json.Unmarshal(data, &root) != nil {
+		return strings.TrimSpace(string(data))
+	}
+	if response, ok := root["response"].(map[string]any); ok {
+		if value, exists := response["error"]; exists && value != nil {
+			return value
+		}
+	}
+	if value, exists := root["error"]; exists && value != nil {
+		return value
+	}
+	if message, ok := root["message"].(string); ok {
+		return message
+	}
+	return strings.TrimSpace(string(data))
 }
 
 func (c *streamConverter) writeData(value any) error {

--- a/backend/internal/infra/provider/provider.go
+++ b/backend/internal/infra/provider/provider.go
@@ -133,6 +133,9 @@ type Response struct {
 	UpstreamURL string
 	Diagnostic  *DiagnosticResponse
 	RateLimit   *RateLimitMetadata
+	// ModelCatalogChanged 表示上游推理响应中的模型目录 ETag 与该账号
+	// 最近一次成功 /models 同步的 ETag 不一致。
+	ModelCatalogChanged bool
 }
 
 const (

--- a/backend/internal/transport/http/account/handler.go
+++ b/backend/internal/transport/http/account/handler.go
@@ -284,6 +284,7 @@ type billingResponse struct {
 	PrepaidBalance       float64                  `json:"prepaidBalance"`
 	CreditUsagePercent   float64                  `json:"creditUsagePercent"`
 	IsUnifiedBillingUser bool                     `json:"isUnifiedBillingUser"`
+	OnDemandEnabled      *bool                    `json:"onDemandEnabled,omitempty"`
 	TopUpMethod          string                   `json:"topUpMethod,omitempty"`
 	UsagePeriodType      string                   `json:"usagePeriodType,omitempty"`
 	UsagePeriodStart     string                   `json:"usagePeriodStart,omitempty"`
@@ -297,6 +298,9 @@ type billingResponse struct {
 type billingHistoryResponse struct {
 	Year         int     `json:"year"`
 	Month        int     `json:"month"`
+	PeriodType   string  `json:"periodType,omitempty"`
+	PeriodStart  string  `json:"periodStart,omitempty"`
+	PeriodEnd    string  `json:"periodEnd,omitempty"`
 	IncludedUsed float64 `json:"includedUsed"`
 	OnDemandUsed float64 `json:"onDemandUsed"`
 	TotalUsed    float64 `json:"totalUsed"`
@@ -1047,9 +1051,13 @@ func newQuotaResponse(value accountapp.QuotaView) quotaResponse {
 func newBillingResponse(value accountdomain.Billing) billingResponse {
 	history := make([]billingHistoryResponse, 0, len(value.History))
 	for _, entry := range value.History {
-		history = append(history, billingHistoryResponse{Year: entry.Year, Month: entry.Month, IncludedUsed: entry.IncludedUsed, OnDemandUsed: entry.OnDemandUsed, TotalUsed: entry.TotalUsed})
+		history = append(history, billingHistoryResponse{
+			Year: entry.Year, Month: entry.Month,
+			PeriodType: entry.PeriodType, PeriodStart: entry.PeriodStart, PeriodEnd: entry.PeriodEnd,
+			IncludedUsed: entry.IncludedUsed, OnDemandUsed: entry.OnDemandUsed, TotalUsed: entry.TotalUsed,
+		})
 	}
-	return billingResponse{PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, Remaining: value.Remaining(), OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, History: history, SyncedAt: value.SyncedAt}
+	return billingResponse{PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, Remaining: value.Remaining(), OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, OnDemandEnabled: value.OnDemandEnabled, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, History: history, SyncedAt: value.SyncedAt}
 }
 
 func pagination(c *gin.Context) (int, int) {

--- a/backend/internal/transport/http/settings/security_test.go
+++ b/backend/internal/transport/http/settings/security_test.go
@@ -47,9 +47,9 @@ func TestSettingsResponseDoesNotExposeBuildTokenAuth(t *testing.T) {
 
 func TestSettingsResponseIncludesRecommendedBuildBaseline(t *testing.T) {
 	response := newSettingsResponse(settingsapp.Snapshot{RecommendedProviderBuild: settingsapp.ProviderBuildRecommendation{
-		ClientVersion: "0.2.99", UserAgent: "grok-shell/0.2.99 (linux; x86_64)",
+		ClientVersion: "0.2.101", UserAgent: "grok-shell/0.2.101 (linux; x86_64)",
 	}})
-	if response.RecommendedProviderBuild.ClientVersion != "0.2.99" || response.RecommendedProviderBuild.UserAgent == "" {
+	if response.RecommendedProviderBuild.ClientVersion != "0.2.101" || response.RecommendedProviderBuild.UserAgent == "" {
 		t.Fatalf("recommended build = %#v", response.RecommendedProviderBuild)
 	}
 }

--- a/frontend/src/features/accounts/accounts-api.ts
+++ b/frontend/src/features/accounts/accounts-api.ts
@@ -16,6 +16,7 @@ export type BillingDTO = {
   prepaidBalance: number;
   creditUsagePercent: number;
   isUnifiedBillingUser: boolean;
+  onDemandEnabled?: boolean;
   topUpMethod?: string;
   usagePeriodType?: string;
   usagePeriodStart?: string;
@@ -29,6 +30,9 @@ export type BillingDTO = {
 export type BillingHistoryDTO = {
   year: number;
   month: number;
+  periodType?: string;
+  periodStart?: string;
+  periodEnd?: string;
   includedUsed: number;
   onDemandUsed: number;
   totalUsed: number;
@@ -124,12 +128,13 @@ export type DevicePollDTO = {
 };
 
 const billingHistoryValidator = hasShape({
-  year: isNumber, month: isNumber, includedUsed: isNumber, onDemandUsed: isNumber, totalUsed: isNumber,
+  year: isNumber, month: isNumber, periodType: isOptional(isString), periodStart: isOptional(isString), periodEnd: isOptional(isString),
+  includedUsed: isNumber, onDemandUsed: isNumber, totalUsed: isNumber,
 });
 const billingValidator = hasShape({
   planCode: isOptional(isString), planName: isOptional(isString), monthlyLimit: isNumber, used: isNumber, remaining: isNumber,
   onDemandCap: isNumber, onDemandUsed: isNumber, prepaidBalance: isNumber, creditUsagePercent: isNumber,
-  isUnifiedBillingUser: isBoolean, topUpMethod: isOptional(isString), usagePeriodType: isOptional(isString),
+  isUnifiedBillingUser: isBoolean, onDemandEnabled: isOptional(isBoolean), topUpMethod: isOptional(isString), usagePeriodType: isOptional(isString),
   usagePeriodStart: isOptional(isString), usagePeriodEnd: isOptional(isString), billingPeriodStart: isOptional(isString),
   billingPeriodEnd: isOptional(isString), history: isOptional(isArrayOf(billingHistoryValidator)), syncedAt: isString,
 });


### PR DESCRIPTION
## Summary

Aligns the Grok Build provider with the official `xai-org/grok-build` 0.2.101 protocol and improves compatibility across:

- OpenAI Responses
- OpenAI Chat Completions
- Anthropic Messages

The compatibility layer now converts or safely downgrades optional client parameters whenever possible instead of rejecting every Codex or Claude Code request.

## Grok Build protocol

- Updated the recommended version and User-Agent to `0.2.101`.
- Aligned official request headers:
  - `x-authenticateresponse`
  - `x-grok-client-mode`
  - `x-grok-user-id`
  - `x-userid`
  - `x-email`
- Uses UUIDv4 request and agent IDs.
- Uses UUIDv7 for new sessions and stable UUIDv8 derivation for existing session keys.
- Removed obsolete headers and no longer fabricates `x-grok-turn-idx`.

## Billing and model synchronization

- Fetches Build billing once through `/billing?format=credits`.
- Supports the latest billing fields:
  - credit usage percentage
  - current billing period
  - monthly and on-demand usage
  - prepaid balance
  - unified billing status
  - on-demand enablement
  - billing history periods
- Stores newly observed billing fields in SQLite and PostgreSQL.
- Records `/models` ETags.
- Detects `x-models-etag` changes from inference responses.
- Automatically schedules a deduplicated account-level model synchronization.

## Retry behavior

- Honors `X-Should-Retry: false`.
- Prevents account failover when the upstream explicitly marks a request as non-retryable.
- Preserves existing quota, rate-limit, and egress retry behavior.

## Responses compatibility

Added or improved support for:

- `namespace`
- `tool_search`
- `custom`
- `web_search`
- `x_search`
- `image_generation`
- `collections_search`
- `file_search`
- `code_execution`
- `code_interpreter`
- `mcp`
- `shell`
- `local_shell`
- `apply_patch`

Compatibility behavior:

- Client Tool Search is emulated through an internal function.
- Server Tool Search eagerly loads declared deferred tools.
- Parallel client Tool Search is downgraded to serial execution.
- Hosted `tool_choice` narrows the visible tool set to preserve forced-tool semantics.
- Custom grammar formats degrade to plain-text custom input.
- Optional `local_shell` and `apply_patch` controls are ignored safely.
- Tool controls are removed when no tools remain.
- Compatibility decisions are exposed through:
  - `X-Grok2API-Compatibility-Warnings`

Unknown tool types, malformed payloads, conflicting constraints, and capabilities that cannot be simulated safely still return explicit request errors.

## Web Search safety

- Preserves native `filters.allowed_domains`.
- Converts legacy top-level `allowed_domains`.
- Safely removes unsupported optional search controls.
- Ignores unknown future optional controls instead of rejecting the request.
- Disables the search tool when `external_web_access: false`.
- Never expands a request that explicitly forbids external network access.

## Chat Completions

- Converts messages, images, functions, tool choices, and structured output to Responses.
- Maps `user` to `safety_identifier`.
- Applies stop sequences locally for streaming and non-streaming responses.
- Ignores unsupported optional penalties and seeds.
- Preserves opaque historical function arguments.
- Supports Web Search aliases and annotations.
- Preserves reasoning content, refusals, and upstream error details.
- Uses stable sequential tool indexes in streamed Chat Completions responses.

## Anthropic Messages

- Supports thinking, signatures, tools, tool results, images, documents, MCP, and structured output.
- Safely ignores `top_k`.
- Supports Anthropic hosted Web Search declarations.
- Preserves ordered streaming blocks:
  - thinking
  - server tool use
  - search result
  - response text
- Supports replaying hosted Web Search blocks in conversation history.
- Preserves refusals and final token usage.
- Converts upstream failures to standard Anthropic error events.

## Usage and audit data

Preserves the latest upstream usage fields across Responses, Chat Completions, Messages, and audit records:

- `input_tokens`
- `output_tokens`
- `total_tokens`
- `cached_tokens`
- `reasoning_tokens`
- `cost_in_usd_ticks`
- `num_sources_used`
- `num_server_side_tools_used`
- `context_details`

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/grok2api`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `git diff --check`

## Compatibility policy

Optional client parameters are converted or safely downgraded whenever possible.

Requests are rejected only when they contain:

- malformed data
- contradictory execution constraints
- unknown tool types
- behavior that cannot be represented without changing security or execution semantics