### PR TITLE
feat: add CLI account pool API and optional admin auth bypass

### DIFF
--- a/backend/internal/app/application.go
+++ b/backend/internal/app/application.go
@@ -236,6 +236,7 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*Applicat
 	auditService := auditapp.NewService(auditRepo, logger, cfg.Audit.BufferSize, cfg.Audit.BatchSize, cfg.Audit.FlushInterval.Value())
 	dashboardService := dashboardapp.NewService(dashboardRepo)
 	selector := gateway.NewSelector(accountRepo, concurrency, sticky, providers, cfg.Routing.StickyTTL.Value(), cfg.Routing.CooldownBase.Value(), cfg.Routing.CooldownMax.Value(), cfg.Routing.CapacityWait.Value())
+	cliPool := gateway.NewCliPool(selector, accountRepo, accountService, cipher)
 	gatewayService := gateway.NewService(modelService, auditService, accountService, clientKeyService, providers, selector, responseRepo, cfg.Routing.MaxAttempts)
 	gatewayService.SetLogger(logger)
 	gatewayService.ConfigureMedia(mediaJobRepo, cfg.Provider.Web.MediaConcurrency)
@@ -284,7 +285,7 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*Applicat
 	readiness := func(readyCtx context.Context) httpserver.ReadinessSnapshot {
 		return readinessSnapshot(readyCtx, startup, runtimeHealth, modelRepo, accountRepo, providers)
 	}
-	router := httpserver.New(httpserver.Dependencies{Logger: logger, RequestTimeout: cfg.Server.RequestTimeout.Value(), MaxBodyBytes: cfg.Server.MaxBodyBytes, ConcurrencyGate: inferenceConcurrency, SecureCookies: cfg.Auth.SecureCookies, SwaggerEnabled: cfg.Server.SwaggerEnabled, PublicAPIBaseURL: cfg.Frontend.EffectivePublicAPIBaseURL(), FrontendStaticPath: cfg.Frontend.StaticPath, Readiness: readiness, TrafficReady: startup.acceptsTraffic, AdminAuth: adminService, Accounts: accountService, AccountSync: accountSyncService, Models: modelService, ClientKeys: clientKeyService, Audits: auditService, Dashboard: dashboardService, Gateway: gatewayService, Media: mediaService, Settings: settingsService, Egress: egressService, Updates: updateService})
+	router := httpserver.New(httpserver.Dependencies{Logger: logger, RequestTimeout: cfg.Server.RequestTimeout.Value(), MaxBodyBytes: cfg.Server.MaxBodyBytes, ConcurrencyGate: inferenceConcurrency, SecureCookies: cfg.Auth.SecureCookies, SwaggerEnabled: cfg.Server.SwaggerEnabled, AdminAuthDisabled: cfg.Server.AdminAuthDisabled, PublicAPIBaseURL: cfg.Frontend.EffectivePublicAPIBaseURL(), FrontendStaticPath: cfg.Frontend.StaticPath, Readiness: readiness, TrafficReady: startup.acceptsTraffic, AdminAuth: adminService, Accounts: accountService, AccountSync: accountSyncService, Models: modelService, ClientKeys: clientKeyService, Audits: auditService, Dashboard: dashboardService, Gateway: gatewayService, CliPool: cliPool, Media: mediaService, Settings: settingsService, Egress: egressService, Updates: updateService})
 	server := &http.Server{Addr: cfg.Server.Listen, Handler: router, ReadHeaderTimeout: 10 * time.Second, ReadTimeout: cfg.Server.ReadTimeout.Value(), IdleTimeout: 2 * time.Minute, MaxHeaderBytes: 64 << 10}
 	return &Application{
 		logger: logger, database: database, server: server,

--- a/backend/internal/application/adminauth/service.go
+++ b/backend/internal/application/adminauth/service.go
@@ -46,6 +46,17 @@ func NewService(admins repository.AdminRepository, sessions repository.AdminSess
 
 func (s *Service) SetLoginRateLimiter(limiter repository.RateLimiter) { s.loginLimiter = limiter }
 
+// LocalAdmin 返回本机免登录模式下注入的管理员身份（优先库内首个管理员）。
+func (s *Service) LocalAdmin(ctx context.Context) admin.Admin {
+	if s == nil || s.admins == nil {
+		return admin.Admin{ID: 1, Username: "local"}
+	}
+	if value, err := s.admins.GetByID(ctx, 1); err == nil {
+		return value
+	}
+	return admin.Admin{ID: 1, Username: "local"}
+}
+
 // Bootstrap 在数据库没有管理员时创建唯一管理员。
 func (s *Service) Bootstrap(ctx context.Context, username, password string) error {
 	count, err := s.admins.Count(ctx)

--- a/backend/internal/application/gateway/clipool.go
+++ b/backend/internal/application/gateway/clipool.go
@@ -1,0 +1,213 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	accountapp "github.com/chenyme/grok2api/backend/internal/application/account"
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/infra/security"
+	"github.com/chenyme/grok2api/backend/internal/repository"
+	"github.com/google/uuid"
+)
+
+const defaultBuildOAuthClientID = "b1a00492-073a-47ea-816f-4c329264a828"
+
+// ReportReason 是 CLI 号池报障原因。
+type ReportReason string
+
+const (
+	ReportReasonOK                 ReportReason = "ok"
+	ReportReasonQuotaExhausted     ReportReason = "quota_exhausted"
+	ReportReasonFreeUsageExhausted ReportReason = "free_usage_exhausted"
+	ReportReasonAuthRejected       ReportReason = "auth_rejected"
+)
+
+// CliPool 为 grok-build CLI 提供与网关共用 Selector 的租号/报障/释放能力。
+type CliPool struct {
+	selector *Selector
+	repo     repository.AccountRepository
+	accounts *accountapp.Service
+	cipher   *security.Cipher
+	mu       sync.Mutex
+	leases   map[string]*cliPoolLease
+}
+
+type cliPoolLease struct {
+	lease   *accountLease
+	billing *account.Billing
+}
+
+// LeaseResult 是租号成功后返回给 CLI 的明文 OAuth 凭据。
+type LeaseResult struct {
+	LeaseID      string     `json:"leaseId"`
+	AccountID    uint64     `json:"accountId"`
+	Name         string     `json:"name"`
+	Email        string     `json:"email,omitempty"`
+	UserID       string     `json:"userId,omitempty"`
+	TeamID       string     `json:"teamId,omitempty"`
+	ClientID     string     `json:"clientId"`
+	AccessToken  string     `json:"accessToken"`
+	RefreshToken string     `json:"refreshToken,omitempty"`
+	ExpiresAt    *time.Time `json:"expiresAt,omitempty"`
+}
+
+// NewCliPool 创建 CLI 号池服务。
+func NewCliPool(selector *Selector, repo repository.AccountRepository, accounts *accountapp.Service, cipher *security.Cipher) *CliPool {
+	return &CliPool{
+		selector: selector,
+		repo:     repo,
+		accounts: accounts,
+		cipher:   cipher,
+		leases:   make(map[string]*cliPoolLease),
+	}
+}
+
+// Lease 从 grok_build 号池租用一个账号（可排除已试账号）。
+func (p *CliPool) Lease(ctx context.Context, excluded []uint64) (LeaseResult, error) {
+	excludedSet := make(map[uint64]bool, len(excluded))
+	for _, id := range excluded {
+		if id != 0 {
+			excludedSet[id] = true
+		}
+	}
+	lease, err := p.selector.Acquire(ctx, account.ProviderBuild, "", "", "", excludedSet, false)
+	if err != nil {
+		return LeaseResult{}, err
+	}
+	accessToken, err := p.cipher.Decrypt(lease.Credential.EncryptedAccessToken)
+	if err != nil {
+		lease.Release()
+		return LeaseResult{}, fmt.Errorf("解密 access token: %w", err)
+	}
+	refreshToken, err := p.cipher.Decrypt(lease.Credential.EncryptedRefreshToken)
+	if err != nil {
+		lease.Release()
+		return LeaseResult{}, fmt.Errorf("解密 refresh token: %w", err)
+	}
+	if accessToken == "" && refreshToken == "" {
+		lease.Release()
+		return LeaseResult{}, fmt.Errorf("账号 %d 没有可用 OAuth 凭据", lease.Credential.ID)
+	}
+	clientID := lease.Credential.OIDCClientID
+	if clientID == "" {
+		clientID = defaultBuildOAuthClientID
+	}
+	leaseID := uuid.NewString()
+	result := LeaseResult{
+		LeaseID:      leaseID,
+		AccountID:    lease.Credential.ID,
+		Name:         lease.Credential.Name,
+		Email:        lease.Credential.Email,
+		UserID:       lease.Credential.UserID,
+		TeamID:       lease.Credential.TeamID,
+		ClientID:     clientID,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+	}
+	if !lease.Credential.ExpiresAt.IsZero() {
+		expires := lease.Credential.ExpiresAt.UTC()
+		result.ExpiresAt = &expires
+	}
+	p.mu.Lock()
+	p.leases[leaseID] = &cliPoolLease{lease: lease, billing: lease.Billing}
+	p.mu.Unlock()
+	return result, nil
+}
+
+// Report 将 CLI 侧账号结果写回号池（不释放并发槽）。
+func (p *CliPool) Report(ctx context.Context, accountID uint64, reason ReportReason, httpStatus int, leaseID string) error {
+	if accountID == 0 {
+		return fmt.Errorf("accountId 不能为空")
+	}
+	credential, billing, err := p.resolveCredential(ctx, accountID, leaseID)
+	if err != nil {
+		return err
+	}
+	switch reason {
+	case ReportReasonOK:
+		p.selector.MarkSuccess(ctx, credential)
+		return nil
+	case ReportReasonFreeUsageExhausted:
+		p.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
+		return nil
+	case ReportReasonQuotaExhausted:
+		if !p.selector.MarkPaidQuotaExhausted(ctx, credential, billing) {
+			status := httpStatus
+			if status == 0 {
+				status = http.StatusPaymentRequired
+			}
+			p.selector.MarkFailure(ctx, credential, status, 0)
+			p.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
+		}
+		return nil
+	case ReportReasonAuthRejected:
+		status := httpStatus
+		if status == 0 {
+			status = http.StatusUnauthorized
+		}
+		if p.accounts != nil {
+			_ = p.accounts.MarkReauthRequired(ctx, credential.ID, "cli pool credential rejected")
+		}
+		p.selector.MarkFailure(ctx, credential, status, 0)
+		p.selector.MarkQuotaStateChanged(credential.Provider)
+		return nil
+	default:
+		return fmt.Errorf("未知报障原因: %s", reason)
+	}
+}
+
+// Release 释放租约对应的并发槽。
+func (p *CliPool) Release(leaseID string) error {
+	if leaseID == "" {
+		return fmt.Errorf("leaseId 不能为空")
+	}
+	p.mu.Lock()
+	entry, ok := p.leases[leaseID]
+	if ok {
+		delete(p.leases, leaseID)
+	}
+	p.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	entry.lease.Release()
+	return nil
+}
+
+func (p *CliPool) resolveCredential(ctx context.Context, accountID uint64, leaseID string) (account.Credential, *account.Billing, error) {
+	if leaseID != "" {
+		p.mu.Lock()
+		entry, ok := p.leases[leaseID]
+		p.mu.Unlock()
+		if ok && entry.lease != nil && entry.lease.Credential.ID == accountID {
+			return entry.lease.Credential, entry.billing, nil
+		}
+	}
+	credential, err := p.repo.Get(ctx, accountID)
+	if err != nil {
+		return account.Credential{}, nil, err
+	}
+	if credential.Provider != account.ProviderBuild {
+		return account.Credential{}, nil, fmt.Errorf("账号 %d 不是 grok_build", accountID)
+	}
+	billings, err := p.repo.GetBillings(ctx, []uint64{accountID})
+	if err != nil {
+		return account.Credential{}, nil, err
+	}
+	billing, ok := billings[accountID]
+	if !ok {
+		return credential, nil, nil
+	}
+	return credential, &billing, nil
+}
+
+// IsSelectionUnavailable 判断错误是否为选号不可用。
+func IsSelectionUnavailable(err error) bool {
+	var unavailable *SelectionUnavailableError
+	return errors.As(err, &unavailable)
+}

--- a/backend/internal/application/gateway/clipool_test.go
+++ b/backend/internal/application/gateway/clipool_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/infra/persistence/relational"
+	"github.com/chenyme/grok2api/backend/internal/infra/runtime/memory"
+	"github.com/chenyme/grok2api/backend/internal/infra/security"
+)
+
+func TestCliPoolLeaseReportRelease(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "clipool.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	key := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	cipher, err := security.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	access, err := cipher.Encrypt("access-token-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refresh, err := cipher.Encrypt("refresh-token-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accounts := relational.NewAccountRepository(database)
+	created, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "primary", SourceKey: "primary",
+		Email: "a@example.com", UserID: "u1", OIDCClientID: "client-1",
+		EncryptedAccessToken: access, EncryptedRefreshToken: refresh,
+		Enabled: true, AuthStatus: account.AuthStatusActive, MaxConcurrent: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+	pool := NewCliPool(selector, accounts, nil, cipher)
+
+	lease, err := pool.Lease(ctx, nil)
+	if err != nil {
+		t.Fatalf("lease: %v", err)
+	}
+	if lease.AccountID != created.ID || lease.AccessToken != "access-token-1" || lease.RefreshToken != "refresh-token-1" {
+		t.Fatalf("unexpected lease: %+v", lease)
+	}
+	if err := pool.Report(ctx, lease.AccountID, ReportReasonFreeUsageExhausted, 429, lease.LeaseID); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	if err := pool.Release(lease.LeaseID); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if err := pool.Release(lease.LeaseID); err != nil {
+		t.Fatalf("idempotent release: %v", err)
+	}
+}
+
+func TestCliPoolLeaseExcludes(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "clipool-exclude.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	key := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	cipher, err := security.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	for _, item := range []struct {
+		name  string
+		token string
+	}{
+		{"a", "tok-a"},
+		{"b", "tok-b"},
+	} {
+		access, _ := cipher.Encrypt(item.token)
+		refresh, _ := cipher.Encrypt("rt-" + item.token)
+		if _, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+			Provider: account.ProviderBuild, Name: item.name, SourceKey: item.name,
+			EncryptedAccessToken: access, EncryptedRefreshToken: refresh,
+			Enabled: true, AuthStatus: account.AuthStatusActive, MaxConcurrent: 2,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+	pool := NewCliPool(selector, accounts, nil, cipher)
+
+	first, err := pool.Lease(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := pool.Lease(ctx, []uint64{first.AccountID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.AccountID == first.AccountID {
+		t.Fatalf("expected excluded account to be skipped, got %#v then %#v", first, second)
+	}
+	_ = pool.Release(first.LeaseID)
+	_ = pool.Release(second.LeaseID)
+}

--- a/backend/internal/domain/model/client_alias.go
+++ b/backend/internal/domain/model/client_alias.go
@@ -1,0 +1,17 @@
+package model
+
+// ClientModelAlias 是下游客户端可见的兼容模型名。
+// 用于 Cursor 等拒绝带点号模型 ID（如 grok-4.5）的场景。
+type ClientModelAlias struct {
+	// Alias 是客户端可填写、并会出现在 GET /v1/models 中的名称。
+	Alias string
+	// Target 是真实对外模型名（无 Provider 前缀），例如 grok-4.5。
+	Target string
+}
+
+// ClientModelAliases 返回需要在模型列表中额外暴露的兼容名称。
+func ClientModelAliases() []ClientModelAlias {
+	return []ClientModelAlias{
+		{Alias: "grok-4-5", Target: "grok-4.5"},
+	}
+}

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -59,6 +59,8 @@ type ServerConfig struct {
 	ReadTimeout           Duration `yaml:"readTimeout"`
 	RequestTimeout        Duration `yaml:"requestTimeout"`
 	SwaggerEnabled        bool     `yaml:"swaggerEnabled"`
+	// AdminAuthDisabled 关闭管理端登录鉴权，仅建议本机开发使用。
+	AdminAuthDisabled bool `yaml:"adminAuthDisabled"`
 }
 
 type FrontendConfig struct {

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -67,6 +67,8 @@ func (a *Adapter) SetEgress(manager *infraegress.Manager) {
 
 func (a *Adapter) Provider() account.Provider { return account.ProviderBuild }
 
+func (a *Adapter) ModelAliases() []provider.ModelAlias { return Aliases() }
+
 func (a *Adapter) UpdateConfig(cfg Config) {
 	a.cfgMu.Lock()
 	a.cfg = cfg

--- a/backend/internal/infra/provider/cli/catalog.go
+++ b/backend/internal/infra/provider/cli/catalog.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider"
+)
+
+// Build 侧兼容别名：将 Cursor 可用名解析到真实上游模型。
+var aliases = []provider.ModelAlias{
+	buildAlias("grok-4-5", "grok-4.5", "grok-4.5", ""),
+}
+
+func buildAlias(alias, publicModel, upstreamModel, effort string) provider.ModelAlias {
+	canonical, _ := modeldomain.NormalizePublicID(account.ProviderBuild, publicModel)
+	return provider.ModelAlias{
+		Alias: alias, PublicModel: canonical, Provider: account.ProviderBuild,
+		UpstreamModel: upstreamModel, ReasoningEffort: effort,
+	}
+}
+
+func Aliases() []provider.ModelAlias {
+	return append([]provider.ModelAlias(nil), aliases...)
+}

--- a/backend/internal/infra/provider/cli/catalog_test.go
+++ b/backend/internal/infra/provider/cli/catalog_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider"
+)
+
+func TestBuildModelAliasMapsCursorFriendlyNameToGrok45(t *testing.T) {
+	registry := provider.NewRegistry(NewAdapter(Config{}, nil))
+	alias, ok := registry.ResolveModelAlias("grok-4-5")
+	if !ok {
+		t.Fatal("grok-4-5 alias missing")
+	}
+	if alias.Provider != account.ProviderBuild {
+		t.Fatalf("provider = %s, want Build", alias.Provider)
+	}
+	if alias.UpstreamModel != "grok-4.5" {
+		t.Fatalf("upstream = %q, want grok-4.5", alias.UpstreamModel)
+	}
+	if !strings.HasPrefix(alias.PublicModel, "Build/") {
+		t.Fatalf("public model = %q, want Build/ prefix", alias.PublicModel)
+	}
+}

--- a/backend/internal/transport/http/clipool/handler.go
+++ b/backend/internal/transport/http/clipool/handler.go
@@ -1,0 +1,114 @@
+package clipool
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/application/gateway"
+	"github.com/chenyme/grok2api/backend/internal/shared/response"
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	pool *gateway.CliPool
+}
+
+func NewHandler(pool *gateway.CliPool) *Handler {
+	return &Handler{pool: pool}
+}
+
+func (h *Handler) Register(router *gin.RouterGroup) {
+	router.POST("/cli-pool/lease", h.lease)
+	router.POST("/cli-pool/report", h.report)
+	router.POST("/cli-pool/release", h.release)
+}
+
+type leaseRequest struct {
+	Excluded []uint64 `json:"excluded"`
+}
+
+type reportRequest struct {
+	AccountID  uint64 `json:"accountId" binding:"required"`
+	Reason     string `json:"reason" binding:"required"`
+	HTTPStatus int    `json:"httpStatus"`
+	LeaseID    string `json:"leaseId"`
+}
+
+type releaseRequest struct {
+	LeaseID string `json:"leaseId" binding:"required"`
+}
+
+func (h *Handler) lease(c *gin.Context) {
+	if h.pool == nil {
+		response.Error(c, http.StatusServiceUnavailable, "cliPoolUnavailable", "CLI 号池未启用")
+		return
+	}
+	var request leaseRequest
+	if c.Request.ContentLength > 0 && c.ShouldBindJSON(&request) != nil {
+		response.Error(c, http.StatusBadRequest, "invalidRequest", "请求参数无效")
+		return
+	}
+	result, err := h.pool.Lease(c.Request.Context(), request.Excluded)
+	if err != nil {
+		if gateway.IsSelectionUnavailable(err) {
+			var unavailable *gateway.SelectionUnavailableError
+			_ = errors.As(err, &unavailable)
+			retryAfter := 0
+			if unavailable != nil && unavailable.RetryAfter > 0 {
+				retryAfter = int(unavailable.RetryAfter.Round(time.Second) / time.Second)
+				if retryAfter < 1 {
+					retryAfter = 1
+				}
+				c.Header("Retry-After", strconv.Itoa(retryAfter))
+			}
+			response.Error(c, http.StatusTooManyRequests, "upstream_quota_exhausted", err.Error())
+			return
+		}
+		response.Error(c, http.StatusInternalServerError, "cliPoolLeaseFailed", "租号失败: "+err.Error())
+		return
+	}
+	response.Success(c, http.StatusOK, result)
+}
+
+func (h *Handler) report(c *gin.Context) {
+	if h.pool == nil {
+		response.Error(c, http.StatusServiceUnavailable, "cliPoolUnavailable", "CLI 号池未启用")
+		return
+	}
+	var request reportRequest
+	if c.ShouldBindJSON(&request) != nil {
+		response.Error(c, http.StatusBadRequest, "invalidRequest", "请求参数无效")
+		return
+	}
+	reason := gateway.ReportReason(request.Reason)
+	switch reason {
+	case gateway.ReportReasonOK, gateway.ReportReasonQuotaExhausted, gateway.ReportReasonFreeUsageExhausted, gateway.ReportReasonAuthRejected:
+	default:
+		response.Error(c, http.StatusBadRequest, "invalidRequest", "未知报障原因")
+		return
+	}
+	if err := h.pool.Report(c.Request.Context(), request.AccountID, reason, request.HTTPStatus, request.LeaseID); err != nil {
+		response.Error(c, http.StatusInternalServerError, "cliPoolReportFailed", "报障失败: "+err.Error())
+		return
+	}
+	response.Success(c, http.StatusOK, gin.H{"ok": true})
+}
+
+func (h *Handler) release(c *gin.Context) {
+	if h.pool == nil {
+		response.Error(c, http.StatusServiceUnavailable, "cliPoolUnavailable", "CLI 号池未启用")
+		return
+	}
+	var request releaseRequest
+	if c.ShouldBindJSON(&request) != nil {
+		response.Error(c, http.StatusBadRequest, "invalidRequest", "请求参数无效")
+		return
+	}
+	if err := h.pool.Release(request.LeaseID); err != nil {
+		response.Error(c, http.StatusBadRequest, "cliPoolReleaseFailed", err.Error())
+		return
+	}
+	response.Success(c, http.StatusOK, gin.H{"ok": true})
+}

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -145,16 +145,28 @@ func (h *Handler) listModels(c *gin.Context) {
 }
 
 // newModelListItems 按下游公开名称去重，隐藏仅用于内部选路的 Provider 前缀。
+// 同时附加 ClientModelAliases（例如 grok-4-5 → grok-4.5），供 Cursor 等客户端使用。
 func newModelListItems(values []modeldomain.Route) []modelListItem {
 	data := make([]modelListItem, 0, len(values))
 	seen := make(map[string]bool, len(values))
+	createdByID := make(map[string]int64, len(values))
 	for _, value := range values {
 		publicID := modeldomain.ExternalPublicID(value.Provider, value.PublicID)
-		if seen[publicID] {
+		if !seen[publicID] {
+			seen[publicID] = true
+			created := value.CreatedAt.Unix()
+			createdByID[publicID] = created
+			data = append(data, modelListItem{ID: publicID, Object: "model", Created: created, OwnedBy: "grok2api"})
+		}
+	}
+	for _, alias := range modeldomain.ClientModelAliases() {
+		if alias.Alias == "" || alias.Target == "" || seen[alias.Alias] || !seen[alias.Target] {
 			continue
 		}
-		seen[publicID] = true
-		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api"})
+		seen[alias.Alias] = true
+		data = append(data, modelListItem{
+			ID: alias.Alias, Object: "model", Created: createdByID[alias.Target], OwnedBy: "grok2api",
+		})
 	}
 	return data
 }

--- a/backend/internal/transport/http/inference/model_list_test.go
+++ b/backend/internal/transport/http/inference/model_list_test.go
@@ -19,3 +19,17 @@ func TestNewModelListItemsDeduplicatesSharedPublicName(t *testing.T) {
 		t.Fatalf("model list = %#v", items)
 	}
 }
+
+func TestNewModelListItemsExposesCursorFriendlyGrok45Alias(t *testing.T) {
+	now := time.Unix(200, 0).UTC()
+	items := newModelListItems([]modeldomain.Route{
+		{PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, CreatedAt: now},
+	})
+	ids := map[string]bool{}
+	for _, item := range items {
+		ids[item.ID] = true
+	}
+	if !ids["grok-4.5"] || !ids["grok-4-5"] {
+		t.Fatalf("expected grok-4.5 and grok-4-5 in %#v", items)
+	}
+}

--- a/backend/internal/transport/http/middleware/auth.go
+++ b/backend/internal/transport/http/middleware/auth.go
@@ -17,8 +17,16 @@ const (
 )
 
 // AdminAuth 校验管理员 Bearer JWT。
-func AdminAuth(service *adminauth.Service) gin.HandlerFunc {
+// disabled 为 true 时跳过鉴权（本机开发），直接注入 LocalAdmin。
+func AdminAuth(service *adminauth.Service, disabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if disabled {
+			if service != nil {
+				c.Set(AdminKey, service.LocalAdmin(c.Request.Context()))
+			}
+			c.Next()
+			return
+		}
 		raw, ok := bearerToken(c.GetHeader("Authorization"))
 		if !ok {
 			response.Error(c, http.StatusUnauthorized, "adminUnauthorized", "管理员登录已失效")

--- a/backend/internal/transport/http/server.go
+++ b/backend/internal/transport/http/server.go
@@ -21,6 +21,7 @@ import (
 	updatecheckapp "github.com/chenyme/grok2api/backend/internal/application/updatecheck"
 	accounthttp "github.com/chenyme/grok2api/backend/internal/transport/http/account"
 	adminauthhttp "github.com/chenyme/grok2api/backend/internal/transport/http/adminauth"
+	clipoolhttp "github.com/chenyme/grok2api/backend/internal/transport/http/clipool"
 	audithttp "github.com/chenyme/grok2api/backend/internal/transport/http/audit"
 	clientkeyhttp "github.com/chenyme/grok2api/backend/internal/transport/http/clientkey"
 	dashboardhttp "github.com/chenyme/grok2api/backend/internal/transport/http/dashboard"
@@ -43,6 +44,7 @@ type Dependencies struct {
 	ConcurrencyGate    *middleware.ConcurrencyGate
 	SecureCookies      bool
 	SwaggerEnabled     bool
+	AdminAuthDisabled  bool
 	PublicAPIBaseURL   string
 	FrontendStaticPath string
 	// Readiness 返回可观测的分层就绪状态。Ready 仅为旧调用方保留。
@@ -57,6 +59,7 @@ type Dependencies struct {
 	Audits       *auditapp.Service
 	Dashboard    *dashboardapp.Service
 	Gateway      *gateway.Service
+	CliPool      *gateway.CliPool
 	Media        *mediaapp.Service
 	Settings     *settingsapp.Service
 	Egress       *egressapp.Service
@@ -139,9 +142,12 @@ func New(deps Dependencies) *gin.Engine {
 	authHandler := adminauthhttp.NewHandler(deps.AdminAuth, deps.SecureCookies)
 	authHandler.RegisterPublic(adminRoot)
 	adminProtected := adminRoot.Group("")
-	adminProtected.Use(middleware.AdminAuth(deps.AdminAuth))
+	adminProtected.Use(middleware.AdminAuth(deps.AdminAuth, deps.AdminAuthDisabled))
 	authHandler.RegisterAuthenticated(adminProtected)
 	accounthttp.NewHandler(deps.Accounts, deps.AccountSync).Register(adminProtected)
+	if deps.CliPool != nil {
+		clipoolhttp.NewHandler(deps.CliPool).Register(adminProtected)
+	}
 	modelhttp.NewHandler(deps.Models).Register(adminProtected)
 	clientkeyhttp.NewHandler(deps.ClientKeys).Register(adminProtected)
 	audithttp.NewHandler(deps.Audits).Register(adminProtected)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,8 @@ server:
   requestTimeout: 2h
   # [按需修改] 仅在本地或受信任环境开启，生产环境保持 false。
   swaggerEnabled: false
+  # [按需修改] 本机开发可设 true 关闭管理后台登录；切勿在公网暴露时开启。
+  adminAuthDisabled: false
 
 auth:
   # [通常不要修改] 管理端访问与刷新令牌有效期。

--- a/frontend/src/app/app-shell.tsx
+++ b/frontend/src/app/app-shell.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Box, ChevronDown, Eye, Image, KeyRound, Languages, LayoutDashboard, LogOut, Menu, MessageSquareText, Monitor, Moon, MoreHorizontal, Settings, Sparkles, Sun, Users, Video } from "lucide-react";
+import { Box, ChevronDown, Eye, Image, KeyRound, Languages, LayoutDashboard, Menu, MessageSquareText, Monitor, Moon, MoreHorizontal, Settings, Sparkles, Sun, Users, Video } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useState, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
@@ -198,9 +198,7 @@ export function AppShell() {
               <DropdownMenuItem onClick={() => void i18n.changeLanguage("en")}>English</DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          <DropdownMenuItem className="h-8" onClick={() => setPasswordOpen(true)}><KeyRound />{t("auth.changePassword")}</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem className="h-8" onClick={() => void logout()}><LogOut />{t("auth.signOut")}</DropdownMenuItem>
+          {/* 本机免登录模式下隐藏改密/退出，避免误操作 */}
         </DropdownMenuContent>
       </DropdownMenu>
       <NavLink

--- a/frontend/src/shared/auth/auth-context.tsx
+++ b/frontend/src/shared/auth/auth-context.tsx
@@ -19,6 +19,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const restoreSession = useCallback(async (): Promise<void> => {
     setStatus("restoring");
+
+    // 本机免登录：后端 adminAuthDisabled 时 /me 无需 token 即可访问
+    try {
+      const openAccess = await apiRequest("/api/admin/v1/me", { retryAuth: false }, decodeAdminDTO);
+      setAdmin(openAccess);
+      setStatus("authenticated");
+      return;
+    } catch {
+      // 继续走正式会话恢复
+    }
+
     const refreshResult = await refreshAccessToken();
     if (refreshResult === "invalid") {
       setAdmin(null);

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,41 @@
+@echo off
+chcp 65001 >nul 2>&1
+title chenyme Grok2API
+
+cd /d "%~dp0"
+
+if not exist "config.yaml" (
+    echo [ERROR] 未找到 config.yaml
+    echo         请先复制: copy config.example.yaml config.yaml
+    pause
+    exit /b 1
+)
+
+where go >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] 未找到 go，请先安装 Go 并加入 PATH
+    pause
+    exit /b 1
+)
+
+netstat -ano | findstr ":8000" | findstr "LISTENING" >nul 2>&1
+if not errorlevel 1 (
+    echo [OK] Grok2API 已在运行  http://127.0.0.1:8000
+    start "" "http://127.0.0.1:8000"
+    pause
+    exit /b 0
+)
+
+echo ================================================
+echo   chenyme Grok2API
+echo   管理端 / API: http://127.0.0.1:8000
+echo   按 Ctrl+C 停止服务
+echo ================================================
+echo.
+
+start "" "http://127.0.0.1:8000"
+cd /d "%~dp0backend"
+go run ./cmd/grok2api --config "%~dp0config.yaml"
+
+echo.
+pause


### PR DESCRIPTION
## Summary
- Add grok-build CLI lease/report pool HTTP API for external clients
- Improve CLI model catalog aliases and inference listing
- Add optional `adminAuthDisabled` for trusted local setups, plus `start.bat`

## Test plan
- [ ] Unit tests for clipool / catalog pass
- [ ] Local admin login bypass works only when `adminAuthDisabled: true`
- [ ] CLI pool lease/report/release flow works against seeded build accounts


Made with [Cursor](https://cursor.com)