### PR TITLE
fix: 补齐 Chromium Client Hints 请求头

### DIFF
--- a/backend/internal/infra/provider/console/adapter.go
+++ b/backend/internal/infra/provider/console/adapter.go
@@ -277,27 +277,6 @@ func consoleEndpoint(baseURL string) string {
 	return baseURL + "/v1/responses"
 }
 
-func applyHeaders(request *http.Request, token string, lease *infraegress.Lease) {
-	userAgent := strings.TrimSpace(lease.UserAgent)
-	if userAgent == "" {
-		userAgent = infraegress.DefaultUserAgent
-	}
-	request.Header.Set("Accept", "*/*")
-	request.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
-	request.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
-	request.Header.Set("Authorization", "Bearer anonymous")
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Cookie", infraegress.BuildSSOCookie(token, lease.CFCookies))
-	request.Header.Set("Origin", "https://console.x.ai")
-	request.Header.Set("Referer", "https://console.x.ai/")
-	request.Header.Set("Sec-Fetch-Dest", "empty")
-	request.Header.Set("Sec-Fetch-Mode", "cors")
-	request.Header.Set("Sec-Fetch-Site", "same-origin")
-	request.Header.Set("Priority", "u=1, i")
-	request.Header.Set("User-Agent", userAgent)
-	request.Header.Set("x-cluster", "https://us-east-1.api.x.ai")
-}
-
 func normalizeRateLimitResponse(response *http.Response) (bool, *provider.RateLimitMetadata, error) {
 	data, truncated, err := provider.ReadDiagnosticBody(response.Body)
 	if err != nil {

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -231,12 +231,15 @@ func TestNormalizeRateLimitResponsePrefersRetryAfterHeader(t *testing.T) {
 }
 
 func TestParseConsoleRateLimitMetadataRPS(t *testing.T) {
-	metadata := parseConsoleRateLimitMetadata([]byte(`Too many requests for team 00000000-0000-0000-0000-000000000013 and model grok-4.20-multi-agent-0309. Requests per Second (actual/limit): 2/2`))
+	metadata := parseConsoleRateLimitMetadata([]byte(`{"code":"resource-exhausted","error":"Too many requests for team 00000000-0000-0000-0000-000000000013 and model grok-4.3. Your team's rate limit is — Requests per Second (actual/limit): 2/2."}`))
 	if metadata == nil {
 		t.Fatal("metadata is nil")
 	}
 	if metadata.Scope != provider.RateLimitScopeRPS || metadata.Actual != 2 || metadata.Limit != 2 || metadata.RetryAfter != 2*time.Second {
 		t.Fatalf("metadata = %#v", metadata)
+	}
+	if metadata.TeamID != "00000000-0000-0000-0000-000000000013" || metadata.Model != "grok-4.3" {
+		t.Fatalf("team/model = %q/%q", metadata.TeamID, metadata.Model)
 	}
 }
 
@@ -309,6 +312,11 @@ func TestAdapterForwardsConsoleHeadersAndNormalizedBody(t *testing.T) {
 		if request.Header.Get("User-Agent") != infraegress.DefaultUserAgent {
 			t.Errorf("user-agent = %q", request.Header.Get("User-Agent"))
 		}
+		if request.Header.Get("Sec-Ch-Ua") != `"Google Chrome";v="146", "Chromium";v="146", "Not(A:Brand";v="24"` ||
+			request.Header.Get("Sec-Ch-Ua-Mobile") != "?0" || request.Header.Get("Sec-Ch-Ua-Platform") != `"macOS"` ||
+			request.Header.Get("Sec-Ch-Ua-Arch") != "x86" || request.Header.Get("Sec-Ch-Ua-Bitness") != "64" {
+			t.Errorf("client hints = %#v", request.Header)
+		}
 		cookie := request.Header.Get("Cookie")
 		if !strings.Contains(cookie, "sso=test-sso") || !strings.Contains(cookie, "sso-rw=test-sso") {
 			t.Errorf("cookie = %q", cookie)
@@ -342,6 +350,16 @@ func TestAdapterForwardsConsoleHeadersAndNormalizedBody(t *testing.T) {
 	}
 	if received["model"] != "grok-4.3" || received["store"] != false || received["metadata"] != nil {
 		t.Fatalf("received = %#v", received)
+	}
+}
+
+func TestApplyChromiumClientHintsSkipsNonChromiumUserAgent(t *testing.T) {
+	header := make(http.Header)
+	applyChromiumClientHints(header, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Version/18.0 Safari/605.1.15")
+	for name := range header {
+		if strings.HasPrefix(http.CanonicalHeaderKey(name), "Sec-Ch-Ua") {
+			t.Fatalf("unexpected client hint %q", name)
+		}
 	}
 }
 

--- a/backend/internal/infra/provider/console/headers.go
+++ b/backend/internal/infra/provider/console/headers.go
@@ -1,0 +1,91 @@
+package console
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
+)
+
+var (
+	chromiumVersionPattern = regexp.MustCompile(`(?i)\b(?:chrome|chromium|crios)/(\d{2,3})(?:\.\d+)*`)
+	edgeVersionPattern     = regexp.MustCompile(`(?i)\b(?:edg|edga|edgios)/(\d{2,3})(?:\.\d+)*`)
+)
+
+func applyHeaders(request *http.Request, token string, lease *infraegress.Lease) {
+	userAgent := strings.TrimSpace(lease.UserAgent)
+	if userAgent == "" {
+		userAgent = infraegress.DefaultUserAgent
+	}
+	request.Header.Set("Accept", "*/*")
+	request.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+	request.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+	request.Header.Set("Authorization", "Bearer anonymous")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Cookie", infraegress.BuildSSOCookie(token, lease.CFCookies))
+	request.Header.Set("Origin", "https://console.x.ai")
+	request.Header.Set("Referer", "https://console.x.ai/")
+	request.Header.Set("Sec-Fetch-Dest", "empty")
+	request.Header.Set("Sec-Fetch-Mode", "cors")
+	request.Header.Set("Sec-Fetch-Site", "same-origin")
+	request.Header.Set("Priority", "u=1, i")
+	request.Header.Set("User-Agent", userAgent)
+	request.Header.Set("x-cluster", "https://us-east-1.api.x.ai")
+	applyChromiumClientHints(request.Header, userAgent)
+}
+
+// applyChromiumClientHints keeps the HTTP headers aligned with the Chromium
+// TLS profile used by the Console transport. Non-Chromium User-Agents do not
+// receive synthetic hints, avoiding contradictory browser fingerprints.
+func applyChromiumClientHints(header http.Header, userAgent string) {
+	lower := strings.ToLower(userAgent)
+	brand := "Google Chrome"
+	match := chromiumVersionPattern.FindStringSubmatch(userAgent)
+	if edge := edgeVersionPattern.FindStringSubmatch(userAgent); len(edge) == 2 {
+		brand, match = "Microsoft Edge", edge
+	} else if strings.Contains(lower, "chromium/") {
+		brand = "Chromium"
+	}
+	if len(match) != 2 {
+		return
+	}
+	version := match[1]
+	header.Set("Sec-Ch-Ua", fmt.Sprintf(`"%s";v="%s", "Chromium";v="%s", "Not(A:Brand";v="24"`, brand, version, version))
+
+	platform := ""
+	switch {
+	case strings.Contains(lower, "windows"):
+		platform = "Windows"
+	case strings.Contains(lower, "mac os x") || strings.Contains(lower, "macintosh"):
+		platform = "macOS"
+	case strings.Contains(lower, "android"):
+		platform = "Android"
+	case strings.Contains(lower, "iphone") || strings.Contains(lower, "ipad"):
+		platform = "iOS"
+	case strings.Contains(lower, "linux"):
+		platform = "Linux"
+	}
+	header.Set("Sec-Ch-Ua-Mobile", "?0")
+	if strings.Contains(lower, "mobile") || platform == "Android" || platform == "iOS" {
+		header.Set("Sec-Ch-Ua-Mobile", "?1")
+	}
+	header.Set("Sec-Ch-Ua-Model", "")
+	if platform != "" {
+		header.Set("Sec-Ch-Ua-Platform", strconv.Quote(platform))
+	}
+
+	arch := ""
+	switch {
+	case strings.Contains(lower, "aarch64") || strings.Contains(lower, "arm64") || strings.Contains(lower, " arm"):
+		arch = "arm"
+	case strings.Contains(lower, "x86_64") || strings.Contains(lower, "x64") || strings.Contains(lower, "win64") || strings.Contains(lower, "intel"):
+		arch = "x86"
+	}
+	if arch != "" {
+		header.Set("Sec-Ch-Ua-Arch", arch)
+		header.Set("Sec-Ch-Ua-Bitness", "64")
+	}
+}


### PR DESCRIPTION
## Summary

补齐 Grok Console 请求缺失的 Chromium Client Hints，使 HTTP 请求头与现有 Chrome 146 TLS 指纹及 User-Agent 保持一致。

## Changes

新增以下请求头：

- `Sec-CH-UA`
- `Sec-CH-UA-Mobile`
- `Sec-CH-UA-Platform`
- `Sec-CH-UA-Arch`
- `Sec-CH-UA-Bitness`
- `Sec-CH-UA-Model`

Client Hints 根据实际 User-Agent 生成：

- 支持 Chrome、Chromium 和 Edge
- 自动识别平台、移动端和 CPU 架构
- 非 Chromium User-Agent 不注入 Client Hints，避免产生矛盾指纹

同时将 Console 请求头构造从 `adapter.go` 拆分到独立的 `headers.go`，避免 Adapter 继续堆积协议细节。

## Console 429 Investigation

使用本地 Console SSO 凭据进行了真实请求验证，上游返回：

```text
resource-exhausted
Requests per Second (actual/limit): 2/2
Retry-After: 2
```

这属于 xAI 官方 Team + Model RPS 限流，不是：

- SSO Token 失效
- 请求路径错误
- Cloudflare 403
- 本地额度计算错误

现有网关已经能够：

- 解析 Team、Model、RPS/RPM 和重置时间
- 按 Team + Model 缓存短期限流状态
- 向客户端返回 `Retry-After`
- 避免将 Team 级限流错误标记为账号失效

本 PR 不尝试绕过或伪造官方限流。

## Compatibility

- Console 端点、Cookie、Authorization、`x-cluster` 和请求体保持不变。
- 不修改模型目录和额度窗口逻辑。
- 不影响 Grok Web 或 Grok Build 请求。
- 已配置的 Console User-Agent 会生成对应的 Client Hints。

## Test Plan

- [x] 默认 Chrome 146 UA 生成匹配的 Client Hints
- [x] macOS、架构和移动端字段正确
- [x] 非 Chromium UA 不注入 Client Hints
- [x] 真实 `resource-exhausted` 响应能够解析 Team、Model 和 RPS
- [x] Console Provider 测试通过
- [x] Race 检测通过