### PR TITLE
fix: allow safe deletion with terminal video jobs

### DIFF
--- a/backend/internal/application/account/service.go
+++ b/backend/internal/application/account/service.go
@@ -32,6 +32,7 @@ var (
 	ErrNotFound       = errors.New("账号不存在")
 	ErrUnsupported    = errors.New("账号来源不支持该操作")
 	ErrConversionBusy = errors.New("账号正在转换为 Grok Build")
+	ErrConflict       = errors.New("账号操作存在冲突")
 )
 
 var ErrCredentialRefreshPermanent = errors.New("OAuth refresh token 已永久失效")
@@ -481,6 +482,23 @@ func (s *Service) BatchDelete(ctx context.Context, ids []uint64) (int64, error) 
 		s.invalidateBuildBotFlagCache()
 	}
 	return deleted, mapRepositoryError(err)
+}
+
+// AccountsBelongToProvider 校验批量账号是否全部属于指定号池。
+// 该校验只读取账号主表，避免详情页的额度、审计或关联查询影响批量操作。
+func (s *Service) AccountsBelongToProvider(ctx context.Context, ids []uint64, providerValue accountdomain.Provider) (bool, error) {
+	if !providerValue.IsValid() {
+		return false, invalidInput("账号来源无效")
+	}
+	values, err := normalizeBatchIDs(ids)
+	if err != nil {
+		return false, err
+	}
+	count, err := s.accounts.CountProviderAccountsByIDs(ctx, providerValue, values)
+	if err != nil {
+		return false, err
+	}
+	return count == int64(len(values)), nil
 }
 
 // CleanupAccounts 按管理端状态清理指定 Provider 账号；正常、待重置和检测中的账号不在清理范围内。
@@ -2568,6 +2586,9 @@ func invalidInput(message string) error {
 func mapRepositoryError(err error) error {
 	if errors.Is(err, repository.ErrNotFound) {
 		return ErrNotFound
+	}
+	if errors.Is(err, repository.ErrConflict) {
+		return fmt.Errorf("%w: %s", ErrConflict, strings.TrimPrefix(err.Error(), repository.ErrConflict.Error()+": "))
 	}
 	return err
 }

--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -463,7 +463,11 @@ func (s *Service) reconcileVideoUsage(ctx context.Context) error {
 }
 
 func (s *Service) recordVideoAudit(ctx context.Context, job media.Job, durationMS int64) error {
-	accountID := job.AccountID
+	var accountID *uint64
+	if job.AccountID > 0 {
+		value := job.AccountID
+		accountID = &value
+	}
 	createdAt := time.Now().UTC()
 	if job.CompletedAt != nil && !job.CompletedAt.IsZero() {
 		createdAt = job.CompletedAt.UTC()
@@ -482,7 +486,7 @@ func (s *Service) recordVideoAudit(ctx context.Context, job media.Job, durationM
 		EventID: "video_usage_" + job.ID, RequestID: job.RequestID, ClientKeyID: job.ClientKeyID, ClientKeyName: job.ClientKeyName,
 		ModelRouteID: job.ModelRouteID, ModelPublicID: job.Model, ModelUpstreamModel: job.UpstreamModel,
 		Provider: job.Provider, Operation: audit.OperationVideo, UsageSource: audit.UsageSourceNone,
-		AccountID: &accountID, AccountName: job.AccountName, StatusCode: statusCode, ErrorCode: job.ErrorCode,
+		AccountID: accountID, AccountName: job.AccountName, StatusCode: statusCode, ErrorCode: job.ErrorCode,
 		EgressNodeID: job.EgressNodeID, EgressNodeName: job.EgressNodeName, EgressScope: job.EgressScope, EgressMode: audit.EgressMode(job.EgressMode),
 		MediaInputImages: int64(len(decodeVideoInput(job.InputJSON))),
 		DurationMS:       durationMS, CreatedAt: createdAt,

--- a/backend/internal/application/gateway/video_test.go
+++ b/backend/internal/application/gateway/video_test.go
@@ -70,6 +70,25 @@ func TestRecoverVideoJobsRecordsFailedAuditWithEgress(t *testing.T) {
 	}
 }
 
+func TestRecoverVideoJobsRecordsDetachedAccountSnapshot(t *testing.T) {
+	completedAt := time.Now().UTC()
+	repository := &videoUsageRepository{job: media.Job{
+		ID: "video_detached_account", RequestID: "request-detached-account",
+		ClientKeyID: 1, ClientKeyName: "client", AccountName: "deleted account",
+		Provider: "grok_web", Model: "grok-imagine-video", ModelRouteID: 3, UpstreamModel: "video",
+		Seconds: 8, Quality: "720p", Status: media.StatusFailed, ErrorCode: "generation_failed",
+		InputJSON: `{}`, CreatedAt: completedAt.Add(-time.Minute), CompletedAt: &completedAt,
+	}}
+	recorder := &durableVideoAuditRecorder{}
+	service := &Service{mediaJobs: repository, audits: recorder}
+	if err := service.RecoverVideoJobs(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.last.AccountID != nil || recorder.last.AccountName != "deleted account" {
+		t.Fatalf("detached account audit = %#v", recorder.last)
+	}
+}
+
 func TestVideoQueueIsBoundedAndDeduplicated(t *testing.T) {
 	service := &Service{}
 	service.ConfigureMedia(&videoUsageRepository{}, 1)

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/domain/media"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -126,6 +127,18 @@ func (r *AccountRepository) ListProviderAccountBatch(ctx context.Context, provid
 		return nil, 0, err
 	}
 	return out, total, nil
+}
+
+// CountProviderAccountsByIDs 只校验账号主表归属，不加载额度、关联或审计数据。
+func (r *AccountRepository) CountProviderAccountsByIDs(ctx context.Context, providerValue account.Provider, ids []uint64) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	var count int64
+	err := r.db.db.WithContext(ctx).Model(&accountModel{}).
+		Where("provider = ? AND id IN ?", providerValue, ids).
+		Count(&count).Error
+	return count, err
 }
 
 func (r *AccountRepository) Summarize(ctx context.Context, now time.Time) ([]repository.AccountSummary, error) {
@@ -972,22 +985,54 @@ func (r *AccountRepository) UpdateMany(ctx context.Context, ids []uint64, update
 }
 
 func (r *AccountRepository) Delete(ctx context.Context, id uint64) error {
-	result := r.db.db.WithContext(ctx).Delete(&accountModel{}, id)
-	if result.Error != nil {
-		return mapError(result.Error)
-	}
-	if result.RowsAffected == 0 {
-		return repository.ErrNotFound
-	}
-	return nil
+	return r.db.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var lockedID uint64
+		if err := tx.Model(&accountModel{}).Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", id).Pluck("id", &lockedID).Error; err != nil {
+			return err
+		}
+		if lockedID == 0 {
+			return repository.ErrNotFound
+		}
+		if err := rejectAccountsWithMediaJobs(tx, []uint64{id}); err != nil {
+			return err
+		}
+		return mapError(tx.Delete(&accountModel{}, id).Error)
+	})
 }
 
 func (r *AccountRepository) DeleteMany(ctx context.Context, ids []uint64) (int64, error) {
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	result := r.db.db.WithContext(ctx).Where("id IN ?", ids).Delete(&accountModel{})
-	return result.RowsAffected, result.Error
+	var deleted int64
+	err := r.db.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var lockedIDs []uint64
+		if err := tx.Model(&accountModel{}).Clauses(clause.Locking{Strength: "UPDATE"}).Where("id IN ?", ids).Pluck("id", &lockedIDs).Error; err != nil {
+			return err
+		}
+		if err := rejectAccountsWithMediaJobs(tx, lockedIDs); err != nil {
+			return err
+		}
+		result := tx.Where("id IN ?", lockedIDs).Delete(&accountModel{})
+		deleted = result.RowsAffected
+		return result.Error
+	})
+	return deleted, err
+}
+
+// rejectAccountsWithMediaJobs 仅保护仍需账号继续执行的活动视频任务。
+// completed/failed 已保存账号名称等快照，删除账号后由外键 SET NULL 保留历史。
+func rejectAccountsWithMediaJobs(db *gorm.DB, ids []uint64) error {
+	var count int64
+	if err := db.Model(&mediaJobModel{}).
+		Where("account_id IN ? AND status IN ?", ids, []string{string(media.StatusQueued), string(media.StatusInProgress)}).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: 账号仍关联 %d 条排队中或进行中的视频任务，请等待任务结束后重试", repository.ErrConflict, count)
+	}
+	return nil
 }
 
 func (r *AccountRepository) DeleteAccountStatusBatch(ctx context.Context, providerValue account.Provider, status string, now time.Time, limit int) ([]uint64, int, error) {
@@ -1006,6 +1051,9 @@ func (r *AccountRepository) DeleteAccountStatusBatch(ctx context.Context, provid
 			return err
 		}
 		candidateCount = len(candidates)
+		if err := rejectAccountsWithMediaJobs(tx, candidates); err != nil {
+			return err
+		}
 		deletion := applyAccountStatusFilter(tx.Where("id IN ?", candidates), status, now).Delete(&accountModel{})
 		if deletion.Error != nil {
 			return deletion.Error

--- a/backend/internal/infra/persistence/relational/media_repository.go
+++ b/backend/internal/infra/persistence/relational/media_repository.go
@@ -441,7 +441,7 @@ func (r *MediaJobRepository) TryClaimMediaJob(ctx context.Context, id string, no
 func mediaJobFromDomain(value media.Job) *mediaJobModel {
 	return &mediaJobModel{
 		ID: value.ID, RequestID: value.RequestID, ClientKeyID: value.ClientKeyID, ClientKeyName: value.ClientKeyName,
-		AccountID: value.AccountID, AccountName: value.AccountName,
+		AccountID: mediaJobAccountID(value.AccountID), AccountName: value.AccountName,
 		EgressNodeID: value.EgressNodeID, EgressNodeName: value.EgressNodeName, EgressScope: value.EgressScope, EgressMode: value.EgressMode,
 		Provider: value.Provider,
 		Model:    value.Model, ModelRouteID: value.ModelRouteID, UpstreamModel: value.UpstreamModel,
@@ -454,9 +454,13 @@ func mediaJobFromDomain(value media.Job) *mediaJobModel {
 }
 
 func mediaJobToDomain(row mediaJobModel) media.Job {
+	var accountID uint64
+	if row.AccountID != nil {
+		accountID = *row.AccountID
+	}
 	return media.Job{
 		ID: row.ID, RequestID: row.RequestID, ClientKeyID: row.ClientKeyID, ClientKeyName: row.ClientKeyName,
-		AccountID: row.AccountID, AccountName: row.AccountName,
+		AccountID: accountID, AccountName: row.AccountName,
 		EgressNodeID: row.EgressNodeID, EgressNodeName: row.EgressNodeName, EgressScope: row.EgressScope, EgressMode: row.EgressMode,
 		Provider: row.Provider,
 		Model:    row.Model, ModelRouteID: row.ModelRouteID, UpstreamModel: row.UpstreamModel,
@@ -466,4 +470,11 @@ func mediaJobToDomain(row mediaJobModel) media.Job {
 		LeaseUntil: row.LeaseUntil, ClaimToken: row.ClaimToken, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
 		CompletedAt: row.CompletedAt, UsageRecordedAt: row.UsageRecordedAt,
 	}
+}
+
+func mediaJobAccountID(value uint64) *uint64 {
+	if value == 0 {
+		return nil
+	}
+	return &value
 }

--- a/backend/internal/infra/persistence/relational/media_repository_test.go
+++ b/backend/internal/infra/persistence/relational/media_repository_test.go
@@ -125,6 +125,57 @@ func TestMediaJobRepositoryListMediaJobsPaginatesAndFilters(t *testing.T) {
 	}
 }
 
+func TestAccountDeleteDetachesTerminalMediaJobsAndRejectsActiveJobs(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDatabase(t)
+	accounts := NewAccountRepository(database)
+	accountValue, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderWeb, AuthType: accountdomain.AuthTypeSSO,
+		Name: "media-delete-account", SourceKey: "media-delete-account",
+		EncryptedAccessToken: testEncryptedToken, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := clientKeyModel{Name: "media-delete-key", Prefix: "media-delete-key", SecretHash: testSecretHash, EncryptedSecret: testEncryptedToken, Enabled: true, RPMLimit: 60, MaxConcurrent: 4}
+	if err := database.db.WithContext(ctx).Create(&key).Error; err != nil {
+		t.Fatal(err)
+	}
+	job := testMediaJob("media_job_account_delete", accountValue.ID, key.ID, mediadomain.StatusCompleted, time.Now().UTC())
+	job.AccountName = accountValue.Name
+	jobs := NewMediaJobRepository(database)
+	if err := jobs.CreateMediaJob(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := accounts.Delete(ctx, accountValue.ID); err != nil {
+		t.Fatalf("delete account with terminal media job: %v", err)
+	}
+	stored, err := jobs.GetMediaJobsByIDs(ctx, []string{job.ID})
+	if err != nil || len(stored) != 1 || stored[0].AccountID != 0 || stored[0].AccountName != accountValue.Name {
+		t.Fatalf("detached terminal job = %#v, error = %v", stored, err)
+	}
+
+	activeAccount, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderWeb, AuthType: accountdomain.AuthTypeSSO,
+		Name: "media-active-account", SourceKey: "media-active-account",
+		EncryptedAccessToken: testEncryptedToken, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeJob := testMediaJob("media_job_account_active", activeAccount.ID, key.ID, mediadomain.StatusInProgress, time.Now().UTC())
+	if err := jobs.CreateMediaJob(ctx, activeJob); err != nil {
+		t.Fatal(err)
+	}
+	if err := accounts.Delete(ctx, activeAccount.ID); !errors.Is(err, repository.ErrConflict) || !strings.Contains(err.Error(), "进行中") {
+		t.Fatalf("delete account with active media job error = %v", err)
+	}
+	if _, err := accounts.Get(ctx, activeAccount.ID); err != nil {
+		t.Fatalf("active job conflict removed account: %v", err)
+	}
+}
+
 func TestMediaAssetRepositoryListMediaAssetsPaginatesAndCounts(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDatabase(t)

--- a/backend/internal/infra/persistence/relational/models.go
+++ b/backend/internal/infra/persistence/relational/models.go
@@ -373,7 +373,7 @@ type mediaJobModel struct {
 	RequestID       string  `gorm:"size:64;not null;check:chk_media_jobs_request_id,length(request_id) BETWEEN 1 AND 64"`
 	ClientKeyID     uint64  `gorm:"not null;check:chk_media_jobs_client_key_id,client_key_id > 0"`
 	ClientKeyName   string  `gorm:"size:160;not null;default:'';check:chk_media_jobs_client_key_name,length(client_key_name) <= 160"`
-	AccountID       uint64  `gorm:"not null;check:chk_media_jobs_account_id,account_id > 0"`
+	AccountID       *uint64 `gorm:"check:chk_media_jobs_account_id,account_id IS NULL OR account_id > 0"`
 	AccountName     string  `gorm:"size:160;not null;default:'';check:chk_media_jobs_account_name,length(account_name) <= 160"`
 	EgressNodeID    *uint64 `gorm:"check:chk_media_jobs_egress_node_id,egress_node_id IS NULL OR egress_node_id > 0"`
 	EgressNodeName  string  `gorm:"size:160;not null;default:'';check:chk_media_jobs_egress_node_name,length(egress_node_name) <= 160"`
@@ -401,7 +401,7 @@ type mediaJobModel struct {
 	UpdatedAt       time.Time `gorm:"not null"`
 	CompletedAt     *time.Time
 	UsageRecordedAt *time.Time
-	Account         *accountModel   `gorm:"foreignKey:AccountID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT"`
+	Account         *accountModel   `gorm:"foreignKey:AccountID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
 	ClientKey       *clientKeyModel `gorm:"foreignKey:ClientKeyID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT"`
 }
 

--- a/backend/internal/infra/persistence/relational/schema.go
+++ b/backend/internal/infra/persistence/relational/schema.go
@@ -111,6 +111,9 @@ func (d *Database) InitializeSchema(ctx context.Context) error {
 	if err := d.ensureMediaJobConstraints(ctx); err != nil {
 		return fmt.Errorf("迁移 media job 数据库约束: %w", err)
 	}
+	if err := d.ensureMediaJobAccountForeignKey(ctx); err != nil {
+		return fmt.Errorf("迁移 media job 账号外键: %w", err)
+	}
 	if err := d.ensureMediaAssetConstraints(ctx); err != nil {
 		return fmt.Errorf("迁移 media asset 数据库约束: %w", err)
 	}
@@ -159,6 +162,44 @@ func (d *Database) ensureMediaJobConstraints(ctx context.Context) error {
 		{model: &mediaJobModel{}, table: "media_jobs", name: "chk_media_jobs_provider"},
 		{model: &mediaJobModel{}, table: "media_jobs", name: "chk_media_jobs_egress_scope"},
 	}, "grok_build")
+}
+
+// ensureMediaJobAccountForeignKey 让终态视频任务在账号删除后保留快照，
+// 同时由应用层阻止删除仍有关联 queued/in_progress 任务的账号。
+func (d *Database) ensureMediaJobAccountForeignKey(ctx context.Context) error {
+	constraint := consoleConstraint{model: &mediaJobModel{}, table: "media_jobs", name: "fk_media_jobs_account"}
+	definition, err := d.constraintDefinition(ctx, constraint)
+	if err != nil {
+		return err
+	}
+	if d.dialect == "postgres" {
+		db := d.db.WithContext(ctx)
+		if err := db.Exec("ALTER TABLE media_jobs ALTER COLUMN account_id DROP NOT NULL").Error; err != nil {
+			return err
+		}
+		if strings.Contains(strings.ToUpper(definition), "ON DELETE SET NULL") {
+			return nil
+		}
+		if err := db.Exec("ALTER TABLE media_jobs DROP CONSTRAINT IF EXISTS fk_media_jobs_account").Error; err != nil {
+			return err
+		}
+		return db.Exec("ALTER TABLE media_jobs ADD CONSTRAINT fk_media_jobs_account FOREIGN KEY (account_id) REFERENCES provider_accounts(id) ON UPDATE CASCADE ON DELETE SET NULL").Error
+	}
+	if strings.Contains(strings.ToUpper(definition), "ON DELETE SET NULL") {
+		return nil
+	}
+	return d.withSQLiteForeignKeysDisabled(ctx, func() error {
+		migrator := d.db.WithContext(ctx).Migrator()
+		if err := migrator.AlterColumn(&mediaJobModel{}, "AccountID"); err != nil {
+			return err
+		}
+		if definition != "" {
+			if err := migrator.DropConstraint(&mediaJobModel{}, "Account"); err != nil {
+				return err
+			}
+		}
+		return migrator.CreateConstraint(&mediaJobModel{}, "Account")
+	})
 }
 
 // ensureMediaAssetConstraints 升级历史仅允许 image 的媒体资产 CHECK，以支持 video 与更大体积。

--- a/backend/internal/infra/persistence/relational/schema_media_job_upgrade_test.go
+++ b/backend/internal/infra/persistence/relational/schema_media_job_upgrade_test.go
@@ -210,6 +210,9 @@ func assertMediaJobSQLContainsBuild(t *testing.T, database *Database) {
 	if strings.Contains(sql, "grok_console") {
 		t.Fatalf("media_jobs unexpectedly allows console: %s", sql)
 	}
+	if !strings.Contains(strings.ToUpper(sql), "ON DELETE SET NULL") {
+		t.Fatalf("media_jobs account history is not detached on account delete: %s", sql)
+	}
 }
 
 func mediaJobsTableSQL(t *testing.T, database *Database) string {

--- a/backend/internal/repository/account.go
+++ b/backend/internal/repository/account.go
@@ -28,6 +28,7 @@ type AccountRepository interface {
 	Summarize(ctx context.Context, now time.Time) ([]AccountSummary, error)
 	ListEnabled(ctx context.Context, provider account.Provider) ([]account.Credential, error)
 	ListEnabledAccountIDs(ctx context.Context, provider account.Provider, refreshableOnly bool) ([]uint64, error)
+	CountProviderAccountsByIDs(ctx context.Context, provider account.Provider, ids []uint64) (int64, error)
 	// FilterMissingBuildConversionIDs 从指定账号中排除已经关联 Build 的 Web 账号。
 	FilterMissingBuildConversionIDs(ctx context.Context, ids []uint64) ([]uint64, error)
 	// ListUnlinkedWebAccountIDs 以 ID 游标取未关联 Web 账号；total 仅在 afterID 为 0 时返回。

--- a/backend/internal/transport/http/account/handler.go
+++ b/backend/internal/transport/http/account/handler.go
@@ -1013,6 +1013,8 @@ func (h *Handler) writeServiceError(c *gin.Context, code string, err error, fall
 		response.Error(c, http.StatusBadRequest, "accountExportLimitExceeded", err.Error())
 	case errors.Is(err, accountapp.ErrInvalidInput), errors.Is(err, accountapp.ErrInvalidImport):
 		response.Error(c, http.StatusBadRequest, code, err.Error())
+	case errors.Is(err, accountapp.ErrConflict):
+		response.Error(c, http.StatusConflict, code, err.Error())
 	case errors.Is(err, accountapp.ErrNotFound):
 		response.Error(c, http.StatusNotFound, "accountNotFound", err.Error())
 	case errors.Is(err, accountapp.ErrUnsupported):
@@ -1233,16 +1235,19 @@ func parseIDs(values []string) ([]uint64, error) {
 }
 
 func (h *Handler) validateProviderIDs(c *gin.Context, ids []uint64, providerValue string) bool {
-	if providerValue != string(accountdomain.ProviderBuild) && providerValue != string(accountdomain.ProviderWeb) && providerValue != string(accountdomain.ProviderConsole) {
+	provider := accountdomain.Provider(providerValue)
+	if !provider.IsValid() {
 		response.Error(c, http.StatusBadRequest, "invalidProvider", "账号来源无效")
 		return false
 	}
-	for _, id := range ids {
-		value, err := h.service.Get(c.Request.Context(), id)
-		if err != nil || string(value.Credential.Provider) != providerValue {
-			response.Error(c, http.StatusConflict, "accountPoolMismatch", "批量操作包含不属于当前号池的账号")
-			return false
-		}
+	valid, err := h.service.AccountsBelongToProvider(c.Request.Context(), ids, provider)
+	if err != nil {
+		h.writeServiceError(c, "accountPoolValidationFailed", err, http.StatusInternalServerError, "校验账号号池失败")
+		return false
+	}
+	if !valid {
+		response.Error(c, http.StatusConflict, "accountPoolMismatch", "批量操作包含不属于当前号池的账号")
+		return false
 	}
 	return true
 }

--- a/frontend/src/features/accounts/accounts-page.tsx
+++ b/frontend/src/features/accounts/accounts-page.tsx
@@ -91,6 +91,11 @@ type BuildConversionProgressState = {
 
 type WebConversionTarget = "build" | "console";
 
+type AccountSelection = {
+  provider: AccountProvider;
+  ids: Set<string>;
+};
+
 export function AccountsPage() {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
@@ -112,7 +117,7 @@ export function AccountsPage() {
   const [renewalFilter, setRenewalFilter] = useState("");
   const [riskFilter, setRiskFilter] = useState("");
   const [sort, setSort] = useState<TableSort>({ field: "createdAt", order: "desc" });
-  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [selection, setSelection] = useState<AccountSelection>(() => ({ provider: "grok_build", ids: new Set() }));
   const [batchDeleteOpen, setBatchDeleteOpen] = useState(false);
   const [cleanupOpen, setCleanupOpen] = useState(false);
   const [cleanupStatuses, setCleanupStatuses] = useState<Set<AccountCleanupStatus>>(() => new Set());
@@ -171,6 +176,7 @@ export function AccountsPage() {
   const clearCloudflareCookies = useWatch({ control: form.control, name: "clearCloudflareCookies" });
   const buildSuperEntitled = useWatch({ control: form.control, name: "buildSuperEntitled" });
   const buildRouteMode = useWatch({ control: form.control, name: "buildRouteMode" });
+  const selected = selection.provider === provider ? selection.ids : new Set<string>();
 
   const accountsQuery = useQuery({
     queryKey: ["accounts", provider, page, pageSize, debouncedSearch, typeFilter, statusFilter, renewalFilter, riskFilter, sort.field, sort.order],
@@ -317,7 +323,7 @@ export function AccountsPage() {
     onSuccess: (conversion) => {
       setConversionProgress(null);
       setWebConversionTargets(null);
-      setSelected(new Set());
+      clearSelection();
       toast.success(t("accounts.conversionCompleted", conversion));
     },
     onError: (error) => { if (!isAbortError(error)) showError(error); },
@@ -338,7 +344,7 @@ export function AccountsPage() {
     },
     onSuccess: (result) => {
       setWebConversionTargets(null);
-      setSelected(new Set());
+      clearSelection();
       toast.success(t("webConsoleSync.completed", result));
     },
     onError: (error) => { if (!isAbortError(error)) showError(error); },
@@ -359,7 +365,7 @@ export function AccountsPage() {
     },
     onSuccess: (result) => {
       setWebAccountScriptsTargets(null);
-      setSelected(new Set());
+      clearSelection();
       if (result.failed > 0) {
         toast.warning(t("webAccountScripts.completedWithFailures", result));
       } else {
@@ -424,7 +430,7 @@ export function AccountsPage() {
   const batchUpdateMutation = useMutation({
     mutationFn: (enabled: boolean) => updateAccountsEnabled([...selected], enabled, provider),
     onSuccess: () => {
-      setSelected(new Set());
+      clearSelection();
       invalidateAccountData();
       toast.success(t("accounts.batchUpdated"));
     },
@@ -434,7 +440,7 @@ export function AccountsPage() {
   const batchBillingMutation = useMutation({
     mutationFn: () => refreshAccountsQuota([...selected], provider),
     onSuccess: (result) => {
-      setSelected(new Set());
+      clearSelection();
       invalidateAccountData();
       toast.success(t("accounts.batchBillingRefreshed", result));
     },
@@ -444,7 +450,7 @@ export function AccountsPage() {
   const batchTokenMutation = useMutation({
     mutationFn: () => refreshAccountsTokens([...selected], provider),
     onSuccess: (result) => {
-      setSelected(new Set());
+      clearSelection();
       invalidateAccountData();
       toast.success(t("accounts.allTokensRefreshed", result));
     },
@@ -454,7 +460,7 @@ export function AccountsPage() {
   const batchDeleteMutation = useMutation({
     mutationFn: () => deleteAccounts([...selected], provider),
     onSuccess: () => {
-      setSelected(new Set());
+      clearSelection();
       setBatchDeleteOpen(false);
       invalidateAccountData();
       toast.success(t("accounts.deleted"));
@@ -517,7 +523,7 @@ export function AccountsPage() {
   function changeProvider(value: AccountProvider) {
     setProvider(value);
     setPage(1);
-    setSelected(new Set());
+    setSelection({ provider: value, ids: new Set() });
     setTypeFilter("");
     setStatusFilter("");
     setRenewalFilter("");
@@ -626,23 +632,27 @@ export function AccountsPage() {
   const selectedOnPage = pageIDs.filter((id) => selected.has(id));
   const allPageSelected = pageIDs.length > 0 && selectedOnPage.length === pageIDs.length;
 
+  function clearSelection(): void {
+    setSelection((current) => ({ provider: current.provider, ids: new Set() }));
+  }
+
   function togglePage(checked: boolean): void {
-    setSelected((current) => {
-      const next = new Set(current);
+    setSelection((current) => {
+      const next = new Set(current.provider === provider ? current.ids : []);
       for (const id of pageIDs) {
         if (checked) next.add(id);
         else next.delete(id);
       }
-      return next;
+      return { provider, ids: next };
     });
   }
 
   function toggleAccount(id: string, checked: boolean): void {
-    setSelected((current) => {
-      const next = new Set(current);
+    setSelection((current) => {
+      const next = new Set(current.provider === provider ? current.ids : []);
       if (checked) next.add(id);
       else next.delete(id);
-      return next;
+      return { provider, ids: next };
     });
   }
 


### PR DESCRIPTION
## Summary

Fix account deletion failures caused by stale cross-provider selections and video-job foreign-key constraints.

Completed and failed video jobs now behave as historical snapshots: deleting their account preserves the task, media, and audit history while detaching the deleted account ID. Queued or in-progress jobs still protect their account until execution finishes.

## Changes

### Batch account operations

- Bind frontend account selections to the active Provider.
- Clear selections when switching between Build, Web, and Console pools.
- Prevent stale account IDs from being submitted with another Provider.
- Replace per-account full-detail validation with a single account-table query.
- Avoid misreporting quota, audit, or linked-account query failures as account-pool mismatches.
- Return internal validation failures separately from genuine Provider mismatches.

### Account deletion and video jobs

- Allow account deletion when associated video jobs are:
  - `completed`
  - `failed`
- Continue blocking account deletion when jobs are:
  - `queued`
  - `in_progress`
- Preserve terminal video task records after account deletion.
- Preserve prompt, model, status, timestamps, account-name snapshot, and media references.
- Detach the deleted account by setting `media_jobs.account_id` to `NULL`.
- Do not cascade-delete video tasks, local media assets, or request audits.
- Return a readable `409 Conflict` when an active video task still requires the account.

### Database migration

- Make `media_jobs.account_id` nullable.
- Change its account foreign key to `ON DELETE SET NULL`.
- Add idempotent SQLite and PostgreSQL migration handling.
- Keep active-task deletion protection in the application layer.
- Lock selected account rows during deletion to avoid concurrent job-creation races.

### Audit compatibility

- Request audits remain independent snapshots and are never deleted with accounts.
- Deferred video audit recording supports detached terminal jobs.
- When an account has already been deleted, the audit retains the account-name snapshot without writing an invalid account ID.

## Result

After upgrading and restarting:

- Accounts associated only with completed or failed video jobs can be deleted normally.
- Existing terminal video records and media remain available.
- Accounts used by queued or running video jobs return a clear conflict and remain intact.
- Cross-provider batch selections can no longer trigger false account-pool mismatch errors.

## Checks

- [x] Relational persistence tests
- [x] Account application tests
- [x] Account HTTP handler tests
- [x] Gateway video recovery and audit tests
- [x] SQLite migration regression tests
- [x] `go vet` on affected packages
- [x] `go build ./cmd/grok2api`
- [x] Frontend production build
- [x] `git diff --check`