### PR TITLE
fix(egress): do not cool Build nodes on OAuth HTTP 400

### DIFF
--- a/backend/internal/infra/egress/manager.go
+++ b/backend/internal/infra/egress/manager.go
@@ -400,6 +400,10 @@ func (m *Manager) FeedbackForScope(ctx context.Context, scope domain.Scope, node
 		// Build 403 可能是账号权限、额度、Token 或出口策略，响应体由网关层
 		// 分类；仅凭状态码不能把标准 CLI 出口误判为 Web anti-bot。
 		return
+	case scope == domain.ScopeBuild && status == http.StatusBadRequest:
+		// Device OAuth 在用户确认前会以 400 + authorization_pending 轮询，
+		// 这是协议正常状态，不能当作出口节点故障进入冷却。
+		return
 	case status == http.StatusForbidden:
 		if m.isStickyProxyNode(value) {
 			// A 403 on an account-bound Resin lease usually means that account's


### PR DESCRIPTION
## Summary

- Device OAuth polls xAI token endpoint with `grant_type=device_code` while waiting for user confirmation.
- Upstream returns **HTTP 400** + `error=authorization_pending` (RFC 8628 normal state).
- Build egress `FeedbackForScope` previously treated that 400 as a node failure (`upstream status 400`), cooled the proxy, and made the next `device/poll` or `device/start` fail with **502 Device OAuth 登录失败**.
- This PR ignores **Build-scope HTTP 400** in egress feedback, consistent with the existing Build **403** exception.

Fixes #663

## Change

```go
case scope == domain.ScopeBuild && status == http.StatusBadRequest:
    // Device OAuth 在用户确认前会以 400 + authorization_pending 轮询，
    // 这是协议正常状态，不能当作出口节点故障进入冷却。
    return
```

File: `backend/internal/infra/egress/manager.go`

## Test plan

- [x] With a Build egress proxy configured, start Device OAuth
- [x] Confirm consecutive polls stay `202 pending` (no 502)
- [x] Confirm Build egress `health` stays 1.0 and `cooldownUntil` is not set
- [x] After user confirms in browser, account authorization succeeds
- [ ] CI / existing egress tests still pass

## Notes

Reproduced on v3.0.2 and current main when Build egress is configured. Direct (no-proxy) OAuth device/code still works; the bug is specifically egress health feedback misclassifying OAuth 400 pending.