### PR TITLE
fix: unify account type labels across providers

### DIFF
--- a/frontend/src/features/accounts/account-quota.tsx
+++ b/frontend/src/features/accounts/account-quota.tsx
@@ -10,7 +10,7 @@ import { formatDateTime, formatNumber } from "@/shared/lib/format";
 export function AccountQuota({ quota, billing, locale }: { quota: QuotaDTO; billing?: BillingDTO; locale: string }) {
   const { t } = useTranslation();
   if (quota.type === "unknown") {
-    return <span className="text-xs text-muted-foreground">{t("accounts.quotaUnknown")}</span>;
+    return <span className="text-xs text-muted-foreground">{t("accountType.pending")}</span>;
   }
   if (quota.type !== "free") {
     return <BuildQuota quota={quota} billing={billing} locale={locale} />;

--- a/frontend/src/features/accounts/accounts-page.tsx
+++ b/frontend/src/features/accounts/accounts-page.tsx
@@ -573,15 +573,15 @@ export function AccountsPage() {
                 <Input className="h-8 pl-9 text-xs" value={search} onChange={(event) => { setSearch(event.target.value); setPage(1); }} placeholder={t("accounts.search")} aria-label={t("accounts.search")} />
               </div>
               <DataTableFilters filters={[
-                ...(provider === "grok_console" ? [] : [{ id: "type", label: t("accounts.type"), value: typeFilter, onChange: (value: string) => { setTypeFilter(value); setPage(1); }, options: provider === "grok_web" ? [
-                  { value: "auto", label: "Auto" },
-                  { value: "basic", label: "Basic" },
-                  { value: "super", label: "Super" },
-                  { value: "heavy", label: "Heavy" },
+                ...(provider === "grok_console" ? [] : [{ id: "type", label: t("accountType.label"), value: typeFilter, onChange: (value: string) => { setTypeFilter(value); setPage(1); }, options: provider === "grok_web" ? [
+                  { value: "auto", label: t("accountType.auto") },
+                  { value: "basic", label: t("accountType.free") },
+                  { value: "super", label: t("accountType.super") },
+                  { value: "heavy", label: t("accountType.heavy") },
                 ] : [
-                  { value: "free", label: t("accounts.quotaFree") },
-                  { value: "paid", label: t("accounts.quotaSuper") },
-                  { value: "unknown", label: t("dashboard.unknown") },
+                  { value: "free", label: t("accountType.free") },
+                  { value: "paid", label: t("accountType.paid") },
+                  { value: "unknown", label: t("accountType.pending") },
                 ] }]),
                 { id: "status", label: t("accounts.status"), value: statusFilter, onChange: (value) => { setStatusFilter(value); setPage(1); }, options: [
                   { value: "active", label: t("accounts.statusActive") },
@@ -651,7 +651,7 @@ export function AccountsPage() {
               <TableRow className="hover:bg-transparent">
                 <TableHead className="px-2"><Checkbox checked={allPageSelected ? true : selectedOnPage.length > 0 ? "indeterminate" : false} onCheckedChange={(checked) => togglePage(checked === true)} aria-label={t("common.selectPage")} /></TableHead>
                 <SortableTableHead field="name" sortBy={sort.field} sortOrder={sort.order} onSort={changeSort}>{t("accounts.account")}</SortableTableHead>
-                <SortableTableHead field="type" sortBy={sort.field} sortOrder={sort.order} align="center" onSort={changeSort} className="whitespace-nowrap">{t("accounts.type")}</SortableTableHead>
+                <SortableTableHead field="type" sortBy={sort.field} sortOrder={sort.order} align="center" onSort={changeSort} className="whitespace-nowrap">{t("accountType.label")}</SortableTableHead>
                 <SortableTableHead field="status" sortBy={sort.field} sortOrder={sort.order} align="center" onSort={changeSort} className="whitespace-nowrap">{t("accounts.status")}</SortableTableHead>
                 <TableHead className="whitespace-nowrap">{t("accounts.quota")}</TableHead>
                 {provider === "grok_build" ? <TableHead className="whitespace-nowrap pl-4">{t("accountCredential.label")}</TableHead> : null}
@@ -687,7 +687,7 @@ export function AccountsPage() {
                         </div>
                       ) : null}
                     </TableCell>
-                    <TableCell className="text-center whitespace-nowrap">{provider === "grok_web" ? <WebAccountType tier={account.webTier} /> : provider === "grok_console" ? <AccountTypeText label={t("console.type")} variant="free" /> : <AccountType quota={account.quota} />}</TableCell>
+                    <TableCell className="text-center whitespace-nowrap">{provider === "grok_web" ? <WebAccountType tier={account.webTier} /> : provider === "grok_console" ? <AccountTypeText label={t("accountType.console")} variant="free" /> : <AccountType quota={account.quota} />}</TableCell>
                     <TableCell className="text-center whitespace-nowrap"><AccountStatus account={account} /></TableCell>
                     <TableCell>{provider === "grok_web" ? <WebQuota windows={account.quotaWindows ?? []} locale={i18n.language} tier={account.webTier} /> : provider === "grok_console" ? <ConsoleQuota windows={account.quotaWindows ?? []} locale={i18n.language} /> : <AccountQuota quota={account.quota} billing={account.billing} locale={i18n.language} />}</TableCell>
                     {provider === "grok_build" ? <TableCell className="whitespace-nowrap pl-4 text-xs">
@@ -922,34 +922,28 @@ function AccountMetricPanel({ icon, label, value, detail, loading }: { icon: Rea
   );
 }
 
-function webTierLabel(tier: AccountDTO["webTier"]) {
-  if (tier === "basic") return "Free";
-  if (tier === "super") return "Super";
-  if (tier === "heavy") return "Heavy";
-  return "Auto";
-}
-
 function WebAccountType({ tier }: { tier?: AccountDTO["webTier"] }) {
-  const label = webTierLabel(tier);
+  const { t } = useTranslation();
+  const label = tier === "basic" ? t("accountType.free") : tier === "super" ? t("accountType.super") : tier === "heavy" ? t("accountType.heavy") : t("accountType.auto");
   return <AccountTypeText label={label} variant={tier === "basic" ? "free" : "default"} />;
 }
 
 function AccountType({ quota }: { quota: QuotaDTO }) {
   const { t } = useTranslation();
   if (quota.type === "unknown") {
-    return <AccountTypeText label={t("dashboard.unknown")} variant="muted" />;
+    return <AccountTypeText label={t("accountType.pending")} title={t("accountType.pendingDescription")} variant="muted" />;
   }
 
   const isFree = quota.type === "free";
-  const label = isFree ? t("accounts.quotaFree") : t("accounts.quotaSuper");
+  const label = isFree ? t("accountType.free") : t("accountType.paid");
   return <AccountTypeText label={label} variant={isFree ? "free" : "default"} />;
 }
 
-function AccountTypeText({ label, variant }: { label: string; variant: "default" | "free" | "muted" }) {
+function AccountTypeText({ label, title, variant }: { label: string; title?: string; variant: "default" | "free" | "muted" }) {
   if (variant === "muted") {
-    return <span className="text-xs text-muted-foreground">{label}</span>;
+    return <span title={title ?? label} className="text-xs text-muted-foreground">{label}</span>;
   }
-  return <span title={label} className={cn("max-w-32 truncate text-xs font-medium", variant === "free" ? "text-emerald-700 dark:text-emerald-300" : "text-primary")}>{label}</span>;
+  return <span title={title ?? label} className={cn("max-w-32 truncate text-xs font-medium", variant === "free" ? "text-emerald-700 dark:text-emerald-300" : "text-primary")}>{label}</span>;
 }
 
 function AccountStatus({ account }: { account: AccountDTO }) {

--- a/frontend/src/shared/i18n/index.ts
+++ b/frontend/src/shared/i18n/index.ts
@@ -5,6 +5,7 @@ const resources = {
   "zh-CN": {
     translation: {
       appName: "Grok2API",
+      accountType: { label: "账号类型", free: "Free", paid: "Super", pending: "待识别", pendingDescription: "账号状态正常，但额度类型尚未识别", auto: "Auto", super: "Super", heavy: "Heavy", console: "Console" },
       accountBulk: {
         convertAllToBuild: "转换为 Build",
         convertAllToBuildTitle: "转换所有 Grok Web 账号？",
@@ -838,6 +839,7 @@ const resources = {
   en: {
     translation: {
       appName: "Grok2API",
+      accountType: { label: "Account type", free: "Free", paid: "Super", pending: "Pending", pendingDescription: "The account is healthy, but its quota type has not been identified yet.", auto: "Auto", super: "Super", heavy: "Heavy", console: "Console" },
       accountBulk: {
         convertAllToBuild: "Convert to Build",
         convertAllToBuildTitle: "Convert all Grok Web accounts?",


### PR DESCRIPTION
## Summary

统一 Grok Build、Grok Web 和 Grok Console 管理页面中的账号类型文案，避免 `Basic`、`Free`、`Auto` 和 `未知` 混用造成误解。

## Changes

- 账号类型列统一命名为「账号类型」
- 将 `未知` 调整为「待识别」
- 为「待识别」增加说明：
  - 账号状态正常，但额度类型尚未识别
- 统一三个渠道的类型展示：
  - Grok Build：Free / Super / 待识别
  - Grok Web：Auto / Free / Super / Heavy
  - Grok Console：Console
- 类型筛选器与表格展示使用同一套文案
- 保持账号健康状态独立展示：
  - 正常
  - 失效
  - 冷却
  - 等待重置
  - 已禁用

## Compatibility

- 不修改账号状态判断逻辑
- 不修改额度计算和路由逻辑
- 不将无法确认类型的账号强制标记为 Free，避免误判付费账号
- 仅调整前端展示和国际化文案

## Test plan

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 验证 Build/Web/Console 三个账号页类型展示
- [x] 验证类型筛选器文案与表格一致
- [x] 验证「待识别」不会被误显示为账号失效