### PR TITLE
feat: 在模型列表中暴露 Grok 4.20 Multi-Agent 推理档位

### DIFF
--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -19,6 +19,7 @@ import (
 	clientkeydomain "github.com/chenyme/grok2api/backend/internal/domain/clientkey"
 	mediadomain "github.com/chenyme/grok2api/backend/internal/domain/media"
 	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+	consoleprovider "github.com/chenyme/grok2api/backend/internal/infra/provider/console"
 	"github.com/chenyme/grok2api/backend/internal/transport/http/middleware"
 	"github.com/gin-gonic/gin"
 )
@@ -154,6 +155,8 @@ type modelListItem struct {
 	OwnedBy string `json:"owned_by"`
 }
 
+const multiAgentBaseModel = "grok-4.20-multi-agent-0309"
+
 func (h *Handler) listModels(c *gin.Context) {
 	values, err := h.models.ListEnabled(c.Request.Context())
 	if err != nil {
@@ -165,15 +168,23 @@ func (h *Handler) listModels(c *gin.Context) {
 
 // newModelListItems 按下游公开名称去重，隐藏仅用于内部选路的 Provider 前缀。
 func newModelListItems(values []modeldomain.Route) []modelListItem {
-	data := make([]modelListItem, 0, len(values))
-	seen := make(map[string]bool, len(values))
+	aliases := consoleprovider.Aliases()
+	data := make([]modelListItem, 0, len(values)+len(aliases))
+	seen := make(map[string]bool, len(values)+len(aliases))
 	for _, value := range values {
 		publicID := modeldomain.ExternalPublicID(value.Provider, value.PublicID)
-		if seen[publicID] {
-			continue
+		if !seen[publicID] {
+			seen[publicID] = true
+			data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api"})
 		}
-		seen[publicID] = true
-		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api"})
+		if value.UpstreamModel == multiAgentBaseModel {
+			for _, alias := range aliases {
+				if alias.Provider == value.Provider && alias.UpstreamModel == value.UpstreamModel && alias.ReasoningEffort != "" && !seen[alias.Alias] {
+					seen[alias.Alias] = true
+					data = append(data, modelListItem{ID: alias.Alias, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api"})
+				}
+			}
+		}
 	}
 	return data
 }

--- a/backend/internal/transport/http/inference/model_list_test.go
+++ b/backend/internal/transport/http/inference/model_list_test.go
@@ -19,3 +19,25 @@ func TestNewModelListItemsDeduplicatesSharedPublicName(t *testing.T) {
 		t.Fatalf("model list = %#v", items)
 	}
 }
+
+func TestNewModelListItemsPublishesMultiAgentEffortsFromConsoleBaseRoute(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	buildRoute := modeldomain.Route{PublicID: "Build/renamed-multi-agent", Provider: account.ProviderBuild, UpstreamModel: "grok-4.20-multi-agent-0309", CreatedAt: now}
+	consoleRoute := modeldomain.Route{PublicID: "Console/renamed-multi-agent", Provider: account.ProviderConsole, UpstreamModel: "grok-4.20-multi-agent-0309", CreatedAt: now}
+	if items := newModelListItems([]modeldomain.Route{buildRoute}); len(items) != 1 || items[0].ID != "renamed-multi-agent" {
+		t.Fatalf("build-only model list = %#v", items)
+	}
+	items := newModelListItems([]modeldomain.Route{buildRoute, consoleRoute})
+	want := []string{
+		"grok-4.20-multi-agent-low", "grok-4.20-multi-agent-medium",
+		"grok-4.20-multi-agent-high", "grok-4.20-multi-agent-xhigh",
+	}
+	if len(items) != len(want)+1 || items[0].ID != "renamed-multi-agent" {
+		t.Fatalf("model list = %#v", items)
+	}
+	for index, publicID := range want {
+		if items[index+1].ID != publicID || items[index+1].Created != now.Unix() {
+			t.Fatalf("model list = %#v", items)
+		}
+	}
+}


### PR DESCRIPTION
复用 Console 模型别名配置，在 /v1/models 中公开 low、medium、high 和 xhigh。 仅在对应基础路由可用时返回别名，并补充跨 Provider 同名去重回归测试。