### PR TITLE
chore: update recommended build client version and user agent to 0.2.102 across multiple files

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -21,8 +21,8 @@ const (
 	StatsigModeManual             = "manual"
 	StatsigModeURL                = "url"
 	DefaultStatsigSignerURL       = "https://grok.wodf.de/sign"
-	RecommendedBuildClientVersion = "0.2.101"
-	RecommendedBuildUserAgent     = "grok-shell/0.2.101 (linux; x86_64)"
+	RecommendedBuildClientVersion = "0.2.102"
+	RecommendedBuildUserAgent     = "grok-shell/0.2.102 (linux; x86_64)"
 
 	maxServerBodyBytes    = 256 << 20
 	maxRequestTimeout     = 24 * time.Hour

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -70,13 +70,13 @@ bootstrapAdmin:
 
 func TestDefaultGrokBuildClientVersionMatchesLocalBaseline(t *testing.T) {
 	build := defaultConfig().Provider.Build
-	if RecommendedBuildClientVersion != "0.2.101" {
+	if RecommendedBuildClientVersion != "0.2.102" {
 		t.Fatalf("recommended clientVersion = %q", RecommendedBuildClientVersion)
 	}
 	if build.ClientVersion != RecommendedBuildClientVersion {
 		t.Fatalf("clientVersion = %q", build.ClientVersion)
 	}
-	if RecommendedBuildUserAgent != "grok-shell/0.2.101 (linux; x86_64)" {
+	if RecommendedBuildUserAgent != "grok-shell/0.2.102 (linux; x86_64)" {
 		t.Fatalf("recommended userAgent = %q", RecommendedBuildUserAgent)
 	}
 	if build.UserAgent != RecommendedBuildUserAgent {

--- a/backend/internal/infra/egress/buildclient_test.go
+++ b/backend/internal/infra/egress/buildclient_test.go
@@ -54,7 +54,7 @@ func TestNewBuildClientRejectsUnsupportedProxyScheme(t *testing.T) {
 
 func TestBuildClientRoutesThroughSOCKS5HWithRemoteDNS(t *testing.T) {
 	target := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.Header.Get("User-Agent") != "grok-shell/0.2.101 (linux; x86_64)" {
+		if request.Header.Get("User-Agent") != "grok-shell/0.2.102 (linux; x86_64)" {
 			t.Errorf("User-Agent = %q", request.Header.Get("User-Agent"))
 		}
 		writer.Header().Set("Connection", "close")
@@ -84,7 +84,7 @@ func TestBuildClientRoutesThroughSOCKS5HWithRemoteDNS(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.Close = true
-	request.Header.Set("User-Agent", "grok-shell/0.2.101 (linux; x86_64)")
+	request.Header.Set("User-Agent", "grok-shell/0.2.102 (linux; x86_64)")
 	response, err := client.Do(request)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/internal/infra/provider/cli/responses_advanced_test.go
+++ b/backend/internal/infra/provider/cli/responses_advanced_test.go
@@ -349,7 +349,7 @@ func TestResponsesBuild02101NativeAndUnsupportedToolMatrix(t *testing.T) {
 			body := []byte(`{"model":"public","input":"hello","tools":[{"type":"` + kind + `"}]}`)
 			_, _, err := normalizeResponsesRequest(body, "grok-4.5")
 			requestErr, ok := err.(*responsesRequestError)
-			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "0.2.101") {
+			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "0.2.102") {
 				t.Fatalf("error = %#v", err)
 			}
 		})

--- a/backend/internal/infra/provider/cli/responses_codex_tools.go
+++ b/backend/internal/infra/provider/cli/responses_codex_tools.go
@@ -19,7 +19,7 @@ func (c *responsesToolCompatibility) normalizeShellTool(tool map[string]any, par
 	return c.normalizeNativeTool(tool, param)
 }
 
-// normalizeLegacyLocalShellTool 将旧 Codex local_shell 升级为 0.2.101 原生 local shell 环境。
+// normalizeLegacyLocalShellTool 将旧 Codex local_shell 升级为 0.2.102 原生 local shell 环境。
 func (c *responsesToolCompatibility) normalizeLegacyLocalShellTool(tool map[string]any, param string) ([]any, error) {
 	if c.nativeShell || c.legacyLocalShell {
 		return nil, &responsesRequestError{

--- a/backend/internal/infra/provider/cli/responses_history.go
+++ b/backend/internal/infra/provider/cli/responses_history.go
@@ -53,7 +53,7 @@ func (c *responsesToolCompatibility) normalizeInputItems(items []any) ([]any, []
 			rewritten = append(rewritten, converted)
 		case "file_search_call", "web_search_call", "image_generation_call", "code_interpreter_call",
 			"shell_call", "mcp_list_tools", "mcp_approval_request", "mcp_approval_response", "mcp_call", "compaction":
-			// 这些类型已进入 Grok Build 0.2.101 的 Responses InputItem 契约。
+			// 这些类型已进入 Grok Build 0.2.102 的 Responses InputItem 契约。
 			// 仅清理 Codex 私有字段和 null，不能把原生调用降级成文本边界。
 			converted := sanitizeNativeHistoryInput(item, itemType)
 			c.changed = true
@@ -275,7 +275,7 @@ func hasPortableReasoningContent(item map[string]any) bool {
 	return false
 }
 
-// sanitizeNativeHistoryInput 按 Grok Build 0.2.101 的原生 InputItem 字段重建历史，
+// sanitizeNativeHistoryInput 按 Grok Build 0.2.102 的原生 InputItem 字段重建历史，
 // 避免 Codex 扩展元数据干扰 Rust untagged enum 的反序列化。
 func sanitizeNativeHistoryInput(item map[string]any, itemType string) map[string]any {
 	var fields []string

--- a/backend/internal/infra/provider/cli/responses_input.go
+++ b/backend/internal/infra/provider/cli/responses_input.go
@@ -131,7 +131,7 @@ func normalizeMessageContent(value any, role, param string) (any, error) {
 		case "input_file":
 			normalized = append(normalized, normalizeInputFilePart(item))
 		default:
-			return nil, &responsesRequestError{Message: "Grok Build 0.2.101 不支持该 message.content 类型", Param: fmt.Sprintf("%s[%d].type", param, index), Code: "unsupported_parameter"}
+			return nil, &responsesRequestError{Message: "Grok Build 0.2.102 不支持该 message.content 类型", Param: fmt.Sprintf("%s[%d].type", param, index), Code: "unsupported_parameter"}
 		}
 	}
 	return normalized, nil

--- a/backend/internal/infra/provider/cli/responses_tool_types.go
+++ b/backend/internal/infra/provider/cli/responses_tool_types.go
@@ -21,7 +21,7 @@ var nativeHostedToolChoiceTypes = map[string]string{
 	"local_shell":                   "shell",
 }
 
-// webSearchCompatibilityFields 是 Codex/OpenAI 新版声明中已知、但 0.2.101 上游会以
+// webSearchCompatibilityFields 是 Codex/OpenAI 新版声明中已知、但 0.2.102 上游会以
 // "Argument not supported" 拒绝的控制字段。Build 只能降级为其原生最小搜索工具。
 var webSearchCompatibilityFields = map[string]struct{}{
 	"external_web_access":  {},
@@ -33,7 +33,7 @@ var webSearchCompatibilityFields = map[string]struct{}{
 	"safe_search":          {},
 }
 
-// normalizeNativeTool 保留 0.2.101 已确认支持的工具，并拒绝只属于 Tool Search 的延迟字段。
+// normalizeNativeTool 保留 0.2.102 已确认支持的工具，并拒绝只属于 Tool Search 的延迟字段。
 func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, _ string) ([]any, error) {
 	converted := cloneJSONObject(tool)
 	if _, exists := converted["defer_loading"]; exists {
@@ -44,7 +44,7 @@ func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, _ 
 	return []any{converted}, nil
 }
 
-// normalizeWebSearchTool 保留 0.2.101 原生支持的 allowed_domains 约束，
+// normalizeWebSearchTool 保留 0.2.102 原生支持的 allowed_domains 约束，
 // 并将无法等价表达的新版控制字段安全降级。
 func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any, kind, param string) ([]any, error) {
 	if external, exists := tool["external_web_access"]; exists {
@@ -53,7 +53,7 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 			return nil, &responsesRequestError{Message: "external_web_access 必须是布尔值", Param: param + ".external_web_access", Code: "invalid_parameter"}
 		}
 		if !enabled {
-			// 0.2.101 不能表达“只允许索引、禁止外网”。发送最小 web_search
+			// 0.2.102 不能表达“只允许索引、禁止外网”。发送最小 web_search
 			// 会扩大客户端授权，因此直接移除该搜索工具，形成安全的能力子集。
 			c.webSearchDisabled = true
 			c.changed = true
@@ -208,7 +208,7 @@ func (c *responsesToolCompatibility) normalizeMCPTool(tool map[string]any, clien
 
 func unsupportedBuildToolError(kind, param string) error {
 	return &responsesRequestError{
-		Message: fmt.Sprintf("Grok Build 0.2.101 不支持 tools.type=%q", kind),
+		Message: fmt.Sprintf("Grok Build 0.2.102 不支持 tools.type=%q", kind),
 		Param:   param + ".type", Code: "unsupported_parameter",
 	}
 }

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -691,7 +691,7 @@ func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (
 			}
 			converted["filters"] = map[string]any{"allowed_domains": value}
 		case "max_uses", "blocked_domains", "user_location", "search_context_size":
-			// Build 0.2.101 只支持 allowed_domains；其余 Anthropic
+			// Build 0.2.102 只支持 allowed_domains；其余 Anthropic
 			// 可选控制字段不转发，避免上游因未知参数拒绝整个请求。
 			continue
 		default:

--- a/backend/internal/transport/http/settings/security_test.go
+++ b/backend/internal/transport/http/settings/security_test.go
@@ -47,9 +47,9 @@ func TestSettingsResponseDoesNotExposeBuildTokenAuth(t *testing.T) {
 
 func TestSettingsResponseIncludesRecommendedBuildBaseline(t *testing.T) {
 	response := newSettingsResponse(settingsapp.Snapshot{RecommendedProviderBuild: settingsapp.ProviderBuildRecommendation{
-		ClientVersion: "0.2.101", UserAgent: "grok-shell/0.2.101 (linux; x86_64)",
+		ClientVersion: "0.2.102", UserAgent: "grok-shell/0.2.102 (linux; x86_64)",
 	}})
-	if response.RecommendedProviderBuild.ClientVersion != "0.2.101" || response.RecommendedProviderBuild.UserAgent == "" {
+	if response.RecommendedProviderBuild.ClientVersion != "0.2.102" || response.RecommendedProviderBuild.UserAgent == "" {
 		t.Fatalf("recommended build = %#v", response.RecommendedProviderBuild)
 	}
 }


### PR DESCRIPTION
## Summary

将项目内置的 Grok Build 推荐客户端版本从 `0.2.101` 更新至官方当前版本 `0.2.102`。

官方仓库和本地 CLI 已确认：

```text
grok 0.2.102
```

## Changes

更新默认版本：

```text
x-grok-client-version: 0.2.102
User-Agent: grok-shell/0.2.102 (linux; x86_64)
```

同步更新：

- 后端推荐客户端版本
- 默认 Grok Build User-Agent
- 管理端推荐版本响应
- 请求头回归测试
- Responses 兼容边界提示
- Codex 工具兼容注释及错误文案
- Anthropic Messages 兼容说明

## Scope

本 PR 仅同步版本基线，不扩大或缩小当前协议能力：

- 不新增未经确认的工具类型
- 不改变 Responses 字段过滤规则
- 不改变账号路由与额度逻辑
- 不执行配置或数据库迁移
- 现有管理端运行设置仍可覆盖默认版本

## Compatibility

升级后：

- 新部署默认使用 `0.2.102`
- 已持久化自定义 Provider 设置保持不变
- 管理端可通过“同步推荐版本”应用新基线
- 旧配置缺少版本字段时继续使用内置默认值

## Test Plan

- [x] 默认 Client Version 为 `0.2.102`
- [x] 默认 User-Agent 为 `grok-shell/0.2.102`
- [x] Build 请求头测试通过
- [x] Responses 与 Codex 工具兼容测试通过
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./cmd/grok2api`
- [x] `git diff --check`