### PR TITLE
feat: enhance Console protocol compatibility and shared SSO egress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@ Thumbs.db
 /config.yaml
 /config.local.yaml
 /config.*.local.yaml
-/docs/rules/
-/docs/project/
+/docs/*
 /backend/docs/goal/
 *.har
 *.pcap

--- a/backend/internal/application/account/service.go
+++ b/backend/internal/application/account/service.go
@@ -868,6 +868,13 @@ func (s *Service) syncWebCredentialsToConsole(ctx context.Context, values []acco
 		seed.Provider = accountdomain.ProviderConsole
 		seed.AuthType = accountdomain.AuthTypeSSO
 		seed.Name = webConsoleAccountName(value.Name, seed.Name)
+		if strings.TrimSpace(value.EncryptedCloudflareCookie) != "" {
+			cookies, decryptErr := s.cipher.Decrypt(value.EncryptedCloudflareCookie)
+			if decryptErr != nil {
+				return ImportResult{}, fmt.Errorf("解密 Grok Web Cloudflare Cookie: %w", decryptErr)
+			}
+			seed.CloudflareCookies = cookies
+		}
 		seeds = append(seeds, seed)
 	}
 	return s.persistImportedSeeds(ctx, seeds, observer, progress)

--- a/backend/internal/application/account/web_console_sync_test.go
+++ b/backend/internal/application/account/web_console_sync_test.go
@@ -41,10 +41,12 @@ func TestSyncWebAccountsToConsoleIsIdempotentAndPreservesBuildLink(t *testing.T)
 
 	accounts := relational.NewAccountRepository(database)
 	token := "shared-sso-token"
+	cloudflareCookie := "cf_clearance=shared-clearance; __cf_bm=shared-bm"
 	webAccount, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
 		Provider: accountdomain.ProviderWeb, AuthType: accountdomain.AuthTypeSSO,
 		Name: "Grok Web primary", SourceKey: "sso:" + security.HashToken(token),
-		EncryptedAccessToken: encrypt(token), Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+		EncryptedAccessToken: encrypt(token), EncryptedCloudflareCookie: encrypt(cloudflareCookie),
+		Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -90,6 +92,13 @@ func TestSyncWebAccountsToConsoleIsIdempotentAndPreservesBuildLink(t *testing.T)
 	}
 	if consoleAccount.Provider != accountdomain.ProviderConsole || consoleAccount.Name != "Grok Console primary" || decrypted != token {
 		t.Fatalf("console account = %#v, token = %q", consoleAccount, decrypted)
+	}
+	consoleCookie, err := cipher.Decrypt(consoleAccount.EncryptedCloudflareCookie)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if consoleCookie != cloudflareCookie {
+		t.Fatalf("console Cloudflare cookie = %q, want %q", consoleCookie, cloudflareCookie)
 	}
 
 	second, err := service.SyncAllWebAccountsToConsoleWithProgress(ctx, nil, nil)

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -362,15 +362,27 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	if err != nil {
 		return nil, ErrModelNotFound
 	}
-	route, routeErr := s.selectConversationRoute(routes, input.ClientKey, operation, path, input.PreviousResponseID != "", nil)
+	// Select the route first without requiring stored-response support. Console
+	// is intentionally stateless but can still accept a complete input replay;
+	// rejecting it here would prevent the Provider compatibility boundary from
+	// normalizing the request.
+	route, routeErr := s.selectConversationRoute(routes, input.ClientKey, operation, path, false, nil)
 	var ownership *inferencedomain.ResponseOwnership
 	if input.PreviousResponseID != "" && routeErr == nil {
-		value, ownershipErr := s.responses.Get(ctx, input.PreviousResponseID, input.ClientKey.ID, time.Now().UTC())
-		if ownershipErr != nil {
-			return nil, ErrResponseNotFound
+		if s.providers.SupportsStoredResponses(route.Provider) {
+			value, ownershipErr := s.responses.Get(ctx, input.PreviousResponseID, input.ClientKey.ID, time.Now().UTC())
+			if ownershipErr != nil {
+				return nil, ErrResponseNotFound
+			}
+			ownership = &value
+			route, routeErr = s.selectConversationRoute(routes, input.ClientKey, operation, path, true, ownership)
+		} else if route.Provider == accountdomain.ProviderConsole {
+			// Console has no response store. It receives the current request as a
+			// stateless replay; the Provider normalizer removes the stale ID.
+			input.PreviousResponseID = ""
+		} else {
+			return nil, ErrResponseStateUnsupported
 		}
-		ownership = &value
-		route, routeErr = s.selectConversationRoute(routes, input.ClientKey, operation, path, true, ownership)
 	}
 	publicModel := modeldomain.ExternalPublicID(route.Provider, route.PublicID)
 	input.PublicModel = publicModel

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -429,9 +429,13 @@ func TestGatewayDoesNotPersistStatelessConsoleResponses(t *testing.T) {
 	if _, err := responseRepo.Get(ctx, "resp-console", key.ID, time.Now().UTC()); !errors.Is(err, repository.ErrNotFound) {
 		t.Fatalf("stateless response ownership err = %v", err)
 	}
-	if _, err := service.CreateResponse(ctx, Input{RequestID: "req-console-next", ClientKey: key, PublicModel: model, PreviousResponseID: "resp-console", Body: []byte(`{"model":"grok-console-stateless","previous_response_id":"resp-console"}`)}); !errors.Is(err, ErrResponseStateUnsupported) {
-		t.Fatalf("previous response error = %v", err)
+	continued, err := service.CreateResponse(ctx, Input{RequestID: "req-console-next", ClientKey: key, PublicModel: model, PreviousResponseID: "resp-console", Body: []byte(`{"model":"grok-console-stateless","previous_response_id":"resp-console","input":"hello again"}`)})
+	if err != nil {
+		t.Fatalf("Console stateless previous response fallback = %v", err)
 	}
+	_, _ = io.ReadAll(continued.Body)
+	continued.Finalize(Usage{}, "resp-console-next", "")
+	_ = continued.Body.Close()
 	if _, err := service.CompactResponse(ctx, Input{RequestID: "req-console-compact", ClientKey: key, PublicModel: model, Body: []byte(`{"model":"grok-console-stateless","input":"hello"}`)}); !errors.Is(err, ErrConversationUnsupported) {
 		t.Fatalf("compact response error = %v", err)
 	}

--- a/backend/internal/infra/egress/manager.go
+++ b/backend/internal/infra/egress/manager.go
@@ -94,7 +94,7 @@ func (m *Manager) Acquire(ctx context.Context, scope domain.Scope, affinity stri
 // AcquireCredential binds the outbound proxy identity to one persisted
 // Provider credential. Resin templates use this identity as their Account.
 func (m *Manager) AcquireCredential(ctx context.Context, scope domain.Scope, credential accountdomain.Credential) (*Lease, error) {
-	ctx = WithAccount(ctx, string(credential.Provider), credential.ID)
+	identity := string(credential.Provider) + "_" + strconv.FormatUint(credential.ID, 10)
 	credentialCookies := ""
 	if scope != domain.ScopeBuild && strings.TrimSpace(credential.EncryptedCloudflareCookie) != "" {
 		cookies, decryptErr := m.cipher.Decrypt(credential.EncryptedCloudflareCookie)
@@ -103,6 +103,19 @@ func (m *Manager) AcquireCredential(ctx context.Context, scope domain.Scope, cre
 		}
 		credentialCookies = application.SanitizeCloudflareCookies(cookies)
 	}
+	// Web and Console accounts can be two database projections of the same SSO
+	// login.  Resin must see one stable account identity across both channels;
+	// otherwise the proxy rotates the IP while the clearance remains bound to
+	// the other lease.  The digest is non-reversible and is only used as a proxy
+	// template account label.
+	if credential.AuthType == accountdomain.AuthTypeSSO && strings.TrimSpace(credential.EncryptedAccessToken) != "" {
+		token, decryptErr := m.cipher.Decrypt(credential.EncryptedAccessToken)
+		if decryptErr != nil {
+			return nil, decryptErr
+		}
+		identity = "sso_" + security.HashToken(token)[:32]
+	}
+	ctx = WithAccountIdentity(ctx, identity)
 	lease, _, err := m.acquire(ctx, scope, strconv.FormatUint(credential.ID, 10), true, credentialCookies)
 	return lease, err
 }
@@ -273,6 +286,12 @@ func (m *Manager) invalidateNodes(scope domain.Scope) {
 func fallbackScopes(scope domain.Scope) []domain.Scope {
 	if scope == domain.ScopeWebAsset {
 		return []domain.Scope{domain.ScopeWebAsset, domain.ScopeWeb}
+	}
+	if scope == domain.ScopeConsole {
+		// Console uses the same browser/clearance surface as Grok Web.  A
+		// dedicated Console node is preferred, but a Web node is a safe and
+		// expected fallback for deployments that configure one shared pool.
+		return []domain.Scope{domain.ScopeConsole, domain.ScopeWeb}
 	}
 	return []domain.Scope{scope}
 }

--- a/backend/internal/infra/egress/manager_test.go
+++ b/backend/internal/infra/egress/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -234,6 +235,49 @@ func TestAcquireCredentialRendersResinAccountAndOverridesNodeCookie(t *testing.T
 	}
 	if len(manager.clients) != 2 {
 		t.Fatalf("cached Resin account pools = %d, want 2", len(manager.clients))
+	}
+}
+
+func TestConsoleFallsBackToWebAndSharesSSOResinIdentity(t *testing.T) {
+	cipher, err := security.NewCipher("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyURL, err := cipher.Encrypt("socks5h://Default.{account}:token@resin:2260")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := "shared-web-console-sso"
+	encryptedToken, err := cipher.Encrypt(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager := NewManager(egressRepositoryTestStub{nodes: []domain.Node{{
+		ID: 7, Name: "shared-web", Scope: domain.ScopeWeb, Enabled: true, Health: 1,
+		EncryptedProxyURL: proxyURL,
+	}}}, cipher)
+	web, err := manager.AcquireCredential(context.Background(), domain.ScopeWeb, accountdomain.Credential{
+		ID: 11, Provider: accountdomain.ProviderWeb, AuthType: accountdomain.AuthTypeSSO,
+		EncryptedAccessToken: encryptedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer web.Release()
+	console, err := manager.AcquireCredential(context.Background(), domain.ScopeConsole, accountdomain.Credential{
+		ID: 22, Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+		EncryptedAccessToken: encryptedToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer console.Release()
+	wantAccount := "sso_" + security.HashToken(token)[:32]
+	if web.NodeID != 7 || console.NodeID != 7 {
+		t.Fatalf("nodes web=%d console=%d, want shared Web node", web.NodeID, console.NodeID)
+	}
+	if !strings.Contains(web.ProxyURL, "Default."+wantAccount+":") || web.ProxyURL != console.ProxyURL {
+		t.Fatalf("proxy identities web=%q console=%q", web.ProxyURL, console.ProxyURL)
 	}
 }
 

--- a/backend/internal/infra/egress/trace.go
+++ b/backend/internal/infra/egress/trace.go
@@ -34,8 +34,19 @@ func WithAccount(ctx context.Context, provider string, accountID uint64) context
 	if ctx == nil || strings.TrimSpace(provider) == "" || accountID == 0 {
 		return ctx
 	}
-	value := strings.TrimSpace(provider) + "_" + fmt.Sprintf("%d", accountID)
-	return context.WithValue(ctx, accountContextKey{}, value)
+	return WithAccountIdentity(ctx, strings.TrimSpace(provider)+"_"+fmt.Sprintf("%d", accountID))
+}
+
+// WithAccountIdentity attaches the stable, non-sensitive identity used by
+// account-bound proxy templates such as Resin.  Providers that represent the
+// same upstream login (for example Web and Console sharing one SSO token) can
+// deliberately pass the same identity so their proxy and clearance lease is
+// not split by the internal provider name.
+func WithAccountIdentity(ctx context.Context, identity string) context.Context {
+	if ctx == nil || strings.TrimSpace(identity) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, accountContextKey{}, strings.TrimSpace(identity))
 }
 
 func accountFromContext(ctx context.Context) string {

--- a/backend/internal/infra/provider/console/adapter.go
+++ b/backend/internal/infra/provider/console/adapter.go
@@ -286,7 +286,7 @@ func applyHeaders(request *http.Request, token, configuredUserAgent string, leas
 	if userAgent == "" {
 		userAgent = strings.TrimSpace(configuredUserAgent)
 	}
-	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Accept", "*/*")
 	request.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
 	request.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
 	request.Header.Set("Authorization", "Bearer anonymous")
@@ -297,6 +297,7 @@ func applyHeaders(request *http.Request, token, configuredUserAgent string, leas
 	request.Header.Set("Sec-Fetch-Dest", "empty")
 	request.Header.Set("Sec-Fetch-Mode", "cors")
 	request.Header.Set("Sec-Fetch-Site", "same-origin")
+	request.Header.Set("Priority", "u=1, i")
 	request.Header.Set("User-Agent", userAgent)
 	request.Header.Set("x-cluster", "https://us-east-1.api.x.ai")
 }

--- a/backend/internal/infra/provider/console/catalog.go
+++ b/backend/internal/infra/provider/console/catalog.go
@@ -22,7 +22,7 @@ type ModelSpec struct {
 }
 
 var catalog = []ModelSpec{
-	{PublicID: "grok-4.3", UpstreamModel: "grok-4.3", SupportsReasoning: true, DefaultReasoningEffort: "high", MaxOutputTokens: 1_000_000, SearchTools: true},
+	{PublicID: "grok-4.3", UpstreamModel: "grok-4.3", SupportsReasoning: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000, SearchTools: true},
 	{PublicID: "grok-4.20-0309", UpstreamModel: "grok-4.20-0309", MaxOutputTokens: 1_000_000, SearchTools: true},
 	{PublicID: "grok-4.20-0309-reasoning", UpstreamModel: "grok-4.20-0309-reasoning", MaxOutputTokens: 1_000_000, SearchTools: true},
 	{PublicID: "grok-4.20-0309-non-reasoning", UpstreamModel: "grok-4.20-0309-non-reasoning", MaxOutputTokens: 1_000_000, SearchTools: true},
@@ -43,7 +43,7 @@ var aliases = []provider.ModelAlias{
 	consoleAlias("grok-4.20-multi-agent-low", "grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-0309", "low"),
 	consoleAlias("grok-4.20-multi-agent-medium", "grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-0309", "medium"),
 	consoleAlias("grok-4.20-multi-agent-high", "grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-0309", "high"),
-	consoleAlias("grok-4.20-multi-agent-xhigh", "grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-0309", "high"),
+	consoleAlias("grok-4.20-multi-agent-xhigh", "grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-0309", "xhigh"),
 }
 
 func consoleAlias(alias, publicModel, upstreamModel, effort string) provider.ModelAlias {

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -93,19 +93,96 @@ func TestNormalizeRequestAppliesConsoleContract(t *testing.T) {
 		t.Fatalf("max_output_tokens = %#v", payload["max_output_tokens"])
 	}
 	reasoning, _ := payload["reasoning"].(map[string]any)
-	if reasoning["effort"] != "high" {
+	if reasoning["effort"] != "xhigh" {
 		t.Fatalf("reasoning = %#v", reasoning)
+	}
+	include, _ := payload["include"].([]any)
+	if len(include) != 1 || include[0] != "reasoning.encrypted_content" {
+		t.Fatalf("include = %#v", include)
 	}
 	tools, _ := payload["tools"].([]any)
 	if len(tools) != 3 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "x_search" || toolIdentity(tools[2]) != "function:lookup" {
 		t.Fatalf("tools = %#v", tools)
 	}
-	for _, body := range []string{
-		`{"model":"grok-4.3","store":true,"input":"hello"}`,
-		`{"model":"grok-4.3","previous_response_id":"resp_1","input":"hello"}`,
+	webSearch, _ := tools[0].(map[string]any)
+	if webSearch["custom"] != nil || webSearch["enable_image_understanding"] != true {
+		t.Fatalf("web_search = %#v", webSearch)
+	}
+	stateless, err := normalizeRequest([]byte(`{"model":"grok-4.3","store":true,"previous_response_id":"resp_1","service_tier":"priority","input":"hello"}`), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var statelessPayload map[string]any
+	if json.Unmarshal(stateless, &statelessPayload) != nil || statelessPayload["store"] != false || statelessPayload["previous_response_id"] != nil || statelessPayload["service_tier"] != nil {
+		t.Fatalf("stateless payload = %#v", statelessPayload)
+	}
+}
+
+func TestNormalizeRequestAppliesConsoleCompatibilityBoundary(t *testing.T) {
+	spec, ok := Resolve("grok-4.20-0309")
+	if !ok {
+		t.Fatal("grok-4.20-0309 missing")
+	}
+	body, err := normalizeRequest([]byte(`{
+		"model":"public",
+		"response_format":{"type":"json_schema","json_schema":{"name":"answer","strict":true,"schema":{"type":"object"}}},
+		"input":[
+			{"type":"reasoning","content":[{"text":"prior thought"}]},
+			{"type":"message","role":"user","content":[
+				{"type":"output_text","text":"hello"},
+				{"type":"image_url","image_url":{"url":"https://example.com/image.png"}}
+			]}
+		],
+		"tools":[
+			{"type":"namespace","name":"crm","tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]},
+			{"type":"web_search","external_web_access":true}
+		],
+		"tool_choice":"required"
+	}`), spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["response_format"] != nil || payload["reasoning"] != nil || payload["tool_choice"] != "auto" {
+		t.Fatalf("payload boundary = %#v", payload)
+	}
+	include, _ := payload["include"].([]any)
+	if len(include) != 1 || include[0] != "reasoning.encrypted_content" {
+		t.Fatalf("include = %#v", include)
+	}
+	text, _ := payload["text"].(map[string]any)
+	format, _ := text["format"].(map[string]any)
+	if format["type"] != "json_schema" || format["name"] != "answer" || format["json_schema"] != nil {
+		t.Fatalf("text.format = %#v", format)
+	}
+	input, _ := payload["input"].([]any)
+	reasoning := input[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if reasoning["type"] != "reasoning_text" {
+		t.Fatalf("reasoning content = %#v", reasoning)
+	}
+	parts := input[1].(map[string]any)["content"].([]any)
+	if parts[0].(map[string]any)["type"] != "input_text" || parts[1].(map[string]any)["type"] != "input_image" || parts[1].(map[string]any)["image_url"] != "https://example.com/image.png" {
+		t.Fatalf("message parts = %#v", parts)
+	}
+	tools, _ := payload["tools"].([]any)
+	if len(tools) != 2 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "x_search" {
+		t.Fatalf("sanitized tools = %#v", tools)
+	}
+	if tools[0].(map[string]any)["external_web_access"] != nil {
+		t.Fatalf("unsupported web search controls leaked: %#v", tools[0])
+	}
+}
+
+func TestNormalizeReasoningPreservesReferenceEfforts(t *testing.T) {
+	for input, want := range map[string]string{
+		"none": "none", "minimal": "low", "low": "low", "medium": "medium",
+		"high": "high", "xhigh": "xhigh", "max": "xhigh",
 	} {
-		if _, err := normalizeRequest([]byte(body), spec); err == nil {
-			t.Fatalf("expected stateless validation error for %s", body)
+		if got := normalizeEffort(input); got != want {
+			t.Fatalf("normalizeEffort(%q) = %q, want %q", input, got, want)
 		}
 	}
 }
@@ -226,7 +303,7 @@ func TestAdapterForwardsConsoleHeadersAndNormalizedBody(t *testing.T) {
 		if request.URL.Path != "/v1/responses" || request.Method != http.MethodPost {
 			t.Errorf("request = %s %s", request.Method, request.URL.Path)
 		}
-		if request.Header.Get("Authorization") != "Bearer anonymous" || request.Header.Get("x-cluster") != "https://us-east-1.api.x.ai" {
+		if request.Header.Get("Authorization") != "Bearer anonymous" || request.Header.Get("x-cluster") != "https://us-east-1.api.x.ai" || request.Header.Get("Accept") != "*/*" || request.Header.Get("Priority") != "u=1, i" {
 			t.Errorf("headers = %#v", request.Header)
 		}
 		cookie := request.Header.Get("Cookie")

--- a/backend/internal/infra/provider/console/definition.go
+++ b/backend/internal/infra/provider/console/definition.go
@@ -20,6 +20,10 @@ func (a *Adapter) Definition() provider.Definition {
 		Conversation: provider.ConversationSurface{
 			Responses: true, ChatCompletions: true, Messages: true,
 		},
-		Inference: provider.InferencePolicy{Usage: provider.UsageUpstream},
+		// Console shares the browser/clearance surface with Web.  A 403 is
+		// therefore normally an egress challenge, not proof that the SSO
+		// credential is invalid; the gateway must retry after rebuilding the
+		// browser session instead of cooling the account.
+		Inference: provider.InferencePolicy{Usage: provider.UsageUpstream, RetryForbiddenAsEgress: true},
 	}
 }

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -25,38 +25,118 @@ func normalizeRequest(body []byte, spec ModelSpec) ([]byte, error) {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("解析 Console Responses 请求: %w", err)
 	}
-	if value, exists := payload["store"]; exists {
-		store, ok := value.(bool)
-		if !ok {
-			return nil, fmt.Errorf("Console store 必须是布尔值")
-		}
-		if store {
-			return nil, fmt.Errorf("Grok Console 不支持 store: true；请使用无状态 Responses 输入回放")
-		}
-	}
-	if value, exists := payload["previous_response_id"]; exists && value != nil {
-		previousID, ok := value.(string)
-		if !ok {
-			return nil, fmt.Errorf("Console previous_response_id 必须是字符串")
-		}
-		if strings.TrimSpace(previousID) != "" {
-			return nil, fmt.Errorf("Grok Console 不支持 previous_response_id；请回放完整输入")
-		}
-		delete(payload, "previous_response_id")
-	}
 	payload["model"] = spec.UpstreamModel
+	// Console is stateless.  Match the reference adapter's compatibility
+	// boundary: replay the supplied input and silently discard stateful client
+	// hints instead of rejecting an otherwise valid request.
 	payload["store"] = false
-	delete(payload, "metadata")
+	for _, field := range []string{
+		"metadata", "previous_response_id", "service_tier", "prompt_cache_key",
+		"background", "conversation",
+	} {
+		delete(payload, field)
+	}
+	normalizeConsoleResponseFormat(payload)
+	patchConsoleInput(payload)
 	if _, exists := payload["max_output_tokens"]; !exists && spec.MaxOutputTokens > 0 {
 		payload["max_output_tokens"] = spec.MaxOutputTokens
 	}
 	normalizeReasoning(payload, spec)
+	ensureReasoningInclude(payload)
+	retainedClientTools := normalizeConsoleTools(payload)
 	if spec.SearchTools {
-		if err := mergeSearchTools(payload); err != nil {
-			return nil, err
+		mergeSearchTools(payload)
+	}
+	normalizeConsoleToolChoice(payload, retainedClientTools)
+	return json.Marshal(payload)
+}
+
+func normalizeConsoleResponseFormat(payload map[string]any) {
+	raw, exists := payload["response_format"]
+	if !exists {
+		return
+	}
+	delete(payload, "response_format")
+	format, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	if typeName, _ := format["type"].(string); typeName == "json_schema" {
+		if nested, ok := format["json_schema"].(map[string]any); ok {
+			flattened := map[string]any{"type": "json_schema"}
+			for key, value := range nested {
+				if key != "type" {
+					flattened[key] = value
+				}
+			}
+			format = flattened
 		}
 	}
-	return json.Marshal(payload)
+	text, _ := payload["text"].(map[string]any)
+	if text == nil {
+		text = make(map[string]any)
+	}
+	if _, exists := text["format"]; !exists {
+		text["format"] = format
+	}
+	payload["text"] = text
+}
+
+func patchConsoleInput(payload map[string]any) {
+	items, ok := payload["input"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		if item["type"] == "reasoning" {
+			patchConsoleReasoningContent(item)
+			continue
+		}
+		content, ok := item["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawPart := range content {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				continue
+			}
+			typeName, _ := part["type"].(string)
+			switch typeName {
+			case "text", "output_text":
+				part["type"] = "input_text"
+			case "image_url":
+				if image, ok := part["image_url"].(map[string]any); ok {
+					if url, _ := image["url"].(string); strings.TrimSpace(url) != "" {
+						part["type"] = "input_image"
+						part["image_url"] = url
+					}
+				}
+			}
+		}
+	}
+}
+
+func patchConsoleReasoningContent(item map[string]any) {
+	content, ok := item["content"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawPart := range content {
+		part, ok := rawPart.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, exists := part["type"]; !exists {
+			if _, hasText := part["text"]; hasText {
+				part["type"] = "reasoning_text"
+			}
+		}
+	}
 }
 
 func normalizeReasoning(payload map[string]any, spec ModelSpec) {
@@ -81,18 +161,104 @@ func normalizeReasoning(payload map[string]any, spec ModelSpec) {
 
 func normalizeEffort(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "none":
+		return "none"
 	case "minimal", "low":
 		return "low"
 	case "medium":
 		return "medium"
-	case "high", "xhigh":
+	case "high":
 		return "high"
+	case "xhigh", "max":
+		return "xhigh"
 	default:
 		return ""
 	}
 }
 
-func mergeSearchTools(payload map[string]any) error {
+func ensureReasoningInclude(payload map[string]any) {
+	value, _ := payload["include"].([]any)
+	seen := make(map[string]struct{}, len(value)+1)
+	result := make([]any, 0, len(value)+1)
+	for _, item := range value {
+		name, ok := item.(string)
+		if !ok || strings.TrimSpace(name) == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	if _, exists := seen["reasoning.encrypted_content"]; !exists {
+		result = append(result, "reasoning.encrypted_content")
+	}
+	payload["include"] = result
+}
+
+func normalizeConsoleTools(payload map[string]any) bool {
+	value, exists := payload["tools"]
+	if !exists || value == nil {
+		return false
+	}
+	tools, ok := value.([]any)
+	if !ok {
+		delete(payload, "tools")
+		delete(payload, "tool_choice")
+		return false
+	}
+	result := make([]any, 0, len(tools))
+	retainedClientTools := false
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		typeName, _ := tool["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(typeName)) {
+		case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
+			clean := map[string]any{"type": "web_search", "enable_image_understanding": true}
+			if enabled, ok := tool["enable_image_understanding"].(bool); ok {
+				clean["enable_image_understanding"] = enabled
+			}
+			result = append(result, clean)
+		case "x_search":
+			clean := map[string]any{"type": "x_search", "enable_video_understanding": true}
+			if enabled, ok := tool["enable_video_understanding"].(bool); ok {
+				clean["enable_video_understanding"] = enabled
+			}
+			result = append(result, clean)
+		case "function":
+			name, _ := tool["name"].(string)
+			if strings.TrimSpace(name) == "" {
+				continue
+			}
+			clean := map[string]any{"type": "function", "name": strings.TrimSpace(name)}
+			for _, field := range []string{"description", "parameters", "strict"} {
+				if fieldValue, exists := tool[field]; exists {
+					clean[field] = fieldValue
+				}
+			}
+			result = append(result, clean)
+			retainedClientTools = true
+		case "mcp", "shell", "image_generation", "collections_search", "file_search", "code_execution", "code_interpreter":
+			// These are native xAI Responses tool variants. Keep their payloads,
+			// while namespace/tool_search remain client-side abstractions and are
+			// intentionally omitted instead of causing an upstream 400.
+			result = append(result, tool)
+			retainedClientTools = true
+		}
+	}
+	if len(result) == 0 {
+		delete(payload, "tools")
+		return false
+	}
+	payload["tools"] = result
+	return retainedClientTools
+}
+
+func mergeSearchTools(payload map[string]any) {
 	defaults := []any{
 		map[string]any{"type": "web_search", "enable_image_understanding": true},
 		map[string]any{"type": "x_search", "enable_video_understanding": true},
@@ -100,10 +266,7 @@ func mergeSearchTools(payload map[string]any) error {
 	positions := map[string]int{"web_search": 0, "x_search": 1}
 	result := append([]any(nil), defaults...)
 	if value, exists := payload["tools"]; exists && value != nil {
-		tools, ok := value.([]any)
-		if !ok {
-			return fmt.Errorf("Console tools 必须是数组")
-		}
+		tools, _ := value.([]any)
 		for _, tool := range tools {
 			identity := toolIdentity(tool)
 			if index, exists := positions[identity]; identity != "" && exists {
@@ -120,7 +283,48 @@ func mergeSearchTools(payload map[string]any) error {
 	if _, exists := payload["tool_choice"]; !exists {
 		payload["tool_choice"] = "auto"
 	}
-	return nil
+}
+
+func normalizeConsoleToolChoice(payload map[string]any, retainedClientTools bool) {
+	choice, exists := payload["tool_choice"]
+	if !exists {
+		payload["tool_choice"] = "auto"
+		return
+	}
+	if value, ok := choice.(string); ok {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "none", "auto":
+			payload["tool_choice"] = strings.ToLower(strings.TrimSpace(value))
+		case "required":
+			if !retainedClientTools {
+				payload["tool_choice"] = "auto"
+			}
+		default:
+			payload["tool_choice"] = "auto"
+		}
+		return
+	}
+	object, ok := choice.(map[string]any)
+	if !ok {
+		payload["tool_choice"] = "auto"
+		return
+	}
+	typeName, _ := object["type"].(string)
+	if typeName != "function" || !retainedClientTools {
+		payload["tool_choice"] = "auto"
+		return
+	}
+	name, _ := object["name"].(string)
+	if strings.TrimSpace(name) == "" {
+		if function, ok := object["function"].(map[string]any); ok {
+			name, _ = function["name"].(string)
+		}
+	}
+	if strings.TrimSpace(name) == "" {
+		payload["tool_choice"] = "auto"
+		return
+	}
+	payload["tool_choice"] = map[string]any{"type": "function", "name": strings.TrimSpace(name)}
 }
 
 func toolIdentity(value any) string {

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -178,8 +178,8 @@ func normalizeEffort(value string) string {
 
 func ensureReasoningInclude(payload map[string]any) {
 	value, _ := payload["include"].([]any)
-	seen := make(map[string]struct{}, len(value)+1)
-	result := make([]any, 0, len(value)+1)
+	seen := make(map[string]struct{})
+	result := make([]any, 0)
 	for _, item := range value {
 		name, ok := item.(string)
 		if !ok || strings.TrimSpace(name) == "" {

--- a/backend/internal/infra/provider/definition_contract_test.go
+++ b/backend/internal/infra/provider/definition_contract_test.go
@@ -64,7 +64,7 @@ func TestProductionProviderDefinitionsMatchImplementedCapabilities(t *testing.T)
 			capabilities: []modeldomain.Capability{modeldomain.CapabilityResponses},
 			credential:   provider.CredentialSurface{AuthType: account.AuthTypeSSO, Import: true},
 			conversation: provider.ConversationSurface{Responses: true, ChatCompletions: true, Messages: true},
-			inference:    provider.InferencePolicy{Usage: provider.UsageUpstream},
+			inference:    provider.InferencePolicy{Usage: provider.UsageUpstream, RetryForbiddenAsEgress: true},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

优化 Grok Console 的账号转换、出口绑定和 Responses 兼容逻辑，对齐 Console 请求策略，同时保留现有 Gateway、审计及多协议转换架构。

## Changes

### 账号与出口

- Web 转 Console 时同步 Cloudflare Cookie
- Web 与 Console 使用相同 SSO 时共享 Resin 粘性代理身份
- 未配置 Console 出口时自动复用 Web 出口
- Console 403 按出口挑战处理，避免错误冷却账号

### 请求兼容

- `store` 统一降级为 `false`
- Console 请求不再因 `previous_response_id` 提前失败
- 删除 Console 不需要的状态和客户端字段
- 转换 `response_format` 为 `text.format`
- 规范化文本、图片和 reasoning 输入块
- 自动补充 `reasoning.encrypted_content`

### 工具兼容

- 清理 `external_web_access` 等未确认支持的控制字段
- 统一不同版本的 `web_search` 类型
- 保留 function、MCP、shell 及原生 Responses 工具
- 过滤 `namespace`、`tool_search` 等客户端抽象，避免上游参数错误
- 无效 `tool_choice` 自动降级为 `auto`

### 模型与推理

- Console 模型目录与参考项目保持一致
- 支持 `none / low / medium / high / xhigh`
- 修复 `xhigh` 被降级为 `high`
- `grok-4.3` 默认推理强度调整为 `medium`

## Compatibility

- Build 和 Web 的状态响应逻辑保持不变
- Console 仍为无状态渠道
- `previous_response_id` 不会恢复服务端历史，客户端需携带完整输入
- 完整 namespace 工具能力仍建议使用 Grok Build

## Test plan

- [x] Web → Console Cookie 继承测试
- [x] Web/Console Resin 粘性身份共享测试
- [x] Console 出口回退测试
- [x] Responses 字段和输入归一化测试
- [x] 工具过滤与 `tool_choice` 降级测试
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./cmd/grok2api`