### PR TITLE
支持 Codex 模型目录

### DIFF
--- a/backend/internal/transport/http/inference/codex_models.go
+++ b/backend/internal/transport/http/inference/codex_models.go
@@ -1,0 +1,231 @@
+package inference
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"unicode"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+	"github.com/gin-gonic/gin"
+)
+
+const codexBaseInstructions = "You are Codex, a coding agent. Follow the user's instructions and use the available tools to complete software engineering tasks. Inspect relevant files before editing, preserve unrelated changes, and verify the result."
+
+type codexReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+type codexTruncationPolicy struct {
+	Mode  string `json:"mode"`
+	Limit int    `json:"limit"`
+}
+
+type codexModelEntry struct {
+	Slug                              string                `json:"slug"`
+	DisplayName                       string                `json:"display_name"`
+	Description                       string                `json:"description"`
+	DefaultReasoningLevel             string                `json:"default_reasoning_level"`
+	SupportedReasoningLevels          []codexReasoningLevel `json:"supported_reasoning_levels"`
+	ShellType                         string                `json:"shell_type"`
+	Visibility                        string                `json:"visibility"`
+	MinimalClientVersion              string                `json:"minimal_client_version"`
+	SupportedInAPI                    bool                  `json:"supported_in_api"`
+	Priority                          int                   `json:"priority"`
+	AdditionalSpeedTiers              []string              `json:"additional_speed_tiers"`
+	ServiceTiers                      []any                 `json:"service_tiers"`
+	DefaultServiceTier                *string               `json:"default_service_tier"`
+	AvailabilityNUX                   any                   `json:"availability_nux"`
+	Upgrade                           any                   `json:"upgrade"`
+	BaseInstructions                  string                `json:"base_instructions"`
+	ModelMessages                     any                   `json:"model_messages"`
+	IncludeSkillsUsageInstructions    bool                  `json:"include_skills_usage_instructions"`
+	SupportsReasoningSummaryParameter bool                  `json:"supports_reasoning_summary_parameter"`
+	SupportsReasoningSummaries        bool                  `json:"supports_reasoning_summaries"`
+	DefaultReasoningSummary           string                `json:"default_reasoning_summary"`
+	SupportVerbosity                  bool                  `json:"support_verbosity"`
+	DefaultVerbosity                  *string               `json:"default_verbosity"`
+	ApplyPatchToolType                *string               `json:"apply_patch_tool_type"`
+	WebSearchToolType                 string                `json:"web_search_tool_type"`
+	TruncationPolicy                  codexTruncationPolicy `json:"truncation_policy"`
+	SupportsParallelToolCalls         bool                  `json:"supports_parallel_tool_calls"`
+	SupportsImageDetailOriginal       bool                  `json:"supports_image_detail_original"`
+	ContextWindow                     int                   `json:"context_window"`
+	MaxContextWindow                  int                   `json:"max_context_window"`
+	AutoCompactTokenLimit             *int                  `json:"auto_compact_token_limit"`
+	EffectiveContextWindowPercent     int                   `json:"effective_context_window_percent"`
+	ExperimentalSupportedTools        []string              `json:"experimental_supported_tools"`
+	InputModalities                   []string              `json:"input_modalities"`
+	SupportsSearchTool                bool                  `json:"supports_search_tool"`
+	UseResponsesLite                  bool                  `json:"use_responses_lite"`
+}
+
+type codexModelCatalog struct {
+	Models []codexModelEntry `json:"models"`
+}
+
+var codexReasoningDescriptions = map[string]string{
+	"none":   "No reasoning",
+	"low":    "Fast responses with lighter reasoning",
+	"medium": "Balances speed and reasoning depth for everyday tasks",
+	"high":   "Greater reasoning depth for complex problems",
+	"xhigh":  "Extra high reasoning depth for complex problems",
+	"max":    "Maximum reasoning depth for the hardest problems",
+}
+
+type grokModelCapability struct {
+	contextWindow   int
+	reasoningLevels []string
+	description     string
+	imageInput      bool
+}
+
+var grokCapabilities = map[string]grokModelCapability{
+	"grok-4.5":                     {500000, []string{"low", "medium", "high"}, "xAI Grok 4.5 frontier model with reasoning and vision.", true},
+	"grok-4.3":                     {1000000, []string{"none", "low", "medium", "high"}, "xAI Grok 4.3 high-capacity reasoning model.", true},
+	"grok-build-0.1":               {256000, []string{"none"}, "xAI Grok Build 0.1 coding model.", false},
+	"grok-4.20-0309-reasoning":     {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 reasoning model.", true},
+	"grok-4.20-0309-non-reasoning": {2000000, []string{"none"}, "xAI Grok 4.20 non-reasoning model.", true},
+	"grok-4.20-multi-agent-0309":   {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 multi-agent model.", true},
+	"grok-3-mini":                  {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini model.", false},
+	"grok-3-mini-fast":             {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini Fast model.", false},
+	"grok-composer-2.5-fast":       {200000, []string{"none"}, "xAI Grok Composer 2.5 model.", false},
+}
+
+var grokDefaultCapability = grokModelCapability{
+	contextWindow:   128000,
+	reasoningLevels: []string{"none"},
+	description:     "Grok model served via grok2api.",
+}
+
+func lookupGrokCapability(slug string) grokModelCapability {
+	if capability, ok := grokCapabilities[slug]; ok {
+		return capability
+	}
+	return grokDefaultCapability
+}
+
+func defaultReasoningLevel(levels []string) string {
+	for _, level := range levels {
+		if level == "medium" {
+			return level
+		}
+	}
+	if len(levels) > 0 {
+		return levels[0]
+	}
+	return "none"
+}
+
+func codexVisibilityForCapability(capability modeldomain.Capability) string {
+	switch capability {
+	case modeldomain.CapabilityImage, modeldomain.CapabilityImageEdit, modeldomain.CapabilityVideo:
+		return "hide"
+	default:
+		return "list"
+	}
+}
+
+func codexReasoningLevelsFor(levels []string) []codexReasoningLevel {
+	result := make([]codexReasoningLevel, 0, len(levels))
+	for _, level := range levels {
+		result = append(result, codexReasoningLevel{Effort: level, Description: codexReasoningDescriptions[level]})
+	}
+	return result
+}
+
+func codexAgentToolsSupported(item modelListItem) bool {
+	return item.Provider == account.ProviderBuild && item.Capability == modeldomain.CapabilityResponses
+}
+
+func codexReasoningSupported(levels []string) bool {
+	for _, level := range levels {
+		if level != "none" {
+			return true
+		}
+	}
+	return false
+}
+
+func newCodexModelCatalog(items []modelListItem) codexModelCatalog {
+	models := make([]codexModelEntry, 0, len(items))
+	for index, item := range items {
+		capability := lookupGrokCapability(item.ID)
+		modalities := []string{"text"}
+		if capability.imageInput {
+			modalities = append(modalities, "image")
+		}
+		var applyPatchToolType *string
+		toolsSupported := codexAgentToolsSupported(item)
+		if toolsSupported {
+			value := "freeform"
+			applyPatchToolType = &value
+		}
+		reasoningSupported := codexReasoningSupported(capability.reasoningLevels)
+		models = append(models, codexModelEntry{
+			Slug:                              item.ID,
+			DisplayName:                       codexDisplayName(item.ID),
+			Description:                       capability.description,
+			DefaultReasoningLevel:             defaultReasoningLevel(capability.reasoningLevels),
+			SupportedReasoningLevels:          codexReasoningLevelsFor(capability.reasoningLevels),
+			ShellType:                         "shell_command",
+			Visibility:                        codexVisibilityForCapability(item.Capability),
+			MinimalClientVersion:              "0.0.0",
+			SupportedInAPI:                    true,
+			Priority:                          index + 1,
+			AdditionalSpeedTiers:              []string{},
+			ServiceTiers:                      []any{},
+			BaseInstructions:                  codexBaseInstructions,
+			IncludeSkillsUsageInstructions:    false,
+			SupportsReasoningSummaryParameter: reasoningSupported,
+			SupportsReasoningSummaries:        reasoningSupported,
+			DefaultReasoningSummary:           "auto",
+			SupportVerbosity:                  false,
+			ApplyPatchToolType:                applyPatchToolType,
+			WebSearchToolType:                 "text",
+			TruncationPolicy:                  codexTruncationPolicy{Mode: "tokens", Limit: 10000},
+			SupportsParallelToolCalls:         toolsSupported,
+			SupportsImageDetailOriginal:       false,
+			ContextWindow:                     capability.contextWindow,
+			MaxContextWindow:                  capability.contextWindow,
+			EffectiveContextWindowPercent:     95,
+			ExperimentalSupportedTools:        []string{},
+			InputModalities:                   modalities,
+			SupportsSearchTool:                false,
+			UseResponsesLite:                  false,
+		})
+	}
+	return codexModelCatalog{Models: models}
+}
+
+func writeCodexModelCatalog(c *gin.Context, catalog codexModelCatalog) {
+	body, err := json.Marshal(catalog)
+	if err != nil {
+		writeOpenAIError(c, http.StatusInternalServerError, "model_list_failed", "编码模型列表失败")
+		return
+	}
+	sum := sha256.Sum256(body)
+	etag := `"` + hex.EncodeToString(sum[:]) + `"`
+	c.Header("ETag", etag)
+	if strings.TrimSpace(c.GetHeader("If-None-Match")) == etag {
+		c.Status(http.StatusNotModified)
+		return
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", body)
+}
+
+func codexDisplayName(slug string) string {
+	words := strings.Fields(strings.NewReplacer("_", " ", "-", " ").Replace(slug))
+	for index, word := range words {
+		runes := []rune(word)
+		if len(runes) > 0 {
+			runes[0] = unicode.ToUpper(runes[0])
+			words[index] = string(runes)
+		}
+	}
+	return strings.Join(words, " ")
+}

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -2,6 +2,7 @@ package inference
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -165,16 +166,21 @@ type videoGenerationRequest struct {
 }
 
 type modelListItem struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	OwnedBy string `json:"owned_by"`
+	ID         string                 `json:"id"`
+	Object     string                 `json:"object"`
+	Created    int64                  `json:"created"`
+	OwnedBy    string                 `json:"owned_by"`
+	Capability modeldomain.Capability `json:"-"`
 }
 
 func (h *Handler) listModels(c *gin.Context) {
 	values, err := h.models.ListEnabled(c.Request.Context())
 	if err != nil {
 		writeOpenAIError(c, http.StatusInternalServerError, "model_list_failed", "读取模型列表失败")
+		return
+	}
+	if clientVersion := strings.TrimSpace(c.Query("client_version")); clientVersion != "" {
+		c.JSON(http.StatusOK, newCodexModelCache(clientVersion, newModelListItems(values)))
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"object": "list", "data": newModelListItems(values)})
@@ -190,9 +196,165 @@ func newModelListItems(values []modeldomain.Route) []modelListItem {
 			continue
 		}
 		seen[publicID] = true
-		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api"})
+		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api", Capability: value.Capability})
 	}
 	return data
+}
+
+type codexReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+type codexTruncationPolicy struct {
+	Mode  string `json:"mode"`
+	Limit int    `json:"limit"`
+}
+
+type codexModelEntry struct {
+	Slug                          string                `json:"slug"`
+	DisplayName                   string                `json:"display_name"`
+	Description                   string                `json:"description"`
+	DefaultReasoningLevel         string                `json:"default_reasoning_level"`
+	SupportedReasoningLevels      []codexReasoningLevel `json:"supported_reasoning_levels"`
+	ShellType                     string                `json:"shell_type"`
+	Visibility                    string                `json:"visibility"`
+	SupportedInAPI                bool                  `json:"supported_in_api"`
+	Priority                      int                   `json:"priority"`
+	SupportVerbosity              bool                  `json:"support_verbosity"`
+	DefaultVerbosity              string                `json:"default_verbosity"`
+	ApplyPatchToolType            string                `json:"apply_patch_tool_type"`
+	WebSearchToolType             string                `json:"web_search_tool_type"`
+	TruncationPolicy              codexTruncationPolicy `json:"truncation_policy"`
+	SupportsParallelToolCalls     bool                  `json:"supports_parallel_tool_calls"`
+	ContextWindow                 int                   `json:"context_window"`
+	MaxContextWindow              int                   `json:"max_context_window"`
+	EffectiveContextWindowPercent int                   `json:"effective_context_window_percent"`
+	InputModalities               []string              `json:"input_modalities"`
+	SupportsSearchTool            bool                  `json:"supports_search_tool"`
+	AutoCompactTokenLimit         *int                  `json:"auto_compact_token_limit"`
+}
+
+type codexModelCache struct {
+	FetchedAt     string            `json:"fetched_at"`
+	Etag          string            `json:"etag"`
+	ClientVersion string            `json:"client_version"`
+	Models        []codexModelEntry `json:"models"`
+}
+
+var codexReasoningDescriptions = map[string]string{
+	"none":   "No reasoning",
+	"low":    "Fast responses with lighter reasoning",
+	"medium": "Balances speed and reasoning depth for everyday tasks",
+	"high":   "Greater reasoning depth for complex problems",
+	"xhigh":  "Extra high reasoning depth for complex problems",
+	"max":    "Maximum reasoning depth for the hardest problems",
+}
+
+type grokModelCapability struct {
+	contextWindow   int
+	reasoningLevels []string
+	description     string
+}
+
+var grokCapabilities = map[string]grokModelCapability{
+	"grok-4.5":                     {500000, []string{"low", "medium", "high"}, "xAI Grok 4.5 — frontier model with strong reasoning, vision, and 500K context."},
+	"grok-4.3":                     {1000000, []string{"none", "low", "medium", "high"}, "xAI Grok 4.3 — high-capacity reasoning model with 1M token context."},
+	"grok-build-0.1":               {256000, nil, "xAI Grok Build 0.1 — fast agentic coding model optimized for tool use."},
+	"grok-4.20-0309-reasoning":     {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 reasoning variant with 2M token context."},
+	"grok-4.20-0309-non-reasoning": {2000000, nil, "xAI Grok 4.20 non-reasoning variant for fast, lightweight responses."},
+	"grok-4.20-multi-agent-0309":   {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 multi-agent model with parallel reasoning and 2M context."},
+	"grok-3-mini":                  {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini — lightweight efficient model for everyday tasks."},
+	"grok-3-mini-fast":             {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini Fast — optimized for speed and low latency."},
+	"grok-composer-2.5-fast":       {200000, nil, "xAI Grok Composer 2.5 — fast generation model."},
+}
+
+var grokDefaultCapability = grokModelCapability{
+	contextWindow: 500000, reasoningLevels: []string{"low", "medium", "high"},
+	description: "Grok model served via grok2api.",
+}
+
+func lookupGrokCapability(slug string) grokModelCapability {
+	if cap, ok := grokCapabilities[slug]; ok {
+		return cap
+	}
+	return grokDefaultCapability
+}
+
+func defaultReasoningLevel(levels []string) string {
+	if len(levels) == 0 {
+		return "none"
+	}
+	return levels[len(levels)-1]
+}
+
+func codexVisibilityForCapability(capability modeldomain.Capability) string {
+	switch capability {
+	case modeldomain.CapabilityImage, modeldomain.CapabilityImageEdit, modeldomain.CapabilityVideo:
+		return "hide"
+	default:
+		return "list"
+	}
+}
+
+func codexReasoningLevelsFor(levels []string) []codexReasoningLevel {
+	result := make([]codexReasoningLevel, 0, len(levels))
+	for _, level := range levels {
+		desc := codexReasoningDescriptions[level]
+		result = append(result, codexReasoningLevel{Effort: level, Description: desc})
+	}
+	return result
+}
+
+func newCodexModelCache(clientVersion string, items []modelListItem) codexModelCache {
+	models := make([]codexModelEntry, 0, len(items))
+	for index, item := range items {
+		cap := lookupGrokCapability(item.ID)
+		models = append(models, codexModelEntry{
+			Slug:                          item.ID,
+			DisplayName:                   codexDisplayName(item.ID),
+			Description:                   cap.description,
+			DefaultReasoningLevel:         defaultReasoningLevel(cap.reasoningLevels),
+			SupportedReasoningLevels:      codexReasoningLevelsFor(cap.reasoningLevels),
+			ShellType:                     "shell_command",
+			Visibility:                    codexVisibilityForCapability(item.Capability),
+			SupportedInAPI:                true,
+			Priority:                      index + 1,
+			SupportVerbosity:              true,
+			DefaultVerbosity:              "low",
+			ApplyPatchToolType:            "freeform",
+			WebSearchToolType:             "text_and_image",
+			TruncationPolicy:              codexTruncationPolicy{Mode: "tokens", Limit: 10000},
+			SupportsParallelToolCalls:     true,
+			ContextWindow:                 cap.contextWindow,
+			MaxContextWindow:              cap.contextWindow,
+			EffectiveContextWindowPercent: 95,
+			InputModalities:               []string{"text", "image"},
+			SupportsSearchTool:            true,
+			AutoCompactTokenLimit:         nil,
+		})
+	}
+	payload := codexModelCache{
+		FetchedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		Etag:          fmt.Sprintf("W/\"%x\"", sha1Sum(models)),
+		ClientVersion: clientVersion,
+		Models:        models,
+	}
+	return payload
+}
+
+func codexDisplayName(slug string) string {
+	display := strings.NewReplacer("_", " ", "-", " ").Replace(slug)
+	return strings.Title(display)
+}
+
+func sha1Sum(models []codexModelEntry) []byte {
+	h := sha1.New()
+	for _, m := range models {
+		io.WriteString(h, m.Slug)
+		io.WriteString(h, m.DisplayName)
+	}
+	return h.Sum(nil)
 }
 
 func (h *Handler) createResponse(c *gin.Context) {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -2,7 +2,6 @@ package inference
 
 import (
 	"bytes"
-	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	clientkeyapp "github.com/chenyme/grok2api/backend/internal/application/clientkey"
 	"github.com/chenyme/grok2api/backend/internal/application/gateway"
 	modelapp "github.com/chenyme/grok2api/backend/internal/application/model"
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	clientkeydomain "github.com/chenyme/grok2api/backend/internal/domain/clientkey"
 	mediadomain "github.com/chenyme/grok2api/backend/internal/domain/media"
 	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
@@ -170,6 +170,7 @@ type modelListItem struct {
 	Object     string                 `json:"object"`
 	Created    int64                  `json:"created"`
 	OwnedBy    string                 `json:"owned_by"`
+	Provider   account.Provider       `json:"-"`
 	Capability modeldomain.Capability `json:"-"`
 }
 
@@ -180,7 +181,7 @@ func (h *Handler) listModels(c *gin.Context) {
 		return
 	}
 	if clientVersion := strings.TrimSpace(c.Query("client_version")); clientVersion != "" {
-		c.JSON(http.StatusOK, newCodexModelCache(clientVersion, newModelListItems(values)))
+		writeCodexModelCatalog(c, newCodexModelCatalog(newModelListItems(values)))
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"object": "list", "data": newModelListItems(values)})
@@ -196,165 +197,9 @@ func newModelListItems(values []modeldomain.Route) []modelListItem {
 			continue
 		}
 		seen[publicID] = true
-		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api", Capability: value.Capability})
+		data = append(data, modelListItem{ID: publicID, Object: "model", Created: value.CreatedAt.Unix(), OwnedBy: "grok2api", Provider: value.Provider, Capability: value.Capability})
 	}
 	return data
-}
-
-type codexReasoningLevel struct {
-	Effort      string `json:"effort"`
-	Description string `json:"description"`
-}
-
-type codexTruncationPolicy struct {
-	Mode  string `json:"mode"`
-	Limit int    `json:"limit"`
-}
-
-type codexModelEntry struct {
-	Slug                          string                `json:"slug"`
-	DisplayName                   string                `json:"display_name"`
-	Description                   string                `json:"description"`
-	DefaultReasoningLevel         string                `json:"default_reasoning_level"`
-	SupportedReasoningLevels      []codexReasoningLevel `json:"supported_reasoning_levels"`
-	ShellType                     string                `json:"shell_type"`
-	Visibility                    string                `json:"visibility"`
-	SupportedInAPI                bool                  `json:"supported_in_api"`
-	Priority                      int                   `json:"priority"`
-	SupportVerbosity              bool                  `json:"support_verbosity"`
-	DefaultVerbosity              string                `json:"default_verbosity"`
-	ApplyPatchToolType            string                `json:"apply_patch_tool_type"`
-	WebSearchToolType             string                `json:"web_search_tool_type"`
-	TruncationPolicy              codexTruncationPolicy `json:"truncation_policy"`
-	SupportsParallelToolCalls     bool                  `json:"supports_parallel_tool_calls"`
-	ContextWindow                 int                   `json:"context_window"`
-	MaxContextWindow              int                   `json:"max_context_window"`
-	EffectiveContextWindowPercent int                   `json:"effective_context_window_percent"`
-	InputModalities               []string              `json:"input_modalities"`
-	SupportsSearchTool            bool                  `json:"supports_search_tool"`
-	AutoCompactTokenLimit         *int                  `json:"auto_compact_token_limit"`
-}
-
-type codexModelCache struct {
-	FetchedAt     string            `json:"fetched_at"`
-	Etag          string            `json:"etag"`
-	ClientVersion string            `json:"client_version"`
-	Models        []codexModelEntry `json:"models"`
-}
-
-var codexReasoningDescriptions = map[string]string{
-	"none":   "No reasoning",
-	"low":    "Fast responses with lighter reasoning",
-	"medium": "Balances speed and reasoning depth for everyday tasks",
-	"high":   "Greater reasoning depth for complex problems",
-	"xhigh":  "Extra high reasoning depth for complex problems",
-	"max":    "Maximum reasoning depth for the hardest problems",
-}
-
-type grokModelCapability struct {
-	contextWindow   int
-	reasoningLevels []string
-	description     string
-}
-
-var grokCapabilities = map[string]grokModelCapability{
-	"grok-4.5":                     {500000, []string{"low", "medium", "high"}, "xAI Grok 4.5 — frontier model with strong reasoning, vision, and 500K context."},
-	"grok-4.3":                     {1000000, []string{"none", "low", "medium", "high"}, "xAI Grok 4.3 — high-capacity reasoning model with 1M token context."},
-	"grok-build-0.1":               {256000, nil, "xAI Grok Build 0.1 — fast agentic coding model optimized for tool use."},
-	"grok-4.20-0309-reasoning":     {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 reasoning variant with 2M token context."},
-	"grok-4.20-0309-non-reasoning": {2000000, nil, "xAI Grok 4.20 non-reasoning variant for fast, lightweight responses."},
-	"grok-4.20-multi-agent-0309":   {2000000, []string{"low", "medium", "high"}, "xAI Grok 4.20 multi-agent model with parallel reasoning and 2M context."},
-	"grok-3-mini":                  {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini — lightweight efficient model for everyday tasks."},
-	"grok-3-mini-fast":             {131072, []string{"low", "medium", "high"}, "xAI Grok 3 Mini Fast — optimized for speed and low latency."},
-	"grok-composer-2.5-fast":       {200000, nil, "xAI Grok Composer 2.5 — fast generation model."},
-}
-
-var grokDefaultCapability = grokModelCapability{
-	contextWindow: 500000, reasoningLevels: []string{"low", "medium", "high"},
-	description: "Grok model served via grok2api.",
-}
-
-func lookupGrokCapability(slug string) grokModelCapability {
-	if cap, ok := grokCapabilities[slug]; ok {
-		return cap
-	}
-	return grokDefaultCapability
-}
-
-func defaultReasoningLevel(levels []string) string {
-	if len(levels) == 0 {
-		return "none"
-	}
-	return levels[len(levels)-1]
-}
-
-func codexVisibilityForCapability(capability modeldomain.Capability) string {
-	switch capability {
-	case modeldomain.CapabilityImage, modeldomain.CapabilityImageEdit, modeldomain.CapabilityVideo:
-		return "hide"
-	default:
-		return "list"
-	}
-}
-
-func codexReasoningLevelsFor(levels []string) []codexReasoningLevel {
-	result := make([]codexReasoningLevel, 0, len(levels))
-	for _, level := range levels {
-		desc := codexReasoningDescriptions[level]
-		result = append(result, codexReasoningLevel{Effort: level, Description: desc})
-	}
-	return result
-}
-
-func newCodexModelCache(clientVersion string, items []modelListItem) codexModelCache {
-	models := make([]codexModelEntry, 0, len(items))
-	for index, item := range items {
-		cap := lookupGrokCapability(item.ID)
-		models = append(models, codexModelEntry{
-			Slug:                          item.ID,
-			DisplayName:                   codexDisplayName(item.ID),
-			Description:                   cap.description,
-			DefaultReasoningLevel:         defaultReasoningLevel(cap.reasoningLevels),
-			SupportedReasoningLevels:      codexReasoningLevelsFor(cap.reasoningLevels),
-			ShellType:                     "shell_command",
-			Visibility:                    codexVisibilityForCapability(item.Capability),
-			SupportedInAPI:                true,
-			Priority:                      index + 1,
-			SupportVerbosity:              true,
-			DefaultVerbosity:              "low",
-			ApplyPatchToolType:            "freeform",
-			WebSearchToolType:             "text_and_image",
-			TruncationPolicy:              codexTruncationPolicy{Mode: "tokens", Limit: 10000},
-			SupportsParallelToolCalls:     true,
-			ContextWindow:                 cap.contextWindow,
-			MaxContextWindow:              cap.contextWindow,
-			EffectiveContextWindowPercent: 95,
-			InputModalities:               []string{"text", "image"},
-			SupportsSearchTool:            true,
-			AutoCompactTokenLimit:         nil,
-		})
-	}
-	payload := codexModelCache{
-		FetchedAt:     time.Now().UTC().Format(time.RFC3339Nano),
-		Etag:          fmt.Sprintf("W/\"%x\"", sha1Sum(models)),
-		ClientVersion: clientVersion,
-		Models:        models,
-	}
-	return payload
-}
-
-func codexDisplayName(slug string) string {
-	display := strings.NewReplacer("_", " ", "-", " ").Replace(slug)
-	return strings.Title(display)
-}
-
-func sha1Sum(models []codexModelEntry) []byte {
-	h := sha1.New()
-	for _, m := range models {
-		io.WriteString(h, m.Slug)
-		io.WriteString(h, m.DisplayName)
-	}
-	return h.Sum(nil)
 }
 
 func (h *Handler) createResponse(c *gin.Context) {
@@ -1576,7 +1421,7 @@ func copyHeaders(destination, source http.Header) {
 	excluded := map[string]struct{}{
 		"connection": {}, "content-length": {}, "keep-alive": {}, "proxy-authenticate": {},
 		"proxy-authorization": {}, "set-cookie": {}, "te": {}, "trailer": {},
-		"transfer-encoding": {}, "upgrade": {},
+		"transfer-encoding": {}, "upgrade": {}, "x-models-etag": {},
 	}
 	for _, value := range source.Values("Connection") {
 		for name := range strings.SplitSeq(value, ",") {

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -689,6 +689,7 @@ func TestCopyHeadersFiltersHopByHopAndUpstreamCookies(t *testing.T) {
 		"Connection":          {"X-Upstream-Internal"},
 		"Content-Type":        {"application/json"},
 		"Set-Cookie":          {"upstream_session=secret"},
+		"X-Models-Etag":       {`"upstream-account-catalog"`},
 		"X-Request-Id":        {"req_123"},
 		"X-Upstream-Internal": {"hidden"},
 	}
@@ -699,7 +700,7 @@ func TestCopyHeadersFiltersHopByHopAndUpstreamCookies(t *testing.T) {
 	if destination.Get("Content-Type") != "application/json" || destination.Get("X-Request-Id") != "req_123" {
 		t.Fatalf("forwarded headers = %#v", destination)
 	}
-	if destination.Get("Set-Cookie") != "" || destination.Get("X-Upstream-Internal") != "" || destination.Get("Connection") != "" {
+	if destination.Get("Set-Cookie") != "" || destination.Get("X-Models-Etag") != "" || destination.Get("X-Upstream-Internal") != "" || destination.Get("Connection") != "" {
 		t.Fatalf("filtered headers leaked = %#v", destination)
 	}
 }

--- a/backend/internal/transport/http/inference/model_list_test.go
+++ b/backend/internal/transport/http/inference/model_list_test.go
@@ -1,11 +1,15 @@
 package inference
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+	"github.com/gin-gonic/gin"
 )
 
 func TestNewModelListItemsDeduplicatesSharedPublicName(t *testing.T) {
@@ -20,19 +24,16 @@ func TestNewModelListItemsDeduplicatesSharedPublicName(t *testing.T) {
 	}
 }
 
-func TestNewCodexModelCacheShapesForClientVersion(t *testing.T) {
+func TestNewCodexModelCatalogIncludesRequiredProtocolFields(t *testing.T) {
 	now := time.Unix(100, 0).UTC()
 	items := newModelListItems([]modeldomain.Route{
-		{PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, CreatedAt: now},
+		{PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, Capability: modeldomain.CapabilityResponses, CreatedAt: now},
 	})
-	cache := newCodexModelCache("0.114.5", items)
-	if cache.ClientVersion != "0.114.5" {
-		t.Fatalf("client_version = %q", cache.ClientVersion)
+	catalog := newCodexModelCatalog(items)
+	if len(catalog.Models) != 1 || catalog.Models[0].Slug != "grok-4.5" {
+		t.Fatalf("models = %#v", catalog.Models)
 	}
-	if len(cache.Models) != 1 || cache.Models[0].Slug != "grok-4.5" {
-		t.Fatalf("models = %#v", cache.Models)
-	}
-	entry := cache.Models[0]
+	entry := catalog.Models[0]
 	if entry.DisplayName != "Grok 4.5" {
 		t.Fatalf("display_name = %q", entry.DisplayName)
 	}
@@ -45,28 +46,35 @@ func TestNewCodexModelCacheShapesForClientVersion(t *testing.T) {
 	if entry.EffectiveContextWindowPercent != 95 {
 		t.Fatalf("effective context window percent = %d, want 95", entry.EffectiveContextWindowPercent)
 	}
-	if entry.DefaultReasoningLevel != "high" {
-		t.Fatalf("default reasoning = %q, want high", entry.DefaultReasoningLevel)
+	if entry.DefaultReasoningLevel != "medium" {
+		t.Fatalf("default reasoning = %q, want medium", entry.DefaultReasoningLevel)
 	}
-	if entry.Description == "" {
-		t.Fatalf("description is empty")
+	if entry.BaseInstructions == "" || entry.ExperimentalSupportedTools == nil {
+		t.Fatalf("required fields missing: %#v", entry)
 	}
-	if entry.AutoCompactTokenLimit != nil {
-		t.Fatalf("auto_compact_token_limit = %v, want nil", entry.AutoCompactTokenLimit)
+	if entry.ApplyPatchToolType == nil || !entry.SupportsParallelToolCalls {
+		t.Fatalf("Build tool metadata = %#v", entry)
+	}
+	body, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope map[string]json.RawMessage
+	if err = json.Unmarshal(body, &envelope); err != nil || len(envelope) != 1 || envelope["models"] == nil {
+		t.Fatalf("catalog envelope = %s, err = %v", body, err)
 	}
 }
 
 func TestNewCodexModelCacheRespectsNonReasoningModel(t *testing.T) {
 	now := time.Unix(100, 0).UTC()
 	items := newModelListItems([]modeldomain.Route{
-		{PublicID: "Build/grok-build-0.1", Provider: account.ProviderBuild, CreatedAt: now},
+		{PublicID: "Build/grok-build-0.1", Provider: account.ProviderBuild, Capability: modeldomain.CapabilityResponses, CreatedAt: now},
 	})
-	cache := newCodexModelCache("0.114.5", items)
-	entry := cache.Models[0]
+	entry := newCodexModelCatalog(items).Models[0]
 	if entry.DefaultReasoningLevel != "none" {
 		t.Fatalf("default reasoning = %q", entry.DefaultReasoningLevel)
 	}
-	if len(entry.SupportedReasoningLevels) != 0 {
+	if len(entry.SupportedReasoningLevels) != 1 || entry.SupportedReasoningLevels[0].Effort != "none" {
 		t.Fatalf("reasoning levels = %#v", entry.SupportedReasoningLevels)
 	}
 	if entry.ContextWindow != 256000 {
@@ -81,11 +89,11 @@ func TestCodexCatalogHidesMediaModels(t *testing.T) {
 		{PublicID: "Web/grok-imagine-image", Provider: account.ProviderWeb, Capability: modeldomain.CapabilityImage, CreatedAt: now},
 		{PublicID: "Web/grok-imagine-video", Provider: account.ProviderWeb, Capability: modeldomain.CapabilityVideo, CreatedAt: now},
 	}
-	cache := newCodexModelCache("0.114.5", newModelListItems(routes))
-	if len(cache.Models) != 3 {
-		t.Fatalf("model count = %d, want 3; slugs = %#v", len(cache.Models), codexSlugs(cache.Models))
+	catalog := newCodexModelCatalog(newModelListItems(routes))
+	if len(catalog.Models) != 3 {
+		t.Fatalf("model count = %d, want 3; slugs = %#v", len(catalog.Models), codexSlugs(catalog.Models))
 	}
-	for _, entry := range cache.Models {
+	for _, entry := range catalog.Models {
 		switch entry.Slug {
 		case "grok-4.5":
 			if entry.Visibility != "list" {
@@ -96,6 +104,43 @@ func TestCodexCatalogHidesMediaModels(t *testing.T) {
 				t.Fatalf("visibility for %s = %q, want hide", entry.Slug, entry.Visibility)
 			}
 		}
+	}
+}
+
+func TestCodexCatalogUsesConservativeUnknownModelDefaults(t *testing.T) {
+	entry := newCodexModelCatalog([]modelListItem{{
+		ID: "custom-model", Provider: account.ProviderWeb, Capability: modeldomain.CapabilityChat,
+	}}).Models[0]
+	if entry.ContextWindow != 128000 || entry.DefaultReasoningLevel != "none" {
+		t.Fatalf("unknown model metadata = %#v", entry)
+	}
+	if len(entry.InputModalities) != 1 || entry.InputModalities[0] != "text" || entry.ApplyPatchToolType != nil || entry.SupportsParallelToolCalls || entry.SupportsSearchTool || entry.SupportVerbosity {
+		t.Fatalf("unknown model over-advertises capabilities: %#v", entry)
+	}
+}
+
+func TestWriteCodexModelCatalogSetsETagAndHandlesNotModified(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	catalog := newCodexModelCatalog([]modelListItem{{
+		ID: "grok-4.5", Provider: account.ProviderBuild, Capability: modeldomain.CapabilityResponses,
+	}})
+	router := gin.New()
+	router.GET("/v1/models", func(c *gin.Context) { writeCodexModelCatalog(c, catalog) })
+
+	first := httptest.NewRecorder()
+	firstRequest := httptest.NewRequest(http.MethodGet, "/v1/models?client_version=0.145.0", nil)
+	router.ServeHTTP(first, firstRequest)
+	etag := first.Header().Get("ETag")
+	if first.Code != http.StatusOK || etag == "" {
+		t.Fatalf("first response = %d, etag = %q", first.Code, etag)
+	}
+
+	second := httptest.NewRecorder()
+	secondRequest := httptest.NewRequest(http.MethodGet, "/v1/models?client_version=0.145.0", nil)
+	secondRequest.Header.Set("If-None-Match", etag)
+	router.ServeHTTP(second, secondRequest)
+	if second.Code != http.StatusNotModified || second.Body.Len() != 0 || second.Header().Get("ETag") != etag {
+		t.Fatalf("conditional response = %d, body = %q, etag = %q", second.Code, second.Body.String(), second.Header().Get("ETag"))
 	}
 }
 

--- a/backend/internal/transport/http/inference/model_list_test.go
+++ b/backend/internal/transport/http/inference/model_list_test.go
@@ -19,3 +19,90 @@ func TestNewModelListItemsDeduplicatesSharedPublicName(t *testing.T) {
 		t.Fatalf("model list = %#v", items)
 	}
 }
+
+func TestNewCodexModelCacheShapesForClientVersion(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	items := newModelListItems([]modeldomain.Route{
+		{PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, CreatedAt: now},
+	})
+	cache := newCodexModelCache("0.114.5", items)
+	if cache.ClientVersion != "0.114.5" {
+		t.Fatalf("client_version = %q", cache.ClientVersion)
+	}
+	if len(cache.Models) != 1 || cache.Models[0].Slug != "grok-4.5" {
+		t.Fatalf("models = %#v", cache.Models)
+	}
+	entry := cache.Models[0]
+	if entry.DisplayName != "Grok 4.5" {
+		t.Fatalf("display_name = %q", entry.DisplayName)
+	}
+	if len(entry.SupportedReasoningLevels) != 3 || entry.SupportedReasoningLevels[0].Effort != "low" {
+		t.Fatalf("reasoning levels = %#v", entry.SupportedReasoningLevels)
+	}
+	if entry.ContextWindow != 500000 || entry.MaxContextWindow != 500000 {
+		t.Fatalf("context window = %d/%d", entry.ContextWindow, entry.MaxContextWindow)
+	}
+	if entry.EffectiveContextWindowPercent != 95 {
+		t.Fatalf("effective context window percent = %d, want 95", entry.EffectiveContextWindowPercent)
+	}
+	if entry.DefaultReasoningLevel != "high" {
+		t.Fatalf("default reasoning = %q, want high", entry.DefaultReasoningLevel)
+	}
+	if entry.Description == "" {
+		t.Fatalf("description is empty")
+	}
+	if entry.AutoCompactTokenLimit != nil {
+		t.Fatalf("auto_compact_token_limit = %v, want nil", entry.AutoCompactTokenLimit)
+	}
+}
+
+func TestNewCodexModelCacheRespectsNonReasoningModel(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	items := newModelListItems([]modeldomain.Route{
+		{PublicID: "Build/grok-build-0.1", Provider: account.ProviderBuild, CreatedAt: now},
+	})
+	cache := newCodexModelCache("0.114.5", items)
+	entry := cache.Models[0]
+	if entry.DefaultReasoningLevel != "none" {
+		t.Fatalf("default reasoning = %q", entry.DefaultReasoningLevel)
+	}
+	if len(entry.SupportedReasoningLevels) != 0 {
+		t.Fatalf("reasoning levels = %#v", entry.SupportedReasoningLevels)
+	}
+	if entry.ContextWindow != 256000 {
+		t.Fatalf("context window = %d", entry.ContextWindow)
+	}
+}
+
+func TestCodexCatalogHidesMediaModels(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	routes := []modeldomain.Route{
+		{PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, Capability: modeldomain.CapabilityResponses, CreatedAt: now},
+		{PublicID: "Web/grok-imagine-image", Provider: account.ProviderWeb, Capability: modeldomain.CapabilityImage, CreatedAt: now},
+		{PublicID: "Web/grok-imagine-video", Provider: account.ProviderWeb, Capability: modeldomain.CapabilityVideo, CreatedAt: now},
+	}
+	cache := newCodexModelCache("0.114.5", newModelListItems(routes))
+	if len(cache.Models) != 3 {
+		t.Fatalf("model count = %d, want 3; slugs = %#v", len(cache.Models), codexSlugs(cache.Models))
+	}
+	for _, entry := range cache.Models {
+		switch entry.Slug {
+		case "grok-4.5":
+			if entry.Visibility != "list" {
+				t.Fatalf("visibility for %s = %q, want list", entry.Slug, entry.Visibility)
+			}
+		case "grok-imagine-image", "grok-imagine-video":
+			if entry.Visibility != "hide" {
+				t.Fatalf("visibility for %s = %q, want hide", entry.Slug, entry.Visibility)
+			}
+		}
+	}
+}
+
+func codexSlugs(models []codexModelEntry) []string {
+	slugs := make([]string, 0, len(models))
+	for _, m := range models {
+		slugs = append(slugs, m.Slug)
+	}
+	return slugs
+}


### PR DESCRIPTION
## 变更内容

- 为带 `client_version` 的模型列表返回 Codex 所需的模型目录结构。
- 在内部模型项中保留 capability 信息，并对媒体模型标记为隐藏。
- 补充 Codex 模型目录与媒体模型可见度测试。

## 原因

Codex 客户端需要比 OpenAI `/v1/models` 更完整的模型元数据，且不应在模型选择器中展示媒体专用模型。

## 影响

普通 `/v1/models` 响应保持不变；仅携带 `client_version` 的请求使用 Codex catalog。

## 验证

- `go test ./internal/transport/http/inference`