### PR TITLE
fix: harden P0 security controls and Build response header timeout (#731)

### DIFF
--- a/backend/internal/application/media/service.go
+++ b/backend/internal/application/media/service.go
@@ -28,6 +28,8 @@ var (
 	ErrActiveVideoSelection  = errors.New("排队中或生成中的视频任务不能删除")
 	ErrInvalidFilter         = errors.New("媒体筛选条件无效")
 	ErrMediaJobsUnavailable  = errors.New("视频任务仓储未配置")
+	// ErrMediaQuotaExceeded is returned when total stored media would exceed MaxTotalBytes.
+	ErrMediaQuotaExceeded = errors.New("媒体总容量已达上限")
 )
 
 // Service 负责图片/视频校验、文件落盘和元数据持久化的一致性收口。
@@ -108,31 +110,62 @@ func (s *Service) SaveImage(ctx context.Context, data []byte) (mediadomain.Asset
 	if !supportedImageMIME(mimeType) {
 		return mediadomain.Asset{}, ErrInvalidImage
 	}
+	sizeBytes := int64(len(data))
+	if err := s.reserveMediaBytes(sizeBytes, cfg.MaxTotalBytes); err != nil {
+		return mediadomain.Asset{}, err
+	}
 	id, err := newAssetID()
 	if err != nil {
+		s.releaseMediaBytes(sizeBytes)
 		return mediadomain.Asset{}, err
 	}
 	digest := sha256.Sum256(data)
 	createdAt := time.Now().UTC()
 	storageKey, err := s.objects.SaveImage(ctx, id, mimeType, data)
 	if err != nil {
+		s.releaseMediaBytes(sizeBytes)
 		return mediadomain.Asset{}, err
 	}
 	asset := mediadomain.Asset{
 		ID: id, Kind: "image", StorageKey: storageKey, MIMEType: mimeType,
-		SizeBytes: int64(len(data)), SHA256: hex.EncodeToString(digest[:]), CreatedAt: createdAt,
+		SizeBytes: sizeBytes, SHA256: hex.EncodeToString(digest[:]), CreatedAt: createdAt,
 	}
 	if err := s.assets.CreateMediaAsset(ctx, asset); err != nil {
+		s.releaseMediaBytes(sizeBytes)
 		_ = s.objects.Delete(context.WithoutCancel(ctx), storageKey)
 		return mediadomain.Asset{}, err
 	}
-	if s.totalBytes.Add(asset.SizeBytes) > cleanupThresholdBytes(cfg) {
+	if s.totalBytes.Load() > cleanupThresholdBytes(cfg) {
 		select {
 		case s.cleanupSignal <- struct{}{}:
 		default:
 		}
 	}
 	return asset, nil
+}
+
+// reserveMediaBytes atomically reserves size against MaxTotalBytes before write.
+// On success the counter already includes size; callers must release on failure.
+func (s *Service) reserveMediaBytes(size, maxTotal int64) error {
+	if size <= 0 {
+		return nil
+	}
+	for {
+		current := s.totalBytes.Load()
+		if maxTotal > 0 && current+size > maxTotal {
+			return ErrMediaQuotaExceeded
+		}
+		if s.totalBytes.CompareAndSwap(current, current+size) {
+			return nil
+		}
+	}
+}
+
+func (s *Service) releaseMediaBytes(size int64) {
+	if size <= 0 {
+		return
+	}
+	s.totalBytes.Add(-size)
 }
 
 // PublicImageURL 返回可直接用于图片展示的公开资源地址。

--- a/backend/internal/application/media/service_test.go
+++ b/backend/internal/application/media/service_test.go
@@ -68,6 +68,33 @@ func TestServicePersistsAndReopensImage(t *testing.T) {
 	}
 }
 
+func TestSaveImageRejectsWhenTotalQuotaExceeded(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "media-quota.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	objects, err := localmedia.NewLocalStore(filepath.Join(t.TempDir(), "objects-quota"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := base64.StdEncoding.DecodeString(onePixelPNG)
+	service := NewService(relational.NewMediaAssetRepository(database), relational.NewMediaJobRepository(database), objects, nil, Config{
+		PublicBaseURL: "https://api.example", MaxImageBytes: 32 << 20, MaxTotalBytes: int64(len(raw)),
+		CleanupThresholdPercent: 80, CleanupInterval: 10 * time.Minute,
+	})
+	if _, err := service.SaveImage(ctx, raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.SaveImage(ctx, raw); !errors.Is(err, ErrMediaQuotaExceeded) {
+		t.Fatalf("second save err = %v, want ErrMediaQuotaExceeded", err)
+	}
+}
+
 func TestAdminDeleteVideoJobsRemovesTerminalJobAssetAndTicket(t *testing.T) {
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "media-video-delete.db"))

--- a/backend/internal/application/media/upload.go
+++ b/backend/internal/application/media/upload.go
@@ -295,7 +295,12 @@ func (s *Service) stageVideo(ctx context.Context, id, mimeType string, body io.R
 }
 
 func (s *Service) commitStagedVideo(ctx context.Context, staged stagedVideo, createdAt time.Time) (mediadomain.Asset, error) {
+	cfg := s.runtimeConfig()
+	if err := s.reserveMediaBytes(staged.SizeBytes, cfg.MaxTotalBytes); err != nil {
+		return mediadomain.Asset{}, err
+	}
 	if err := s.objects.CommitVideoUpload(ctx, staged.TempPath, staged.StorageKey); err != nil {
+		s.releaseMediaBytes(staged.SizeBytes)
 		return mediadomain.Asset{}, err
 	}
 	asset := mediadomain.Asset{
@@ -303,10 +308,11 @@ func (s *Service) commitStagedVideo(ctx context.Context, staged stagedVideo, cre
 		SizeBytes: staged.SizeBytes, SHA256: staged.SHA256, CreatedAt: createdAt,
 	}
 	if err := s.assets.CreateMediaAsset(ctx, asset); err != nil {
+		s.releaseMediaBytes(staged.SizeBytes)
 		_ = s.objects.Delete(context.WithoutCancel(ctx), staged.StorageKey)
 		return mediadomain.Asset{}, err
 	}
-	if s.totalBytes.Add(asset.SizeBytes) > cleanupThresholdBytes(s.runtimeConfig()) {
+	if s.totalBytes.Load() > cleanupThresholdBytes(cfg) {
 		select {
 		case s.cleanupSignal <- struct{}{}:
 		default:

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -299,10 +299,15 @@ func applyDomainConfig(base config.Config, value settingsdomain.Config) config.C
 	if clearanceRefresh <= 0 {
 		clearanceRefresh = base.Provider.Web.ClearanceRefresh.Value()
 	}
+	// AllowInternalStatsigSigner is file-only: never persisted in runtime settings.
+	// Preserve it from base (YAML load) across DB reloads so Docker/K8s internal
+	// signers remain valid after LoadPersisted / ReloadPersisted.
+	allowInternalStatsigSigner := base.Provider.Web.AllowInternalStatsigSigner
 	base.Provider.Web = config.WebProviderConfig{
 		BaseURL: value.ProviderWeb.BaseURL, QuotaTimeout: config.Duration(value.ProviderWeb.QuotaTimeout),
 		StatsigMode: value.ProviderWeb.StatsigMode, StatsigManualValue: value.ProviderWeb.StatsigManualValue, StatsigSignerURL: value.ProviderWeb.StatsigSignerURL,
-		ClearanceMode: clearanceMode, FlareSolverrURL: flareSolverrURL,
+		AllowInternalStatsigSigner: allowInternalStatsigSigner,
+		ClearanceMode:              clearanceMode, FlareSolverrURL: flareSolverrURL,
 		ClearanceTimeout: config.Duration(clearanceTimeout), ClearanceRefresh: config.Duration(clearanceRefresh),
 		ChatTimeout: config.Duration(value.ProviderWeb.ChatTimeout), ImageTimeout: config.Duration(value.ProviderWeb.ImageTimeout),
 		VideoTimeout:     config.Duration(value.ProviderWeb.VideoTimeout),
@@ -440,13 +445,10 @@ func mergeEditable(current config.Config, input EditableConfig) (config.Config, 
 	next.Provider.Build.UserAgent = strings.TrimSpace(input.ProviderBuild.UserAgent)
 	next.Provider.Web.BaseURL = strings.TrimSpace(input.ProviderWeb.BaseURL)
 	next.Provider.Web.StatsigMode = strings.TrimSpace(input.ProviderWeb.StatsigMode)
-	nextSigner := strings.TrimSpace(input.ProviderWeb.StatsigSignerURL)
-	// Hot updates cannot introduce or retain a newly-chosen internal signer URL.
-	// File-only allowInternalStatsigSigner is preserved only when the signer URL is unchanged.
-	if nextSigner != strings.TrimSpace(current.Provider.Web.StatsigSignerURL) {
-		next.Provider.Web.AllowInternalStatsigSigner = false
-	}
-	next.Provider.Web.StatsigSignerURL = nextSigner
+	// AllowInternalStatsigSigner is file-only and never present on EditableConfig.
+	// Keep the current (YAML-loaded) flag so Docker/K8s internal signers work when
+	// explicitly allowed; Validate rejects internal URLs when the flag is false.
+	next.Provider.Web.StatsigSignerURL = strings.TrimSpace(input.ProviderWeb.StatsigSignerURL)
 	if input.ProviderWeb.ClearanceProvided {
 		next.Provider.Web.ClearanceMode = strings.TrimSpace(input.ProviderWeb.ClearanceMode)
 		next.Provider.Web.FlareSolverrURL = strings.TrimSpace(input.ProviderWeb.FlareSolverrURL)

--- a/backend/internal/application/settings/service.go
+++ b/backend/internal/application/settings/service.go
@@ -440,7 +440,13 @@ func mergeEditable(current config.Config, input EditableConfig) (config.Config, 
 	next.Provider.Build.UserAgent = strings.TrimSpace(input.ProviderBuild.UserAgent)
 	next.Provider.Web.BaseURL = strings.TrimSpace(input.ProviderWeb.BaseURL)
 	next.Provider.Web.StatsigMode = strings.TrimSpace(input.ProviderWeb.StatsigMode)
-	next.Provider.Web.StatsigSignerURL = strings.TrimSpace(input.ProviderWeb.StatsigSignerURL)
+	nextSigner := strings.TrimSpace(input.ProviderWeb.StatsigSignerURL)
+	// Hot updates cannot introduce or retain a newly-chosen internal signer URL.
+	// File-only allowInternalStatsigSigner is preserved only when the signer URL is unchanged.
+	if nextSigner != strings.TrimSpace(current.Provider.Web.StatsigSignerURL) {
+		next.Provider.Web.AllowInternalStatsigSigner = false
+	}
+	next.Provider.Web.StatsigSignerURL = nextSigner
 	if input.ProviderWeb.ClearanceProvided {
 		next.Provider.Web.ClearanceMode = strings.TrimSpace(input.ProviderWeb.ClearanceMode)
 		next.Provider.Web.FlareSolverrURL = strings.TrimSpace(input.ProviderWeb.FlareSolverrURL)

--- a/backend/internal/application/settings/service_test.go
+++ b/backend/internal/application/settings/service_test.go
@@ -227,6 +227,90 @@ func TestLoadPersistedRejectsIncompleteStatsigPayload(t *testing.T) {
 	}
 }
 
+// File-only allowInternalStatsigSigner must survive LoadPersisted so Docker/K8s
+// internal signers remain valid after runtime settings are applied from the DB.
+func TestLoadPersistedPreservesFileAllowInternalStatsigSigner(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Provider.Web.AllowInternalStatsigSigner = true
+	cfg.Provider.Web.StatsigMode = config.StatsigModeURL
+	cfg.Provider.Web.StatsigSignerURL = "http://grok-signer-go:8788/sign"
+	value := toDomainConfig(cfg)
+	// Domain payload never carries the file-only flag; base must keep it.
+	repository := &runtimeSettingsRepositoryStub{value: value, found: true, revision: 1, updatedAt: time.Now().UTC()}
+	loaded, _, _, err := LoadPersisted(context.Background(), cfg, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.Provider.Web.AllowInternalStatsigSigner {
+		t.Fatal("AllowInternalStatsigSigner was cleared by applyDomainConfig")
+	}
+	if loaded.Provider.Web.StatsigSignerURL != "http://grok-signer-go:8788/sign" {
+		t.Fatalf("signer URL = %q", loaded.Provider.Web.StatsigSignerURL)
+	}
+}
+
+// YAML allowInternal=true + runtime internal signer stays legal; changing the
+// signer to a different internal host still works when the file flag is set;
+// without the flag, any internal signer is rejected.
+func TestInternalStatsigSignerRequiresFileAllowFlag(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Provider.Web.AllowInternalStatsigSigner = true
+	cfg.Provider.Web.StatsigMode = config.StatsigModeURL
+	cfg.Provider.Web.StatsigSignerURL = "https://grok.wodf.de/sign"
+	repo := &runtimeSettingsRepositoryStub{}
+	service := NewService(cfg, time.Time{}, 0, repo, nil, nil)
+
+	input := service.Get().Config
+	input.ProviderWeb.StatsigMode = config.StatsigModeURL
+	input.ProviderWeb.StatsigSignerURL = "http://grok-signer-go:8788/sign"
+	if _, err := service.Update(context.Background(), service.Get().Revision, input); err != nil {
+		t.Fatalf("internal signer with file allow flag rejected: %v", err)
+	}
+	if service.Get().Config.ProviderWeb.StatsigSignerURL != "http://grok-signer-go:8788/sign" {
+		t.Fatalf("signer not applied: %#v", service.Get().Config.ProviderWeb)
+	}
+	// Hot-update to another internal host remains legal while file flag is true.
+	next := service.Get().Config
+	next.ProviderWeb.StatsigSignerURL = "http://signer.internal:8788/sign"
+	if _, err := service.Update(context.Background(), service.Get().Revision, next); err != nil {
+		t.Fatalf("second internal signer with file allow flag rejected: %v", err)
+	}
+
+	// Without the file flag, the same internal URL must be rejected.
+	denied := testConfig(t)
+	denied.Provider.Web.AllowInternalStatsigSigner = false
+	denied.Provider.Web.StatsigMode = config.StatsigModeURL
+	denied.Provider.Web.StatsigSignerURL = "https://grok.wodf.de/sign"
+	blocked := NewService(denied, time.Time{}, 0, &runtimeSettingsRepositoryStub{}, nil, nil)
+	bad := blocked.Get().Config
+	bad.ProviderWeb.StatsigSignerURL = "http://grok-signer-go:8788/sign"
+	if _, err := blocked.Update(context.Background(), blocked.Get().Revision, bad); err == nil {
+		t.Fatal("internal signer accepted without allowInternalStatsigSigner")
+	}
+}
+
+func TestReloadPersistedKeepsFileAllowInternalStatsigSigner(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Provider.Web.AllowInternalStatsigSigner = true
+	cfg.Provider.Web.StatsigMode = config.StatsigModeURL
+	cfg.Provider.Web.StatsigSignerURL = "http://grok-signer-go:8788/sign"
+	value := toDomainConfig(cfg)
+	// Simulate another instance writing a different (still internal) signer.
+	value.ProviderWeb.StatsigSignerURL = "http://signer.internal:8788/sign"
+	repo := &runtimeSettingsRepositoryStub{value: value, found: true, revision: 2, updatedAt: time.Now().UTC()}
+	var applied config.Config
+	service := NewService(cfg, time.Now().UTC(), 1, repo, nil, func(next config.Config) { applied = next })
+	if err := service.ReloadPersisted(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !applied.Provider.Web.AllowInternalStatsigSigner {
+		t.Fatal("ReloadPersisted cleared AllowInternalStatsigSigner")
+	}
+	if applied.Provider.Web.StatsigSignerURL != "http://signer.internal:8788/sign" {
+		t.Fatalf("signer after reload = %q", applied.Provider.Web.StatsigSignerURL)
+	}
+}
+
 func TestLoadPersistedRejectsIncompleteBatchPayload(t *testing.T) {
 	cfg := testConfig(t)
 	value := toDomainConfig(cfg)

--- a/backend/internal/application/settings/service_test.go
+++ b/backend/internal/application/settings/service_test.go
@@ -51,8 +51,8 @@ func TestUpdatePersistsAppliesAndReportsRestart(t *testing.T) {
 	input.Media.MaxTotalBytes = 2 << 30
 	input.Media.CleanupThresholdPercent = 75
 	input.Media.CleanupInterval = "5m"
-	input.Frontend.PublicAPIBaseURL = "https://public.example.com"
-	input.ProviderConsole.BaseURL = "https://console.example.com"
+	input.Frontend.PublicAPIBaseURL = "http://public.example.com"
+	input.ProviderConsole.BaseURL = "https://console.x.ai"
 	input.ProviderConsole.ChatTimeout = "6m"
 	input.Batch = BatchConfig{ImportConcurrency: 26, ConversionConcurrency: 27, SyncConcurrency: 28, RefreshConcurrency: 29, RandomDelay: "750ms"}
 
@@ -69,13 +69,13 @@ func TestUpdatePersistsAppliesAndReportsRestart(t *testing.T) {
 	if applied.Media.MaxTotalBytes != 2<<30 || applied.Media.CleanupThresholdPercent != 75 || applied.Media.CleanupInterval.Value() != 5*time.Minute {
 		t.Fatalf("media configuration was not applied: %#v", applied.Media)
 	}
-	if applied.Frontend.PublicAPIBaseURLOverride != "https://public.example.com" || applied.Frontend.EffectivePublicAPIBaseURL() != "https://public.example.com" {
+	if applied.Frontend.PublicAPIBaseURLOverride != "http://public.example.com" || applied.Frontend.EffectivePublicAPIBaseURL() != "http://public.example.com" {
 		t.Fatalf("frontend configuration was not applied: %#v", applied.Frontend)
 	}
 	if applied.Batch.ImportConcurrency != 26 || applied.Batch.ConversionConcurrency != 27 || applied.Batch.SyncConcurrency != 28 || applied.Batch.RefreshConcurrency != 29 || applied.Batch.RandomDelay.Value() != 750*time.Millisecond {
 		t.Fatalf("batch configuration was not applied: %#v", applied.Batch)
 	}
-	if applied.Provider.Console.BaseURL != "https://console.example.com" || applied.Provider.Console.ChatTimeout.Value() != 6*time.Minute {
+	if applied.Provider.Console.BaseURL != "https://console.x.ai" || applied.Provider.Console.ChatTimeout.Value() != 6*time.Minute {
 		t.Fatalf("console configuration was not applied: %#v", applied.Provider.Console)
 	}
 	if len(snapshot.RestartRequired) != 1 || snapshot.RestartRequired[0] != "audit.bufferSize" {
@@ -85,7 +85,7 @@ func TestUpdatePersistsAppliesAndReportsRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reloaded.Server.MaxConcurrentRequests != 2048 || reloaded.Routing.MaxAttempts != 5 || !reloaded.Routing.PreferFreeBuild || reloaded.Audit.BufferSize != input.Audit.BufferSize || reloaded.Media.MaxTotalBytes != 2<<30 || reloaded.Media.CleanupThresholdPercent != 75 || reloaded.Batch.SyncConcurrency != 28 || reloaded.Batch.RandomDelay.Value() != 750*time.Millisecond || reloaded.Provider.Console.BaseURL != "https://console.example.com" {
+	if reloaded.Server.MaxConcurrentRequests != 2048 || reloaded.Routing.MaxAttempts != 5 || !reloaded.Routing.PreferFreeBuild || reloaded.Audit.BufferSize != input.Audit.BufferSize || reloaded.Media.MaxTotalBytes != 2<<30 || reloaded.Media.CleanupThresholdPercent != 75 || reloaded.Batch.SyncConcurrency != 28 || reloaded.Batch.RandomDelay.Value() != 750*time.Millisecond || reloaded.Provider.Console.BaseURL != "https://console.x.ai" {
 		t.Fatalf("configuration was not persisted")
 	}
 }

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -142,8 +142,10 @@ type WebProviderConfig struct {
 	StatsigMode         string   `yaml:"-"`
 	StatsigManualValue  string   `yaml:"-"`
 	StatsigSignerURL    string   `yaml:"-"`
-	// AllowInternalStatsigSigner permits internal/private signer URLs from the
-	// config file only. Hot settings updates never set this flag (file-only).
+	// AllowInternalStatsigSigner permits internal/private Statsig signer URLs.
+	// File-only: loaded from YAML, never from admin hot settings. When true,
+	// runtime settings may set an internal signer URL (Docker/K8s service names).
+	// When false, Validate rejects all internal signer URLs.
 	AllowInternalStatsigSigner bool     `yaml:"allowInternalStatsigSigner"`
 	ClearanceMode              string   `yaml:"-"`
 	FlareSolverrURL            string   `yaml:"-"`

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -142,18 +142,21 @@ type WebProviderConfig struct {
 	StatsigMode         string   `yaml:"-"`
 	StatsigManualValue  string   `yaml:"-"`
 	StatsigSignerURL    string   `yaml:"-"`
-	ClearanceMode       string   `yaml:"-"`
-	FlareSolverrURL     string   `yaml:"-"`
-	ClearanceTimeout    Duration `yaml:"-"`
-	ClearanceRefresh    Duration `yaml:"-"`
-	QuotaTimeout        Duration `yaml:"quotaTimeout"`
-	ChatTimeout         Duration `yaml:"chatTimeout"`
-	ImageTimeout        Duration `yaml:"imageTimeout"`
-	VideoTimeout        Duration `yaml:"videoTimeout"`
-	MediaConcurrency    int      `yaml:"mediaConcurrency"`
-	AllowNSFW           bool     `yaml:"allowNSFW"`
-	RecoveryBackoffBase Duration `yaml:"recoveryBackoffBase"`
-	RecoveryBackoffMax  Duration `yaml:"recoveryBackoffMax"`
+	// AllowInternalStatsigSigner permits internal/private signer URLs from the
+	// config file only. Hot settings updates never set this flag (file-only).
+	AllowInternalStatsigSigner bool     `yaml:"allowInternalStatsigSigner"`
+	ClearanceMode              string   `yaml:"-"`
+	FlareSolverrURL            string   `yaml:"-"`
+	ClearanceTimeout           Duration `yaml:"-"`
+	ClearanceRefresh           Duration `yaml:"-"`
+	QuotaTimeout               Duration `yaml:"quotaTimeout"`
+	ChatTimeout                Duration `yaml:"chatTimeout"`
+	ImageTimeout               Duration `yaml:"imageTimeout"`
+	VideoTimeout               Duration `yaml:"videoTimeout"`
+	MediaConcurrency           int      `yaml:"mediaConcurrency"`
+	AllowNSFW                  bool     `yaml:"allowNSFW"`
+	RecoveryBackoffBase        Duration `yaml:"recoveryBackoffBase"`
+	RecoveryBackoffMax         Duration `yaml:"recoveryBackoffMax"`
 }
 
 type ConsoleProviderConfig struct {
@@ -342,6 +345,9 @@ func (c Config) Validate() error {
 			}
 		}
 	}
+	if effectivePublic := c.Frontend.EffectivePublicAPIBaseURL(); strings.HasPrefix(strings.ToLower(effectivePublic), "https://") && !c.Auth.SecureCookies {
+		return errors.New("frontend.publicApiBaseURL 为 HTTPS 时 auth.secureCookies 必须为 true")
+	}
 	switch c.Database.Driver {
 	case "sqlite":
 		if strings.TrimSpace(c.Database.SQLite.Path) == "" {
@@ -422,13 +428,16 @@ func (c Config) Validate() error {
 	if err != nil || webURL.Scheme != "https" || webURL.Host == "" || webURL.User != nil {
 		return errors.New("provider.web.baseURL 必须是无凭据的 HTTPS URL")
 	}
+	if err := validateProviderHost("provider.web.baseURL", webURL.Hostname()); err != nil {
+		return err
+	}
 	switch c.Provider.Web.StatsigMode {
 	case StatsigModeManual:
 		if !validStatsigID(c.Provider.Web.StatsigManualValue) {
 			return errors.New("provider.web 手动 x-statsig-id 格式无效")
 		}
 	case StatsigModeURL:
-		if err := signerurl.Validate(c.Provider.Web.StatsigSignerURL); err != nil {
+		if err := signerurl.ValidateWithOptions(c.Provider.Web.StatsigSignerURL, c.Provider.Web.AllowInternalStatsigSigner); err != nil {
 			return fmt.Errorf("provider.web Statsig 签名 URL 无效: %w", err)
 		}
 	default:
@@ -461,6 +470,9 @@ func (c Config) Validate() error {
 	consoleURL, err := url.ParseRequestURI(strings.TrimSpace(c.Provider.Console.BaseURL))
 	if err != nil || consoleURL.Scheme != "https" || consoleURL.Host == "" || consoleURL.User != nil {
 		return errors.New("provider.console.baseURL 必须是无凭据的 HTTPS URL")
+	}
+	if err := validateProviderHost("provider.console.baseURL", consoleURL.Hostname()); err != nil {
+		return err
 	}
 	if c.Provider.Console.ChatTimeout.Value() < 5*time.Second || c.Provider.Console.ChatTimeout.Value() > 30*time.Minute {
 		return errors.New("provider.console.chatTimeout 必须在 5 秒到 30 分钟之间")
@@ -503,6 +515,7 @@ func (c Config) Validate() error {
 
 // validateAPIBaseURL 仅允许无凭据、query、fragment 的 HTTP(S) API 根地址。
 // requireHTTPS 为 true 时强制 HTTPS（用于生产默认 XAI 备用地址）。
+// Host 必须属于官方 Provider 域名后缀（*.x.ai / *.grok.com）。
 func validateAPIBaseURL(name, raw string, requireHTTPS bool) error {
 	parsed, err := url.ParseRequestURI(strings.TrimSpace(raw))
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
@@ -510,15 +523,33 @@ func validateAPIBaseURL(name, raw string, requireHTTPS bool) error {
 	}
 	switch parsed.Scheme {
 	case "https":
-		return nil
+		return validateProviderHost(name, parsed.Hostname())
 	case "http":
 		if requireHTTPS {
 			return fmt.Errorf("%s 必须是 HTTPS URL", name)
 		}
-		return nil
+		return validateProviderHost(name, parsed.Hostname())
 	default:
 		return fmt.Errorf("%s 必须是不含凭据、查询参数和片段的 HTTP(S) URL", name)
 	}
+}
+
+// allowedProviderHostSuffixes limits hot-updatable and file-loaded Provider
+// BaseURLs so compromised admin sessions cannot exfiltrate credentials to
+// arbitrary hosts.
+var allowedProviderHostSuffixes = []string{"x.ai", "grok.com"}
+
+func validateProviderHost(name, host string) error {
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if host == "" {
+		return fmt.Errorf("%s 主机名无效", name)
+	}
+	for _, suffix := range allowedProviderHostSuffixes {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s 主机必须是 x.ai 或 grok.com 及其子域", name)
 }
 
 // NormalizeBuildFallbackBaseURL 在旧配置缺字段时填入默认 XAI 备用地址。

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -244,12 +244,40 @@ func TestValidateStatsigModes(t *testing.T) {
 	remote := base
 	remote.Provider.Web.StatsigMode = StatsigModeURL
 	remote.Provider.Web.StatsigSignerURL = "http://grok-signer-go:8788/sign"
+	if err := remote.Validate(); err == nil {
+		t.Fatal("internal Statsig signer was accepted without allowInternalStatsigSigner")
+	}
+	remote.Provider.Web.AllowInternalStatsigSigner = true
 	if err := remote.Validate(); err != nil {
-		t.Fatalf("Docker internal Statsig signer rejected: %v", err)
+		t.Fatalf("Docker internal Statsig signer rejected with allow flag: %v", err)
 	}
 	remote.Provider.Web.StatsigSignerURL = "http://signer.example.com:8788/sign"
 	if err := remote.Validate(); err == nil {
 		t.Fatal("public plaintext Statsig signer URL was accepted")
+	}
+}
+
+func TestValidateRejectsNonProviderBaseURLHosts(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Secrets.JWTSecret = "12345678901234567890123456789012"
+	cfg.Secrets.CredentialEncryptionKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	cfg.Provider.Build.BaseURL = "https://attacker.example/v1"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("attacker build baseURL was accepted")
+	}
+	cfg.Provider.Build.BaseURL = "https://cli-chat-proxy.grok.com/v1"
+	cfg.Provider.Web.BaseURL = "https://evil.example"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("attacker web baseURL was accepted")
+	}
+	cfg.Provider.Web.BaseURL = "https://grok.com"
+	cfg.Provider.Console.BaseURL = "https://console.attacker.example"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("attacker console baseURL was accepted")
+	}
+	cfg.Provider.Console.BaseURL = "https://console.x.ai"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid provider hosts rejected: %v", err)
 	}
 }
 
@@ -314,8 +342,17 @@ func TestValidateFrontendPublicAPIBaseURL(t *testing.T) {
 	}
 	cfg.Frontend.PublicAPIBaseURL = "https://api.example.com/grok2api"
 	cfg.Auth.SecureCookies = false
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("https publicApiBaseURL with secureCookies=false was accepted")
+	}
+	cfg.Auth.SecureCookies = true
 	if err := cfg.Validate(); err != nil {
-		t.Fatalf("valid frontend.publicApiBaseURL rejected: %v", err)
+		t.Fatalf("valid https publicApiBaseURL with secureCookies rejected: %v", err)
+	}
+	cfg.Frontend.PublicAPIBaseURL = "http://127.0.0.1:8000"
+	cfg.Auth.SecureCookies = false
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("http local publicApiBaseURL rejected: %v", err)
 	}
 }
 

--- a/backend/internal/infra/egress/buildclient.go
+++ b/backend/internal/infra/egress/buildclient.go
@@ -13,6 +13,12 @@ import (
 	xproxy "golang.org/x/net/proxy"
 )
 
+// buildResponseHeaderTimeout is how long Build egress waits for the first
+// response header after the request body is fully written. Large prompts can
+// take well over 30s before cli-chat-proxy starts streaming (issue #731).
+// This only bounds header arrival; stream body reads use the request context.
+const buildResponseHeaderTimeout = 10 * time.Minute
+
 // newBuildClient keeps Grok Build on the standard Go HTTP/TLS stack used by
 // the official CLI-facing transport. Browser TLS impersonation is reserved for
 // Grok Web, where the browser fingerprint and User-Agent belong together.
@@ -27,7 +33,7 @@ func newBuildClient(proxyURL string) (*http.Client, error) {
 		MaxConnsPerHost:       256,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: buildResponseHeaderTimeout,
 		ExpectContinueTimeout: time.Second,
 	}
 	if strings.TrimSpace(proxyURL) != "" {

--- a/backend/internal/infra/egress/buildclient_test.go
+++ b/backend/internal/infra/egress/buildclient_test.go
@@ -46,6 +46,21 @@ func TestNewBuildClientUsesStandardTransportForEveryProxyFamily(t *testing.T) {
 	}
 }
 
+// Issue #731: large Build payloads can take >30s before response headers arrive.
+func TestNewBuildClientResponseHeaderTimeoutCoversSlowBuildHeaders(t *testing.T) {
+	client, err := newBuildClient("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout < 10*time.Minute {
+		t.Fatalf("ResponseHeaderTimeout = %s, want >= 10m (issue #731)", transport.ResponseHeaderTimeout)
+	}
+}
+
 func TestNewBuildClientRejectsUnsupportedProxyScheme(t *testing.T) {
 	if _, err := newBuildClient("ftp://proxy.example:21"); err == nil {
 		t.Fatal("unsupported proxy scheme was accepted")

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -57,8 +57,12 @@ type Adapter struct {
 	logger         *slog.Logger
 }
 
+// fallbackResponseHeaderTimeout matches egress.buildResponseHeaderTimeout so
+// the no-egress path does not reintroduce the 30s header cutoff (issue #731).
+const fallbackResponseHeaderTimeout = 10 * time.Minute
+
 func NewAdapter(cfg Config, cipher *security.Cipher) *Adapter {
-	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, ForceAttemptHTTP2: true, MaxIdleConns: 256, MaxIdleConnsPerHost: 128, MaxConnsPerHost: 256, IdleConnTimeout: 90 * time.Second, TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: 30 * time.Second}
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, ForceAttemptHTTP2: true, MaxIdleConns: 256, MaxIdleConnsPerHost: 128, MaxConnsPerHost: 256, IdleConnTimeout: 90 * time.Second, TLSHandshakeTimeout: 10 * time.Second, ResponseHeaderTimeout: fallbackResponseHeaderTimeout}
 	httpClient := &http.Client{Transport: transport}
 	// The official CLI uses a persistent machine identity. The gateway does not collect machine fingerprints;
 	// instead each backend process generates one random UUID for its lifetime as the Agent identity.

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -29,6 +29,18 @@ func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error)
 	return fn(request)
 }
 
+// Issue #731: fallback Build transport must wait longer than 30s for response headers.
+func TestNewAdapterFallbackTransportResponseHeaderTimeout(t *testing.T) {
+	adapter := NewAdapter(Config{}, nil)
+	transport, ok := adapter.base.(*http.Transport)
+	if !ok {
+		t.Fatalf("base transport = %T, want *http.Transport", adapter.base)
+	}
+	if transport.ResponseHeaderTimeout < 10*time.Minute {
+		t.Fatalf("ResponseHeaderTimeout = %s, want >= 10m (issue #731)", transport.ResponseHeaderTimeout)
+	}
+}
+
 func TestCredentialMetadataMarksOnlyNumericBotFlagOne(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {

--- a/backend/internal/pkg/signerurl/policy.go
+++ b/backend/internal/pkg/signerurl/policy.go
@@ -12,7 +12,13 @@ const MaxLength = 2048
 
 // Validate 接受公网 HTTPS:443，或管理员显式配置的内网 HTTP/HTTPS 地址。
 // 内网范围包括容器单标签服务名、localhost、.local/.internal 和私有地址。
+// allowInternal=false 时拒绝一切内网地址（用于管理端热更新路径）。
 func Validate(value string) error {
+	return ValidateWithOptions(value, true)
+}
+
+// ValidateWithOptions 与 Validate 相同，但可关闭内网地址。
+func ValidateWithOptions(value string, allowInternal bool) error {
 	raw := strings.TrimSpace(value)
 	parsed, err := url.ParseRequestURI(raw)
 	if err != nil || parsed.Host == "" || parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || strings.Contains(raw, "#") || len(raw) > MaxLength {
@@ -26,6 +32,9 @@ func Validate(value string) error {
 	}
 	host := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
 	internal := IsInternalHost(host)
+	if internal && !allowInternal {
+		return fmt.Errorf("签名 URL 不允许内网地址（需在配置文件中开启 allowInternalStatsigSigner）")
+	}
 	switch strings.ToLower(parsed.Scheme) {
 	case "http":
 		if internal {

--- a/backend/internal/pkg/signerurl/policy_test.go
+++ b/backend/internal/pkg/signerurl/policy_test.go
@@ -34,3 +34,15 @@ func TestValidateRejectsUnsafeOrMalformedSigner(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateWithOptionsRejectsInternalWhenDisallowed(t *testing.T) {
+	if err := ValidateWithOptions("http://grok-signer-go:8788/sign", false); err == nil {
+		t.Fatal("internal signer accepted when allowInternal=false")
+	}
+	if err := ValidateWithOptions("https://grok.wodf.de/sign", false); err != nil {
+		t.Fatalf("public HTTPS signer rejected: %v", err)
+	}
+	if err := ValidateWithOptions("http://grok-signer-go:8788/sign", true); err != nil {
+		t.Fatalf("internal signer rejected when allowInternal=true: %v", err)
+	}
+}

--- a/backend/internal/transport/http/media/handler.go
+++ b/backend/internal/transport/http/media/handler.go
@@ -66,7 +66,8 @@ func (h *Handler) getImage(c *gin.Context) {
 	}
 	c.Header("Content-Type", asset.MIMEType)
 	c.Header("Content-Length", strconv.FormatInt(asset.SizeBytes, 10))
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+	// Capability URLs: keep private so shared caches/CDNs do not pin leaked IDs for a year.
+	c.Header("Cache-Control", "private, max-age=3600")
 	c.Header("ETag", etag)
 	c.Header("X-Content-Type-Options", "nosniff")
 	if c.Request.Method == http.MethodHead {
@@ -95,7 +96,7 @@ func (h *Handler) getVideo(c *gin.Context) {
 	}
 	c.Header("Content-Type", asset.MIMEType)
 	c.Header("Content-Disposition", `inline; filename="`+asset.ID+`"`)
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+	c.Header("Cache-Control", "private, max-age=3600")
 	c.Header("ETag", `"`+asset.SHA256+`"`)
 	c.Header("X-Content-Type-Options", "nosniff")
 	http.ServeContent(c.Writer, c.Request, asset.ID, asset.CreatedAt, seeker)

--- a/backend/internal/transport/http/media/handler.go
+++ b/backend/internal/transport/http/media/handler.go
@@ -117,6 +117,8 @@ func (h *Handler) putVideoUpload(c *gin.Context) {
 	case errors.Is(err, mediaapp.ErrVideoUploadTooLarge):
 		// 体积超限优先于通用无效上传，返回 413。
 		c.Status(http.StatusRequestEntityTooLarge)
+	case errors.Is(err, mediaapp.ErrMediaQuotaExceeded):
+		c.Status(http.StatusInsufficientStorage)
 	case errors.Is(err, mediaapp.ErrInvalidVideoUpload):
 		c.Status(http.StatusBadRequest)
 	case errors.Is(err, mediaapp.ErrUploadTicketsUnavailable):

--- a/backend/internal/transport/http/media/handler_test.go
+++ b/backend/internal/transport/http/media/handler_test.go
@@ -53,6 +53,9 @@ func TestPublicImageSupportsGetHeadAndETag(t *testing.T) {
 	if get.Code != http.StatusOK || get.Header().Get("Content-Type") != "image/png" || get.Body.Len() != len(raw) || get.Header().Get("ETag") == "" {
 		t.Fatalf("GET status=%d headers=%#v size=%d", get.Code, get.Header(), get.Body.Len())
 	}
+	if cache := get.Header().Get("Cache-Control"); cache != "private, max-age=3600" {
+		t.Fatalf("Cache-Control = %q, want private, max-age=3600", cache)
+	}
 	head := httptest.NewRecorder()
 	router.ServeHTTP(head, httptest.NewRequest(http.MethodHead, path, nil))
 	if head.Code != http.StatusOK || head.Body.Len() != 0 || head.Header().Get("Content-Length") == "" {

--- a/backend/internal/transport/http/media/handler_test.go
+++ b/backend/internal/transport/http/media/handler_test.go
@@ -222,6 +222,54 @@ func TestPutVideoUploadReturns413WhenBodyTooLarge(t *testing.T) {
 	}
 }
 
+func TestPutVideoUploadReturns507WhenTotalQuotaExceeded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "media-upload-507.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	objects, err := localmedia.NewLocalStore(filepath.Join(t.TempDir(), "objects-507"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fill hard capacity with an image so video commit rejects at reserve
+	// (before platform-specific video sync), mapping ErrMediaQuotaExceeded → 507.
+	rawPNG, _ := base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+	payload := append([]byte{0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm'}, bytes.Repeat([]byte{0x0b}, 64)...)
+	tickets := relational.NewMediaUploadTicketRepository(database)
+	service := mediaapp.NewServiceWithTickets(
+		relational.NewMediaAssetRepository(database),
+		relational.NewMediaJobRepository(database),
+		tickets, objects, nil,
+		mediaapp.Config{
+			PublicBaseURL: "https://api.example", MaxImageBytes: 32 << 20, MaxTotalBytes: int64(len(rawPNG)),
+			CleanupThresholdPercent: 80, CleanupInterval: time.Minute,
+		},
+	)
+	if _, err := service.SaveImage(ctx, rawPNG); err != nil {
+		t.Fatal(err)
+	}
+	uploadURL, _, err := service.IssueVideoUpload(ctx, "job_507_reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := uploadURL[len("https://api.example/v1/media/uploads/"):]
+	router := gin.New()
+	NewHandler(service).RegisterPublic(router)
+	req := httptest.NewRequest(http.MethodPut, "/v1/media/uploads/"+token, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "video/mp4")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusInsufficientStorage {
+		t.Fatalf("status = %d, want 507, body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestPutVideoUploadReturns400ForInvalidMIME(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx := context.Background()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -73,6 +73,13 @@ media:
     # [按需修改] 图片二进制目录；数据库只保存资源元数据。
     path: "./data/media"
 
+provider:
+  web:
+    # [按需修改] 仅配置文件可读。true 时允许管理端将 Statsig 签名 URL 设为内网地址
+    #（如 Docker 服务名 http://grok-signer-go:8788/sign）。false（默认）时拒绝一切内网 signer，
+    # 防止被控管理会话把请求导向内网 SSRF。热更新无法改写本开关。
+    allowInternalStatsigSigner: false
+
 routing:
   # [按需修改] 服务端推理回放缓存：多轮时自动补回客户端未携带的 encrypted_content。
   reasoningReplayEnabled: true


### PR DESCRIPTION
## Summary

Addresses high-priority security findings from a static audit of grok2api, plus open issue **#731**.

### Security (P0)

1. **Provider BaseURL host allowlist** — `provider.build/web/console.baseURL` must be `x.ai` or `grok.com` (or subdomains). Prevents a compromised admin session from redirecting credential-bearing egress to an attacker host.
2. **Statsig signer internal URLs (file-auth model)** — Internal/private signer URLs require `provider.web.allowInternalStatsigSigner: true` in the **YAML config file** only. The flag is never set from admin hot settings. When the flag is true, runtime settings may set/change internal signer URLs (Docker/K8s service names). When false, Validate rejects all internal signer URLs (SSRF control).
   - `applyDomainConfig` / `LoadPersisted` / `ReloadPersisted` **preserve** the file-only flag so reloads do not wipe Docker/K8s setups.
   - Hot updates **do not clear** the flag when the signer URL changes (flag is file-owned).
3. **Media hard capacity** — `SaveImage` / video commit reject before write when `total + size > MaxTotalBytes` (`ErrMediaQuotaExceeded`).
4. **Media Cache-Control** — Public capability media GET uses `private, max-age=3600` instead of year-long `public, immutable`.
5. **Secure cookies** — When effective `publicApiBaseURL` is HTTPS, `auth.secureCookies` must be `true` (config validation).

### Bugfix

6. **#731** — Build HTTP client `ResponseHeaderTimeout` raised from **30s → 10m** in both egress `newBuildClient` and CLI adapter fallback transport. Large Build payloads no longer fail with `http2: timeout awaiting response headers` while waiting for the first response header. Body streaming remains governed by the request context / server request timeout.

### Follow-up hardening (this push)

- Fix regression where `applyDomainConfig` rebuilt `WebProviderConfig` without `AllowInternalStatsigSigner`, breaking YAML-allowed internal signers after DB load/reload.
- Map `ErrMediaQuotaExceeded` → **HTTP 507** on public video PUT.
- Document `provider.web.allowInternalStatsigSigner` in `config.example.yaml` with accurate usage (file-only; enables admin-set internal signer when true).
- Integration-style tests: load/reload preserve flag; hot-update internal signer allowed only with flag; 507 on quota.

## Test plan

- [x] `go test` on egress, signerurl, config, cli, settings (incl. allowInternal load/reload/hot-update), media (SaveImage/quota), media handler (Cache-Control, 507)
- [ ] Deploy with HTTPS `publicApiBaseURL` and confirm `secureCookies: true` is required
- [ ] Attempt hot-update of BaseURL to non-`*.x.ai`/`*.grok.com` host → rejected
- [ ] YAML `allowInternalStatsigSigner: true` + admin set `http://grok-signer-go:8788/sign` → accepted; without flag → rejected
- [ ] Large Build prompt that previously hit 30s header timeout → succeeds or fails only on real upstream errors
- [ ] Fill media store to `MaxTotalBytes` → further saves/uploads return quota error (507 on video PUT)

## Notes

- Capability URL media model (unguessable IDs, no API key on GET) is unchanged; only cache policy and capacity enforcement tightened.
- **Correct usage for Docker/K8s internal Statsig signer:** set `provider.web.allowInternalStatsigSigner: true` in the config file, then set the signer URL in admin runtime settings (or keep the default public signer). The admin UI cannot enable the allow flag itself.
- Windows-local video sync tests may fail with `Access is denied` independently of this change (observed on clean `upstream/main` as well).

## Review status

Prior review: request changes on Statsig path (flag cleared by `applyDomainConfig` / hot-update clear conflicted with PR claim). Those merge conditions are addressed in `e9af54f`.