### PR TITLE
fix: record Anthropic Messages cache usage

### DIFF
--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1175,6 +1175,7 @@ type responseUsageDTO struct {
 	ContextDetails         responseContextDetailsDTO `json:"context_details"`
 	PromptTokens           int64                     `json:"prompt_tokens"`
 	CompletionTokens       int64                     `json:"completion_tokens"`
+	CacheReadInputTokens   int64                     `json:"cache_read_input_tokens"`
 }
 
 type responseInputDetailsDTO struct {
@@ -1213,7 +1214,7 @@ func (value responseUsageDTO) toGatewayUsage(responseModel string) gateway.Usage
 		total = input + output
 	}
 	return gateway.Usage{
-		InputTokens: input, CachedInputTokens: value.InputTokensDetails.CachedTokens,
+		InputTokens: input, CachedInputTokens: max(value.InputTokensDetails.CachedTokens, value.CacheReadInputTokens),
 		OutputTokens: output, ReasoningTokens: value.OutputTokensDetails.ReasoningTokens,
 		TotalTokens: total, CostInUSDTicks: value.CostInUSDTicks,
 		NumSourcesUsed: value.NumSourcesUsed, NumServerSideToolsUsed: value.NumServerSideToolsUsed,

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -489,6 +489,14 @@ func TestExtractUsageFromCompletedEvent(t *testing.T) {
 	}
 }
 
+func TestExtractUsageFromAnthropicMessages(t *testing.T) {
+	metadata := extractMetadata([]byte(`{"id":"msg_1","model":"grok-4.5","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":4}}`))
+	usage := metadata.Usage
+	if usage.InputTokens != 10 || usage.CachedInputTokens != 4 || usage.OutputTokens != 5 || usage.TotalTokens != 15 {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
 func TestUsageInspectorHandlesChunkedSSE(t *testing.T) {
 	inspector := &responseInspector{}
 	inspector.Inspect([]byte("data: {\"response\":{\"id\":\"resp_stream\",\"usage\":{\"input_tokens\":2,"))


### PR DESCRIPTION
## 问题

Anthropic Messages 响应在协议转换后使用 `cache_read_input_tokens` 表示缓存命中，但统一 usage 解析器只读取 Responses 的 `input_tokens_details.cached_tokens`，导致 Messages 请求的 `request_audits.cached_input_tokens` 始终记录为 0。

## 修改

- 解析 Anthropic `cache_read_input_tokens` 并写入统一 `CachedInputTokens`
- 保留 Responses `input_tokens_details.cached_tokens` 的现有行为
- 增加 Anthropic Messages usage 回归测试

## 验证

- `go test ./...`
- 本地真实流式 Messages 请求记录到 `input_tokens=129669`、`cached_input_tokens=128896`