### PR TITLE
fix: 保留推理恢复后的限流响应

### DIFF
--- a/backend/internal/infra/provider/cli/responses_compaction_test.go
+++ b/backend/internal/infra/provider/cli/responses_compaction_test.go
@@ -218,6 +218,12 @@ func TestGatewayCompactionLifecycleWithMillionTokenScaleHistory(t *testing.T) {
 	adapter, encrypted := newCompactionTestAdapter(t)
 	// “x ”在常见 BPE 编码中接近一个 token；此处保守构造超过 1M token 量级的历史文本。
 	history := strings.Repeat("x ", 2<<20)
+	summary := healthyCompactionSummary()
+	continuation := gatewayCompactionContinuation(summary)
+	encodedSummary, err := json.Marshal(continuation)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var calls atomic.Int32
 	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		call := calls.Add(1)
@@ -230,9 +236,9 @@ func TestGatewayCompactionLifecycleWithMillionTokenScaleHistory(t *testing.T) {
 			if len(data) < 4<<20 || strings.Contains(string(data), "compaction_trigger") {
 				t.Fatalf("压缩采样未携带完整超长历史：size=%d", len(data))
 			}
-			return sseResponse(http.StatusOK, compactionSampleSSE("resp_million", healthyCompactionSummary()), request), nil
+			return sseResponse(http.StatusOK, compactionSampleSSE("resp_million", summary), request), nil
 		case 2:
-			if len(data) >= 4096 || strings.Contains(string(data), `"type":"compaction"`) || strings.Contains(string(data), `"encrypted_content"`) || !strings.Contains(string(data), "压缩后继续执行") {
+			if len(data) >= 4096 || strings.Contains(string(data), `"type":"compaction"`) || strings.Contains(string(data), `"encrypted_content"`) || !strings.Contains(string(data), string(encodedSummary)) || !strings.Contains(string(data), "压缩后继续执行") {
 				t.Fatalf("压缩回放泄漏原始状态：size=%d", len(data))
 			}
 			return jsonHTTPResponse(request, http.StatusOK, `{"id":"resp_continue","status":"completed","output":[]}`), nil

--- a/backend/internal/infra/provider/cli/responses_compaction_test.go
+++ b/backend/internal/infra/provider/cli/responses_compaction_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 	"github.com/chenyme/grok2api/backend/internal/infra/security"
 )
 
@@ -208,6 +209,103 @@ func TestForwardResponseEmulatesRemoteCompactionV2(t *testing.T) {
 	}
 	if !strings.Contains(response.Header.Get("X-Grok2API-Compatibility-Warnings"), "remote_compaction_v2_emulated") {
 		t.Fatalf("warnings = %q", response.Header.Get("X-Grok2API-Compatibility-Warnings"))
+	}
+}
+
+// TestGatewayCompactionLifecycleWithMillionTokenScaleHistory 验证超长历史压缩后，
+// 下一轮只会向上游发送解密出的摘要和新消息，不会重新发送原始历史或 opaque blob。
+func TestGatewayCompactionLifecycleWithMillionTokenScaleHistory(t *testing.T) {
+	adapter, encrypted := newCompactionTestAdapter(t)
+	// “x ”在常见 BPE 编码中接近一个 token；此处保守构造超过 1M token 量级的历史文本。
+	history := strings.Repeat("x ", 2<<20)
+	var calls atomic.Int32
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		data, readErr := io.ReadAll(request.Body)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		switch call {
+		case 1:
+			if len(data) < 4<<20 || strings.Contains(string(data), "compaction_trigger") {
+				t.Fatalf("压缩采样未携带完整超长历史：size=%d", len(data))
+			}
+			return sseResponse(http.StatusOK, compactionSampleSSE("resp_million", healthyCompactionSummary()), request), nil
+		case 2:
+			if len(data) >= 4096 || strings.Contains(string(data), `"type":"compaction"`) || strings.Contains(string(data), `"encrypted_content"`) || !strings.Contains(string(data), "压缩后继续执行") {
+				t.Fatalf("压缩回放泄漏原始状态：size=%d", len(data))
+			}
+			return jsonHTTPResponse(request, http.StatusOK, `{"id":"resp_continue","status":"completed","output":[]}`), nil
+		default:
+			t.Fatalf("unexpected call %d", call)
+			return nil, nil
+		}
+	})
+
+	initialBody, err := json.Marshal(map[string]any{
+		"model": "grok-4.5",
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": history},
+			map[string]any{"type": "compaction_trigger"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compacted, err := adapter.ForwardResponse(t.Context(), provider.ResponseResourceRequest{
+		Credential:     account.Credential{ID: 1, Provider: account.ProviderBuild, EncryptedAccessToken: encrypted},
+		Method:         http.MethodPost,
+		Path:           "/responses",
+		Model:          "grok-4.5",
+		PromptCacheKey: "million-token-session",
+		Body:           initialBody,
+		NormalizeBody:  true,
+		Operation:      conversation.OperationResponses,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	compactedBody, readErr := io.ReadAll(compacted.Body)
+	_ = compacted.Body.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var compactedPayload struct {
+		Output []struct {
+			Type             string `json:"type"`
+			EncryptedContent string `json:"encrypted_content"`
+		} `json:"output"`
+	}
+	if json.Unmarshal(compactedBody, &compactedPayload) != nil || len(compactedPayload.Output) != 1 || compactedPayload.Output[0].Type != "compaction" || compactedPayload.Output[0].EncryptedContent == "" {
+		t.Fatalf("压缩响应无有效 blob：%s", compactedBody)
+	}
+
+	continuedBody, err := json.Marshal(map[string]any{
+		"model": "grok-4.5",
+		"input": []any{
+			map[string]any{"type": "compaction", "encrypted_content": compactedPayload.Output[0].EncryptedContent},
+			map[string]any{"type": "message", "role": "user", "content": "压缩后继续执行"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	continued, err := adapter.ForwardResponse(t.Context(), provider.ResponseResourceRequest{
+		Credential:     account.Credential{ID: 1, Provider: account.ProviderBuild, EncryptedAccessToken: encrypted},
+		Method:         http.MethodPost,
+		Path:           "/responses",
+		Model:          "grok-4.5",
+		PromptCacheKey: "million-token-session",
+		Body:           continuedBody,
+		NormalizeBody:  true,
+		Operation:      conversation.OperationResponses,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer continued.Body.Close()
+	if calls.Load() != 2 || continued.StatusCode != http.StatusOK {
+		t.Fatalf("calls=%d status=%d", calls.Load(), continued.StatusCode)
 	}
 }
 

--- a/backend/internal/infra/provider/cli/responses_reasoning_recovery.go
+++ b/backend/internal/infra/provider/cli/responses_reasoning_recovery.go
@@ -96,6 +96,13 @@ func (a *Adapter) recoverReasoningDecodeFailure(
 			a.logReasoningRecovery(request, base, "encrypted_content", "recovered", retry.StatusCode, nil)
 			return retry, retryURL, reasoningRecoveryOutcome{encryptedContentDowngraded: true}
 		}
+		if retry.StatusCode == http.StatusTooManyRequests {
+			// 去除失效密文后得到的 429 是当前账号的真实上游状态。保留它，
+			// 让网关进行账号冷却和切换，不能回退成已无效的初始解码 400。
+			_ = original.Body.Close()
+			a.logReasoningRecovery(request, base, "encrypted_content", "rate_limited", retry.StatusCode, nil)
+			return retry, retryURL, reasoningRecoveryOutcome{encryptedContentDowngraded: true}
+		}
 		sameDecodeFailure, inspectErr := responseHasReasoningDecodeFailure(retry)
 		if inspectErr != nil || !sameDecodeFailure {
 			a.logReasoningRecovery(request, base, "encrypted_content", "retry_rejected", retry.StatusCode, inspectErr)

--- a/backend/internal/infra/provider/cli/responses_reasoning_recovery.go
+++ b/backend/internal/infra/provider/cli/responses_reasoning_recovery.go
@@ -126,6 +126,16 @@ func (a *Adapter) recoverReasoningDecodeFailure(
 		a.logReasoningRecovery(request, base, "session_reset", "response_decode_failed", retry.StatusCode, err)
 		return original, requestURL, reasoningRecoveryOutcome{failed: true}
 	}
+	if retry.StatusCode == http.StatusTooManyRequests {
+		// 无状态恢复也可能命中当前账号的真实限流。与去密文恢复保持一致，
+		// 必须把 429 交回网关，才能执行账号冷却和候选账号切换。
+		_ = original.Body.Close()
+		a.logReasoningRecovery(request, base, "session_reset", "rate_limited", retry.StatusCode, nil)
+		return retry, retryURL, reasoningRecoveryOutcome{
+			encryptedContentDowngraded: encryptedChanged,
+			sessionReset:               true,
+		}
+	}
 	if !isHTTPSuccess(retry.StatusCode) {
 		status := retry.StatusCode
 		_ = retry.Body.Close()

--- a/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
+++ b/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
@@ -280,6 +280,69 @@ func TestRecoverReasoningDecodeFailurePreservesRateLimitAfterOpaqueStrip(t *test
 	}
 }
 
+// TestRecoverReasoningDecodeFailureWithMillionTokenScaleCompactionBlob 覆盖 Claude Code
+// 在超长上下文压缩后回放大体积 opaque 状态、且上游拒绝该状态的恢复路径。
+func TestRecoverReasoningDecodeFailureWithMillionTokenScaleCompactionBlob(t *testing.T) {
+	adapter, encrypted := newReasoningRecoveryTestAdapter(t)
+	// 按常用的约 4 字节/token 估算，4 MiB 的 opaque 状态覆盖约 100 万 token 的量级。
+	compactionBlob := strings.Repeat("x", 4<<20)
+	body, err := json.Marshal(map[string]any{
+		"model": "grok-4.5",
+		"input": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"summary":           []any{},
+				"encrypted_content": compactionBlob,
+			},
+			map[string]any{"role": "user", "content": "压缩后继续执行"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls atomic.Int32
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		data, readErr := io.ReadAll(request.Body)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		switch call {
+		case 1:
+			if len(data) < 4<<20 || !strings.Contains(string(data), `"encrypted_content"`) {
+				t.Fatalf("初始 1M 级 compaction 请求不完整：size=%d", len(data))
+			}
+			return jsonHTTPResponse(request, http.StatusBadRequest, `{"error":"Could not decode the compaction blob. Ensure it is unmodified from the compact response."}`), nil
+		case 2:
+			if len(data) >= 4096 || strings.Contains(string(data), `"encrypted_content"`) || !strings.Contains(string(data), "压缩后继续执行") {
+				t.Fatalf("恢复请求仍携带 opaque 状态：size=%d", len(data))
+			}
+			return jsonHTTPResponse(request, http.StatusTooManyRequests, `{"error":{"message":"rate limited after compaction recovery"}}`), nil
+		default:
+			t.Fatalf("unexpected call %d", call)
+			return nil, nil
+		}
+	})
+
+	response, err := adapter.ForwardResponse(t.Context(), provider.ResponseResourceRequest{
+		Credential:     account.Credential{ID: 1, Provider: account.ProviderBuild, EncryptedAccessToken: encrypted},
+		Method:         http.MethodPost,
+		Path:           "/responses",
+		Model:          "grok-4.5",
+		PromptCacheKey: "million-token-session",
+		Body:           body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	responseBody, _ := io.ReadAll(response.Body)
+	warnings := response.Header.Get("X-Grok2API-Compatibility-Warnings")
+	if calls.Load() != 2 || response.StatusCode != http.StatusTooManyRequests || !strings.Contains(string(responseBody), "rate limited after compaction recovery") || !strings.Contains(warnings, "reasoning_encrypted_content_downgraded") {
+		t.Fatalf("calls=%d status=%d warnings=%q body=%s", calls.Load(), response.StatusCode, warnings, responseBody)
+	}
+}
+
 func TestRecoverReasoningDecodeFailureDoesNotResetStoredResponseChain(t *testing.T) {
 	adapter, encrypted := newReasoningRecoveryTestAdapter(t)
 	var calls atomic.Int32

--- a/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
+++ b/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
@@ -245,6 +245,41 @@ func TestRecoverReasoningDecodeFailureEscalatesFromOpaqueStripToSessionReset(t *
 	}
 }
 
+func TestRecoverReasoningDecodeFailurePreservesRateLimitAfterOpaqueStrip(t *testing.T) {
+	adapter, encrypted := newReasoningRecoveryTestAdapter(t)
+	var calls atomic.Int32
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch calls.Add(1) {
+		case 1:
+			return jsonHTTPResponse(request, http.StatusBadRequest, `{"error":"Could not decode the compaction blob. Ensure it is unmodified from the compact response."}`), nil
+		case 2:
+			data, _ := io.ReadAll(request.Body)
+			if strings.Contains(string(data), `"encrypted_content"`) {
+				t.Fatalf("rate-limit recovery body still contains encrypted content: %s", data)
+			}
+			return jsonHTTPResponse(request, http.StatusTooManyRequests, `{"error":{"message":"rate limited"}}`), nil
+		default:
+			t.Fatalf("unexpected call %d", calls.Load())
+			return nil, nil
+		}
+	})
+
+	response, err := adapter.ForwardResponse(t.Context(), provider.ResponseResourceRequest{
+		Credential: account.Credential{ID: 1, Provider: account.ProviderBuild, EncryptedAccessToken: encrypted},
+		Method:     http.MethodPost, Path: "/responses", Model: "grok-4.5", PromptCacheKey: "session-1",
+		Body: []byte(`{"model":"grok-4.5","input":[{"type":"reasoning","summary":[],"encrypted_content":"opaque"},{"role":"user","content":"continue"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	warnings := response.Header.Get("X-Grok2API-Compatibility-Warnings")
+	if calls.Load() != 2 || response.StatusCode != http.StatusTooManyRequests || !strings.Contains(string(body), "rate limited") || !strings.Contains(warnings, "reasoning_encrypted_content_downgraded") || strings.Contains(warnings, "reasoning_recovery_failed") {
+		t.Fatalf("calls=%d status=%d warnings=%q body=%s", calls.Load(), response.StatusCode, warnings, body)
+	}
+}
+
 func TestRecoverReasoningDecodeFailureDoesNotResetStoredResponseChain(t *testing.T) {
 	adapter, encrypted := newReasoningRecoveryTestAdapter(t)
 	var calls atomic.Int32

--- a/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
+++ b/backend/internal/infra/provider/cli/responses_reasoning_recovery_test.go
@@ -280,6 +280,54 @@ func TestRecoverReasoningDecodeFailurePreservesRateLimitAfterOpaqueStrip(t *test
 	}
 }
 
+func TestRecoverReasoningDecodeFailurePreservesRateLimitAfterSessionReset(t *testing.T) {
+	adapter, encrypted := newReasoningRecoveryTestAdapter(t)
+	var calls atomic.Int32
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		call := calls.Add(1)
+		data, _ := io.ReadAll(request.Body)
+		switch call {
+		case 1:
+			if !strings.Contains(string(data), `"encrypted_content":"opaque"`) || request.Header.Get("x-grok-session-id") == "" {
+				t.Fatalf("initial body=%s headers=%#v", data, request.Header)
+			}
+		case 2:
+			if strings.Contains(string(data), `"encrypted_content"`) || request.Header.Get("x-grok-session-id") == "" || !strings.Contains(string(data), `"prompt_cache_key":"session-1"`) {
+				t.Fatalf("opaque downgrade body=%s headers=%#v", data, request.Header)
+			}
+		case 3:
+			if strings.Contains(string(data), `"encrypted_content"`) || strings.Contains(string(data), `"prompt_cache_key"`) || request.Header.Get("x-grok-session-id") != "" || request.Header.Get("x-grok-conv-id") != "" {
+				t.Fatalf("session reset body=%s headers=%#v", data, request.Header)
+			}
+			response := jsonHTTPResponse(request, http.StatusTooManyRequests, `{"error":{"message":"rate limited after session reset"}}`)
+			response.Header.Set("Retry-After", "17")
+			return response, nil
+		default:
+			t.Fatalf("unexpected call %d", call)
+			return nil, nil
+		}
+		return jsonHTTPResponse(request, http.StatusBadRequest, `{"error":"Could not decode the compaction blob. Ensure it is unmodified from the compact response."}`), nil
+	})
+
+	response, err := adapter.ForwardResponse(t.Context(), provider.ResponseResourceRequest{
+		Credential: account.Credential{ID: 1, Provider: account.ProviderBuild, EncryptedAccessToken: encrypted},
+		Method:     http.MethodPost, Path: "/responses", Model: "grok-4.5", PromptCacheKey: "session-1",
+		Body: []byte(`{"model":"grok-4.5","input":[{"type":"reasoning","summary":[],"encrypted_content":"opaque"},{"role":"user","content":"continue"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	warnings := response.Header.Get("X-Grok2API-Compatibility-Warnings")
+	if calls.Load() != 3 || response.StatusCode != http.StatusTooManyRequests || response.Header.Get("Retry-After") != "17" || !strings.Contains(string(body), "rate limited after session reset") {
+		t.Fatalf("calls=%d status=%d retry_after=%q body=%s", calls.Load(), response.StatusCode, response.Header.Get("Retry-After"), body)
+	}
+	if !strings.Contains(warnings, "reasoning_encrypted_content_downgraded") || !strings.Contains(warnings, "reasoning_session_reset") || strings.Contains(warnings, "reasoning_recovery_failed") {
+		t.Fatalf("warnings=%q", warnings)
+	}
+}
+
 // TestRecoverReasoningDecodeFailureWithMillionTokenScaleCompactionBlob 覆盖 Claude Code
 // 在超长上下文压缩后回放大体积 opaque 状态、且上游拒绝该状态的恢复路径。
 func TestRecoverReasoningDecodeFailureWithMillionTokenScaleCompactionBlob(t *testing.T) {


### PR DESCRIPTION
## 问题
Claude Code "alwaysThinkingEnabled": "true"时，Grok Build 可能拒绝回放的 opaque `reasoning.encrypted_content`，并返回：

```text
Could not decode the compaction blob. Ensure it is unmodified from the compact response.
```

网关会先剥离失效密文并重试。若这次恢复请求已经获得真实的 `429 Too Many Requests`，现有逻辑会丢弃该响应并回退为最初的解码 `400`，使网关无法按既有账号限流逻辑冷却当前账号、切换可用账号。

## 修改

- 当密文剥离恢复请求返回 `429` 时，保留该真实上游响应。
- 保留 `reasoning_encrypted_content_downgraded` 兼容告警，供审计和排查使用。
- 新增回归测试，覆盖“初始解码 400 -> 去密文重试 429”的场景，断言不再回退为旧 400，也不会错误标记 `reasoning_recovery_failed`。

## 验证

- `go test ./internal/infra/provider/cli -run 'TestRecoverReasoningDecodeFailure|TestStripReasoningEncryptedContent' -count=1`
- `go test ./...`：本次相关的 gateway / CLI provider 测试通过；
- PR 评论中的复现用例覆盖 1M token 量级历史压缩、opaque 状态恢复，以及恢复后真实 `429` 的传递。