### PR TITLE
fix(egress): allow direct fallback when all nodes are disabled

### DIFF
--- a/backend/internal/infra/egress/manager.go
+++ b/backend/internal/infra/egress/manager.go
@@ -133,10 +133,13 @@ func (m *Manager) acquire(ctx context.Context, scope domain.Scope, affinity stri
 		if err != nil {
 			return nil, false, err
 		}
-		configured = configured || len(nodes) > 0
 		candidateAvailable := make([]domain.Node, 0, len(nodes))
 		for _, node := range nodes {
-			if node.Enabled && (node.CooldownUntil == nil || !now.Before(*node.CooldownUntil)) {
+			if !node.Enabled {
+				continue
+			}
+			configured = true
+			if node.CooldownUntil == nil || !now.Before(*node.CooldownUntil) {
 				candidateAvailable = append(candidateAvailable, node)
 			}
 		}

--- a/backend/internal/infra/egress/manager_test.go
+++ b/backend/internal/infra/egress/manager_test.go
@@ -93,6 +93,16 @@ func TestConfiguredCoolingAppNodesNeverFallBackToDirect(t *testing.T) {
 	}
 }
 
+func TestDisabledConfiguredNodesAllowDirectFallback(t *testing.T) {
+	manager := NewManager(egressRepositoryTestStub{nodes: []domain.Node{{
+		ID: 1, Name: "disabled-proxy", Scope: domain.ScopeBuild, Enabled: false, Health: 1,
+	}}}, nil)
+	lease, configured, err := manager.AcquireIfConfigured(context.Background(), domain.ScopeBuild, "")
+	if err != nil || configured || lease != nil {
+		t.Fatalf("disabled proxy fallback: lease=%#v configured=%v err=%v", lease, configured, err)
+	}
+}
+
 func TestAcquireIfConfiguredDoesNotChangeBuildDirectTransport(t *testing.T) {
 	cipher, err := security.NewCipher("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 	if err != nil {


### PR DESCRIPTION
## Summary

- ignore disabled egress nodes when determining whether a proxy scope is configured
- allow the existing direct fallback when every node in the scope is disabled
- keep fail-closed behavior when an enabled node exists but is cooling down

## Root cause

`Manager.acquire` marked a scope as configured whenever the repository returned any node. Disabled nodes were then filtered out of the available set, leaving `configured=true` with no available nodes and returning `当前没有可用的 <scope> 出口节点` instead of using the direct fallback.

The configured flag is now set only after a node passes the enabled check. Enabled nodes in cooldown still set the flag, so a proxy outage does not silently expose the direct IP.

## User impact

Administrators can use the Enabled toggle to disable every proxy node for a scope and return that scope to direct routing without deleting the saved node configuration.

## Checks

- `go test ./internal/infra/egress ./internal/application/egress`
- `git diff --check`