### PR TITLE
fix(gateway): mid-tier failover for 402 spending-limit

### DIFF
--- a/backend/internal/application/gateway/failure.go
+++ b/backend/internal/application/gateway/failure.go
@@ -104,8 +104,9 @@ func newHTTPUpstreamFailure(status int, body []byte, accountID uint64, accountNa
 		failure.PublicMessage = "上游账号额度不足"
 		failure.AccountScoped = true
 		failure.QuotaExhausted = true
-		// spending-limit is account-scoped; free-window recovery applies when billing is not paid.
-		failure.FreeQuotaExhausted = isFreeQuotaExhaustion(metadataText) || isPaidQuotaExhaustion(metadataText)
+		// spending-limit is account-scoped, but its paid/free recovery kind depends on
+		// the selected account's billing snapshot and must be decided by the selector.
+		failure.FreeQuotaExhausted = isFreeQuotaExhaustion(metadataText)
 	case http.StatusForbidden:
 		failure.Code = "upstream_forbidden"
 		failure.PublicMessage = "上游拒绝了该请求"

--- a/backend/internal/application/gateway/failure.go
+++ b/backend/internal/application/gateway/failure.go
@@ -104,6 +104,8 @@ func newHTTPUpstreamFailure(status int, body []byte, accountID uint64, accountNa
 		failure.PublicMessage = "上游账号额度不足"
 		failure.AccountScoped = true
 		failure.QuotaExhausted = true
+		// spending-limit is account-scoped; free-window recovery applies when billing is not paid.
+		failure.FreeQuotaExhausted = isFreeQuotaExhaustion(metadataText) || isPaidQuotaExhaustion(metadataText)
 	case http.StatusForbidden:
 		failure.Code = "upstream_forbidden"
 		failure.PublicMessage = "上游拒绝了该请求"

--- a/backend/internal/application/gateway/failure_test.go
+++ b/backend/internal/application/gateway/failure_test.go
@@ -67,3 +67,14 @@ func TestRetryableResponseHonorsUpstreamRetryVeto(t *testing.T) {
 		t.Fatal("未知 x-should-retry 值应按未提供处理")
 	}
 }
+
+func TestPaymentRequiredAlwaysRetriesDespiteUpstreamVeto(t *testing.T) {
+	response := &provider.Response{
+		StatusCode: http.StatusPaymentRequired,
+		Header:     http.Header{"X-Should-Retry": {"false"}},
+		Body:       io.NopCloser(strings.NewReader(`{"code":"personal-team-blocked:spending-limit","error":"You have run out of credits"}`)),
+	}
+	if !isRetryableResponse(response) {
+		t.Fatal("402 spending-limit must force account rotation even when X-Should-Retry is false")
+	}
+}

--- a/backend/internal/application/gateway/failure_test.go
+++ b/backend/internal/application/gateway/failure_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	accountdomain "github.com/chenyme/grok2api/backend/internal/domain/account"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 )
 
@@ -49,21 +50,31 @@ func TestHTTPUpstreamFailureClassifiesBuildForbiddenBodies(t *testing.T) {
 	}
 }
 
+func TestHTTPUpstreamFailureLeavesPaymentRecoveryKindToBilling(t *testing.T) {
+	failure := newHTTPUpstreamFailure(http.StatusPaymentRequired, []byte(`{
+		"code":"personal-team-blocked:spending-limit",
+		"error":"You have run out of credits"
+	}`), 42, "build")
+	if !failure.AccountScoped || !failure.QuotaExhausted || failure.FreeQuotaExhausted || failure.UpstreamCode != "personal-team-blocked:spending-limit" {
+		t.Fatalf("failure = %#v", failure)
+	}
+}
+
 func TestRetryableResponseHonorsUpstreamRetryVeto(t *testing.T) {
 	response := &provider.Response{
 		StatusCode: http.StatusInternalServerError,
 		Header:     http.Header{"X-Should-Retry": {"false"}},
 		Body:       io.NopCloser(strings.NewReader(`{"error":"invalid request history"}`)),
 	}
-	if isRetryableResponse(response) {
+	if isRetryableResponse(response, accountdomain.ProviderBuild) {
 		t.Fatal("x-should-retry:false 必须禁止换账号重试")
 	}
 	response.Header.Set("X-Should-Retry", "true")
-	if !isRetryableResponse(response) {
+	if !isRetryableResponse(response, accountdomain.ProviderBuild) {
 		t.Fatal("x-should-retry:true 不应覆盖现有状态码重试策略")
 	}
 	response.Header.Set("X-Should-Retry", "unknown")
-	if !isRetryableResponse(response) {
+	if !isRetryableResponse(response, accountdomain.ProviderBuild) {
 		t.Fatal("未知 x-should-retry 值应按未提供处理")
 	}
 }
@@ -74,7 +85,10 @@ func TestPaymentRequiredAlwaysRetriesDespiteUpstreamVeto(t *testing.T) {
 		Header:     http.Header{"X-Should-Retry": {"false"}},
 		Body:       io.NopCloser(strings.NewReader(`{"code":"personal-team-blocked:spending-limit","error":"You have run out of credits"}`)),
 	}
-	if !isRetryableResponse(response) {
+	if !isRetryableResponse(response, accountdomain.ProviderBuild) {
 		t.Fatal("402 spending-limit must force account rotation even when X-Should-Retry is false")
+	}
+	if isRetryableResponse(response, accountdomain.ProviderWeb) {
+		t.Fatal("non-Build 402 must continue honoring X-Should-Retry:false")
 	}
 }

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -33,9 +33,18 @@ const maxConcurrencySnapshots = 256
 
 const modelAccessDeniedCooldown = 5 * time.Minute
 
-// freeQuotaRecoveryPause is how long a free/unrecognized profile stays out of the pool after quota exhaustion.
-// Shorter than a full calendar day so recovered accounts rejoin faster; a failed probe re-applies the pause.
-const freeQuotaRecoveryPause = 2 * time.Hour
+const defaultFreeQuotaRecoveryPause = 24 * time.Hour
+
+// paymentRequiredRecoveryPause is only the final fallback for a 402 account
+// without an upstream reset, Retry-After, or parseable billing period.
+const paymentRequiredRecoveryPause = 20 * time.Hour
+
+type quotaRecoveryHints struct {
+	Billing    *account.Billing
+	QuotaMode  string
+	RetryAfter time.Duration
+	Fallback   time.Duration
+}
 
 type candidateSnapshot struct {
 	values    []account.RoutingCandidate
@@ -497,9 +506,16 @@ func (s *Selector) markSuccess(ctx context.Context, credential account.Credentia
 	}
 }
 
-func (s *Selector) MarkFreeQuotaExhausted(ctx context.Context, credential account.Credential, used, limit int64) {
+func (s *Selector) MarkFreeQuotaExhausted(ctx context.Context, credential account.Credential, used, limit int64, hints quotaRecoveryHints) {
 	now := time.Now().UTC()
-	nextProbeAt := now.Add(freeQuotaRecoveryPause)
+	if hints.Fallback <= 0 {
+		hints.Fallback = defaultFreeQuotaRecoveryPause
+	}
+	nextProbeAt := s.resolveQuotaRecoveryAt(ctx, credential.ID, now, hints)
+	s.markFreeQuotaExhaustedAt(ctx, credential, used, limit, now, nextProbeAt)
+}
+
+func (s *Selector) markFreeQuotaExhaustedAt(ctx context.Context, credential account.Credential, used, limit int64, now, nextProbeAt time.Time) {
 	_ = s.accounts.SaveQuotaRecovery(ctx, account.QuotaRecovery{
 		AccountID: credential.ID, Kind: account.QuotaRecoveryKindFree, Status: account.QuotaRecoveryStatusExhausted,
 		ConfirmedUsed: used, ConfirmedLimit: limit, ExhaustedAt: &now,
@@ -512,11 +528,11 @@ func (s *Selector) MarkFreeQuotaExhausted(ctx context.Context, credential accoun
 func (s *Selector) MarkModelQuotaExhausted(ctx context.Context, credential account.Credential, upstreamModel string, retryAfter time.Duration) {
 	upstreamModel = strings.TrimSpace(upstreamModel)
 	if upstreamModel == "" {
-		s.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
+		s.MarkFreeQuotaExhausted(ctx, credential, 0, 0, quotaRecoveryHints{})
 		return
 	}
 	if retryAfter <= 0 {
-		retryAfter = freeQuotaRecoveryPause
+		retryAfter = defaultFreeQuotaRecoveryPause
 	}
 	until := time.Now().UTC().Add(retryAfter)
 	_ = s.accounts.UpsertModelQuotaBlock(ctx, account.ModelQuotaBlock{
@@ -544,24 +560,51 @@ func (s *Selector) MarkModelAccessDenied(ctx context.Context, credential account
 	s.invalidateCandidates(credential.Provider)
 }
 
-// MarkPaidQuotaExhausted 将额度耗尽的账号移出号池。
-// 付费账期已知时等到 period end 再探测；否则按 freeQuotaRecoveryPause 暂停后允许探测。
-func (s *Selector) MarkPaidQuotaExhausted(ctx context.Context, credential account.Credential, billing *account.Billing) bool {
+// MarkPaymentQuotaExhausted 将 402/spending-limit 账号移出号池。付费账号按真实账期
+// 进行 Billing 探测；Free/Unknown 依次采用上游 ResetAt、Retry-After、账期时间和 20h fallback。
+func (s *Selector) MarkPaymentQuotaExhausted(ctx context.Context, credential account.Credential, hints quotaRecoveryHints) {
 	now := time.Now().UTC()
-	if billing != nil && billing.IsPaid() {
-		if periodEnd, ok := billing.PeriodEnd(); ok {
+	if hints.Billing != nil && hints.Billing.IsPaid() {
+		if periodEnd, ok := hints.Billing.PeriodEnd(); ok && periodEnd.After(now) {
 			_ = s.accounts.SaveQuotaRecovery(ctx, account.QuotaRecovery{
 				AccountID: credential.ID, Kind: account.QuotaRecoveryKindPaid, Status: account.QuotaRecoveryStatusExhausted,
 				ExhaustedAt: &now, NextProbeAt: &periodEnd, LastConfirmedAt: &now, UpdatedAt: now,
 			})
 			_ = s.sticky.DeleteByAccount(ctx, credential.ID)
 			s.invalidateCandidates(credential.Provider)
-			return true
+			return
 		}
 	}
-	// Fallback: free/unrecognized billing profiles (e.g. 402 personal-team-blocked:spending-limit).
-	s.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
-	return true
+	hints.Fallback = paymentRequiredRecoveryPause
+	s.MarkFreeQuotaExhausted(ctx, credential, 0, 0, hints)
+}
+
+func (s *Selector) resolveQuotaRecoveryAt(ctx context.Context, accountID uint64, now time.Time, hints quotaRecoveryHints) time.Time {
+	if mode := strings.TrimSpace(hints.QuotaMode); mode != "" {
+		if windows, err := s.accounts.GetQuotaWindows(ctx, []uint64{accountID}); err == nil {
+			var resetAt time.Time
+			for _, window := range windows[accountID] {
+				if window.Mode != mode || window.ResetAt == nil || !window.ResetAt.After(now) {
+					continue
+				}
+				if resetAt.IsZero() || window.ResetAt.Before(resetAt) {
+					resetAt = window.ResetAt.UTC()
+				}
+			}
+			if !resetAt.IsZero() {
+				return resetAt
+			}
+		}
+	}
+	if hints.RetryAfter > 0 {
+		return now.Add(hints.RetryAfter)
+	}
+	if hints.Billing != nil {
+		if periodEnd, ok := hints.Billing.PeriodEnd(); ok && periodEnd.After(now) {
+			return periodEnd
+		}
+	}
+	return now.Add(hints.Fallback)
 }
 
 // MarkQuotaStateChanged 在 Billing 探测改变持久化额度状态后立即失效候选快照。

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -33,6 +33,10 @@ const maxConcurrencySnapshots = 256
 
 const modelAccessDeniedCooldown = 5 * time.Minute
 
+// freeQuotaRecoveryPause is how long a free/unrecognized profile stays out of the pool after quota exhaustion.
+// Shorter than a full calendar day so recovered accounts rejoin faster; a failed probe re-applies the pause.
+const freeQuotaRecoveryPause = 2 * time.Hour
+
 type candidateSnapshot struct {
 	values    []account.RoutingCandidate
 	expiresAt time.Time
@@ -495,7 +499,7 @@ func (s *Selector) markSuccess(ctx context.Context, credential account.Credentia
 
 func (s *Selector) MarkFreeQuotaExhausted(ctx context.Context, credential account.Credential, used, limit int64) {
 	now := time.Now().UTC()
-	nextProbeAt := now.Add(24 * time.Hour)
+	nextProbeAt := now.Add(freeQuotaRecoveryPause)
 	_ = s.accounts.SaveQuotaRecovery(ctx, account.QuotaRecovery{
 		AccountID: credential.ID, Kind: account.QuotaRecoveryKindFree, Status: account.QuotaRecoveryStatusExhausted,
 		ConfirmedUsed: used, ConfirmedLimit: limit, ExhaustedAt: &now,
@@ -512,7 +516,7 @@ func (s *Selector) MarkModelQuotaExhausted(ctx context.Context, credential accou
 		return
 	}
 	if retryAfter <= 0 {
-		retryAfter = 24 * time.Hour
+		retryAfter = freeQuotaRecoveryPause
 	}
 	until := time.Now().UTC().Add(retryAfter)
 	_ = s.accounts.UpsertModelQuotaBlock(ctx, account.ModelQuotaBlock{
@@ -540,22 +544,23 @@ func (s *Selector) MarkModelAccessDenied(ctx context.Context, credential account
 	s.invalidateCandidates(credential.Provider)
 }
 
-// MarkPaidQuotaExhausted 使用已知真实账期将付费账号移出号池，到期后才允许 Billing 探测。
+// MarkPaidQuotaExhausted 将额度耗尽的账号移出号池。
+// 付费账期已知时等到 period end 再探测；否则按 freeQuotaRecoveryPause 暂停后允许探测。
 func (s *Selector) MarkPaidQuotaExhausted(ctx context.Context, credential account.Credential, billing *account.Billing) bool {
-	if billing == nil || !billing.IsPaid() {
-		return false
-	}
-	periodEnd, ok := billing.PeriodEnd()
-	if !ok {
-		return false
-	}
 	now := time.Now().UTC()
-	_ = s.accounts.SaveQuotaRecovery(ctx, account.QuotaRecovery{
-		AccountID: credential.ID, Kind: account.QuotaRecoveryKindPaid, Status: account.QuotaRecoveryStatusExhausted,
-		ExhaustedAt: &now, NextProbeAt: &periodEnd, LastConfirmedAt: &now, UpdatedAt: now,
-	})
-	_ = s.sticky.DeleteByAccount(ctx, credential.ID)
-	s.invalidateCandidates(credential.Provider)
+	if billing != nil && billing.IsPaid() {
+		if periodEnd, ok := billing.PeriodEnd(); ok {
+			_ = s.accounts.SaveQuotaRecovery(ctx, account.QuotaRecovery{
+				AccountID: credential.ID, Kind: account.QuotaRecoveryKindPaid, Status: account.QuotaRecoveryStatusExhausted,
+				ExhaustedAt: &now, NextProbeAt: &periodEnd, LastConfirmedAt: &now, UpdatedAt: now,
+			})
+			_ = s.sticky.DeleteByAccount(ctx, credential.ID)
+			s.invalidateCandidates(credential.Provider)
+			return true
+		}
+	}
+	// Fallback: free/unrecognized billing profiles (e.g. 402 personal-team-blocked:spending-limit).
+	s.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
 	return true
 }
 

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -145,6 +145,84 @@ func TestSelectorSkipsQuotaProbeBeforeDue(t *testing.T) {
 	}
 }
 
+func TestSelectorQuotaRecoveryUsesBestKnownReset(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "quota-recovery.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	value, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "build", SourceKey: "build", EncryptedAccessToken: "encrypted",
+		Enabled: true, AuthStatus: account.AuthStatusActive, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	resetAt := now.Add(4 * time.Hour).Truncate(time.Second)
+	if err := accounts.SaveQuotaWindows(ctx, value.ID, account.WebTierAuto, now, []account.QuotaWindow{{
+		AccountID: value.ID, Mode: "fast", Remaining: 0, Total: 20, ResetAt: &resetAt, Source: account.QuotaSourceUpstream,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	paidPeriodEnd := now.Add(7 * time.Hour).Truncate(time.Second)
+	selector.MarkPaymentQuotaExhausted(ctx, value, quotaRecoveryHints{Billing: &account.Billing{
+		AccountID: value.ID, PlanCode: "super", MonthlyLimit: 100, BillingPeriodEnd: paidPeriodEnd.Format(time.RFC3339),
+	}, QuotaMode: "fast", RetryAfter: time.Hour})
+	recovery := requireQuotaRecovery(t, ctx, accounts, value.ID)
+	if recovery.Kind != account.QuotaRecoveryKindPaid || recovery.NextProbeAt == nil || !recovery.NextProbeAt.Equal(paidPeriodEnd) {
+		t.Fatalf("paid recovery = %#v", recovery)
+	}
+
+	selector.MarkPaymentQuotaExhausted(ctx, value, quotaRecoveryHints{QuotaMode: "fast", RetryAfter: time.Hour})
+	recovery = requireQuotaRecovery(t, ctx, accounts, value.ID)
+	if recovery.Kind != account.QuotaRecoveryKindFree || recovery.NextProbeAt == nil || !recovery.NextProbeAt.Equal(resetAt) {
+		t.Fatalf("upstream reset recovery = %#v", recovery)
+	}
+
+	retryStarted := time.Now().UTC()
+	selector.MarkPaymentQuotaExhausted(ctx, value, quotaRecoveryHints{QuotaMode: "missing", RetryAfter: 90 * time.Minute})
+	recovery = requireQuotaRecovery(t, ctx, accounts, value.ID)
+	assertRecoveryDelay(t, recovery, retryStarted, 90*time.Minute)
+
+	fallbackStarted := time.Now().UTC()
+	selector.MarkPaymentQuotaExhausted(ctx, value, quotaRecoveryHints{QuotaMode: "missing"})
+	recovery = requireQuotaRecovery(t, ctx, accounts, value.ID)
+	assertRecoveryDelay(t, recovery, fallbackStarted, paymentRequiredRecoveryPause)
+
+	freeStarted := time.Now().UTC()
+	selector.MarkFreeQuotaExhausted(ctx, value, 100, 100, quotaRecoveryHints{QuotaMode: "missing"})
+	recovery = requireQuotaRecovery(t, ctx, accounts, value.ID)
+	assertRecoveryDelay(t, recovery, freeStarted, defaultFreeQuotaRecoveryPause)
+}
+
+func requireQuotaRecovery(t *testing.T, ctx context.Context, accounts repository.AccountRepository, accountID uint64) account.QuotaRecovery {
+	t.Helper()
+	recovery, err := accounts.GetQuotaRecovery(ctx, accountID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return recovery
+}
+
+func assertRecoveryDelay(t *testing.T, recovery account.QuotaRecovery, started time.Time, delay time.Duration) {
+	t.Helper()
+	if recovery.NextProbeAt == nil {
+		t.Fatalf("recovery has no next probe: %#v", recovery)
+	}
+	want := started.Add(delay)
+	if recovery.NextProbeAt.Before(want.Add(-time.Second)) || recovery.NextProbeAt.After(want.Add(2*time.Second)) {
+		t.Fatalf("next probe = %s, want around %s", recovery.NextProbeAt, want)
+	}
+}
+
 func TestSelectorUsesPaidWeeklyPoolAsWebQuotaGate(t *testing.T) {
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "weekly-web.db"))

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -725,6 +725,12 @@ attemptLoop:
 				failureHandled = true
 			} else if lastFailure.QuotaExhausted {
 				failureHandled = s.selector.MarkPaidQuotaExhausted(ctx, credential, lease.Billing)
+				if !failureHandled {
+					// Unrecognized / free Build profiles still return 402 spending-limit.
+					// Pause so the account leaves the hot pool until freeQuotaRecoveryPause elapses.
+					s.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
+					failureHandled = true
+				}
 			}
 			if s.providers.SupportsCredentialRefresh(credential.Provider) && lastFailure.PermanentAccountDenial {
 				if credential.Provider == accountdomain.ProviderBuild {
@@ -1146,7 +1152,17 @@ func isRetryableResponse(response *provider.Response) bool {
 	if response == nil || !isRetryable(response.StatusCode) {
 		return false
 	}
+	// Account-scoped payment failures must always rotate accounts.
+	// Upstream X-Should-Retry:false is only honored for non-account errors (e.g. 5xx history).
+	if forcesAccountFailover(response.StatusCode) {
+		return true
+	}
 	return !strings.EqualFold(strings.TrimSpace(response.Header.Get("X-Should-Retry")), "false")
+}
+
+// forcesAccountFailover returns true for statuses that always mean "this account cannot serve the request".
+func forcesAccountFailover(status int) bool {
+	return status == http.StatusPaymentRequired
 }
 
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -655,7 +655,7 @@ attemptLoop:
 		}
 		egressForbidden := s.providers.RetryForbiddenAsEgress(credential.Provider) && response.StatusCode == http.StatusForbidden
 		finalEgressForbidden := egressForbidden && (attempt > 0 || attempt+1 >= attempts)
-		if isRetryableResponse(response) && !finalEgressForbidden {
+		if isRetryableResponse(response, route.Provider) && !finalEgressForbidden {
 			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
 			body, _ := readRetryableBody(response.Body)
 			if egressForbidden {
@@ -715,22 +715,23 @@ attemptLoop:
 				s.selector.MarkQuotaStateChanged(credential.Provider)
 				failureHandled = reconcileErr == nil && exhausted
 			} else if used, limit, exhausted := parseFreeQuotaExhaustion(body); exhausted {
-				s.selector.MarkFreeQuotaExhausted(ctx, credential, used, limit)
+				s.selector.MarkFreeQuotaExhausted(ctx, credential, used, limit, quotaRecoveryHints{
+					Billing: lease.Billing, QuotaMode: lease.QuotaMode, RetryAfter: retryAfter,
+				})
 				failureHandled = true
 			} else if lastFailure.ModelQuotaExhausted {
 				s.selector.MarkModelQuotaExhausted(ctx, credential, route.UpstreamModel, retryAfter)
 				failureHandled = true
 			} else if lastFailure.FreeQuotaExhausted {
-				s.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
+				s.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0, quotaRecoveryHints{
+					Billing: lease.Billing, QuotaMode: lease.QuotaMode, RetryAfter: retryAfter,
+				})
 				failureHandled = true
 			} else if lastFailure.QuotaExhausted {
-				failureHandled = s.selector.MarkPaidQuotaExhausted(ctx, credential, lease.Billing)
-				if !failureHandled {
-					// Unrecognized / free Build profiles still return 402 spending-limit.
-					// Pause so the account leaves the hot pool until freeQuotaRecoveryPause elapses.
-					s.selector.MarkFreeQuotaExhausted(ctx, credential, 0, 0)
-					failureHandled = true
-				}
+				s.selector.MarkPaymentQuotaExhausted(ctx, credential, quotaRecoveryHints{
+					Billing: lease.Billing, QuotaMode: lease.QuotaMode, RetryAfter: retryAfter,
+				})
+				failureHandled = true
 			}
 			if s.providers.SupportsCredentialRefresh(credential.Provider) && lastFailure.PermanentAccountDenial {
 				if credential.Provider == accountdomain.ProviderBuild {
@@ -805,8 +806,9 @@ attemptLoop:
 				record.ContextOutputTokens = usage.ContextOutputTokens
 				record.DurationMS = time.Since(startedAt).Milliseconds()
 				record.ErrorCode = errorCode
-				if response.StatusCode < 200 || response.StatusCode >= 300 || errorCode != "" {
-					record.Attempts = failureAttempts.snapshot()
+				attempts := failureAttempts.snapshot()
+				if response.StatusCode < 200 || response.StatusCode >= 300 || errorCode != "" || len(attempts) > 0 {
+					record.Attempts = attempts
 				}
 				record.CreatedAt = now
 				applyAuditEgress(&record, egressTrace, route.Provider)
@@ -1148,21 +1150,22 @@ func isRetryable(status int) bool {
 	return status == 402 || status == 403 || status == 429 || status >= 500
 }
 
-func isRetryableResponse(response *provider.Response) bool {
+func isRetryableResponse(response *provider.Response, upstreamProvider accountdomain.Provider) bool {
 	if response == nil || !isRetryable(response.StatusCode) {
 		return false
 	}
 	// Account-scoped payment failures must always rotate accounts.
 	// Upstream X-Should-Retry:false is only honored for non-account errors (e.g. 5xx history).
-	if forcesAccountFailover(response.StatusCode) {
+	if forcesAccountFailover(response.StatusCode, upstreamProvider) {
 		return true
 	}
 	return !strings.EqualFold(strings.TrimSpace(response.Header.Get("X-Should-Retry")), "false")
 }
 
-// forcesAccountFailover returns true for statuses that always mean "this account cannot serve the request".
-func forcesAccountFailover(status int) bool {
-	return status == http.StatusPaymentRequired
+// forcesAccountFailover scopes the Build billing-wall override to the Provider
+// whose 402 contract is known. Other Providers continue honoring X-Should-Retry.
+func forcesAccountFailover(status int, upstreamProvider accountdomain.Provider) bool {
+	return upstreamProvider == accountdomain.ProviderBuild && status == http.StatusPaymentRequired
 }
 
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -115,7 +115,11 @@ func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adapter := &failoverAdapter{firstID: first.ID}
+	adapter := &failoverAdapter{
+		firstID: first.ID, failureStatus: http.StatusPaymentRequired,
+		failureBody:   `{"code":"personal-team-blocked:spending-limit","error":"You have run out of credits"}`,
+		failureHeader: http.Header{"X-Should-Retry": {"false"}},
+	}
 	registry := provider.NewRegistry(adapter)
 	cipher := testCipher(t)
 	sticky := memory.NewStickyStore()
@@ -159,11 +163,11 @@ func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 		t.Fatalf("observed account = %#v, err = %v", observedAccount, err)
 	}
 	logs, total, err := auditRepo.List(ctx, 0, 10)
-	if err != nil || total != 1 || logs[0].AccountID == nil || *logs[0].AccountID != second.ID || logs[0].ClientKeyName != "test-key" || logs[0].ModelPublicID != "grok-test" || logs[0].ModelUpstreamModel != "Build/grok-test" || logs[0].AccountName != "second" || logs[0].CachedInputTokens != 80 || logs[0].AttemptCount != 0 {
+	if err != nil || total != 1 || logs[0].AccountID == nil || *logs[0].AccountID != second.ID || logs[0].ClientKeyName != "test-key" || logs[0].ModelPublicID != "grok-test" || logs[0].ModelUpstreamModel != "Build/grok-test" || logs[0].AccountName != "second" || logs[0].CachedInputTokens != 80 || logs[0].StatusCode != http.StatusOK || logs[0].AttemptCount != 1 {
 		t.Fatalf("audit = %#v, %d, %v", logs, total, err)
 	}
 	detail, err := auditRepo.Get(ctx, logs[0].ID)
-	if err != nil || len(detail.Attempts) != 0 {
+	if err != nil || len(detail.Attempts) != 1 || detail.Attempts[0].UpstreamStatusCode == nil || *detail.Attempts[0].UpstreamStatusCode != http.StatusPaymentRequired || !strings.Contains(string(detail.Attempts[0].ResponseBody), "personal-team-blocked:spending-limit") {
 		t.Fatalf("audit detail = %#v, err = %v", detail, err)
 	}
 	ownership, err := responseRepo.Get(ctx, "resp-test", clientKey.ID, time.Now().UTC())
@@ -1387,6 +1391,9 @@ func runQuotaRefreshWorkers(t *testing.T, service *accountapp.Service) {
 type failoverAdapter struct {
 	mu                     sync.Mutex
 	firstID                uint64
+	failureStatus          int
+	failureBody            string
+	failureHeader          http.Header
 	attempts               []uint64
 	lastMethod             string
 	lastPath               string
@@ -1753,12 +1760,21 @@ func (a *failoverAdapter) ForwardResponse(_ context.Context, request provider.Re
 	resourceStatus := a.resourceStatus
 	a.mu.Unlock()
 	status, body := http.StatusOK, "ok"
+	header := make(http.Header)
 	if request.Method != http.MethodPost && resourceStatus != 0 {
 		status, body = resourceStatus, "missing"
 	} else if request.Credential.ID == a.firstID {
-		status, body = http.StatusTooManyRequests, "limited"
+		status = a.failureStatus
+		if status == 0 {
+			status = http.StatusTooManyRequests
+		}
+		body = a.failureBody
+		if body == "" {
+			body = "limited"
+		}
+		header = a.failureHeader.Clone()
 	}
-	return &provider.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+	return &provider.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader(body))}, nil
 }
 
 func (a *failoverAdapter) setResourceStatus(status int) {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1476,8 +1476,12 @@ func writeGatewayError(c *gin.Context, err error) {
 		status, code = http.StatusBadRequest, "invalid_request"
 		message = err.Error()
 	case errors.As(err, &upstreamFailure):
-		if isUpstreamCredentialStatus(upstreamFailure.HTTPStatus) {
+		if isUpstreamCredentialStatus(upstreamFailure.HTTPStatus) || upstreamFailure.QuotaExhausted || upstreamFailure.FreeQuotaExhausted {
+			// Gateway mid-tier behavior: never expose upstream upgrade/billing prompts to clients.
 			code = upstreamFailure.ClientCredentialErrorCode()
+			if upstreamFailure.QuotaExhausted || upstreamFailure.FreeQuotaExhausted || upstreamFailure.HTTPStatus == http.StatusPaymentRequired {
+				code = "upstream_unavailable"
+			}
 			status, message = http.StatusServiceUnavailable, credentialErrorMessage(code)
 		} else {
 			status, code, message = upstreamFailure.HTTPStatus, upstreamFailure.Code, upstreamFailure.PublicMessage
@@ -1538,7 +1542,8 @@ func writeGatewayAnthropicError(c *gin.Context, err error) {
 }
 
 func isUpstreamCredentialStatus(status int) bool {
-	return status == http.StatusUnauthorized || status == http.StatusForbidden
+	// Include 402 so official "add credits / upgrade SuperGrok" bodies never reach clients (Grok CLI, etc.).
+	return status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusPaymentRequired
 }
 
 func selectionErrorResponse(c *gin.Context, failure *gateway.SelectionUnavailableError) (int, string, string) {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1476,7 +1476,7 @@ func writeGatewayError(c *gin.Context, err error) {
 		status, code = http.StatusBadRequest, "invalid_request"
 		message = err.Error()
 	case errors.As(err, &upstreamFailure):
-		if isUpstreamCredentialStatus(upstreamFailure.HTTPStatus) || upstreamFailure.QuotaExhausted || upstreamFailure.FreeQuotaExhausted {
+		if isSanitizedUpstreamAvailabilityFailure(upstreamFailure) {
 			// Gateway mid-tier behavior: never expose upstream upgrade/billing prompts to clients.
 			code = upstreamFailure.ClientCredentialErrorCode()
 			if upstreamFailure.QuotaExhausted || upstreamFailure.FreeQuotaExhausted || upstreamFailure.HTTPStatus == http.StatusPaymentRequired {
@@ -1515,8 +1515,11 @@ func writeGatewayAnthropicError(c *gin.Context, err error) {
 		status, errorType = http.StatusBadRequest, "invalid_request_error"
 		message = err.Error()
 	case errors.As(err, &upstreamFailure):
-		if isUpstreamCredentialStatus(upstreamFailure.HTTPStatus) {
+		if isSanitizedUpstreamAvailabilityFailure(upstreamFailure) {
 			clientCode = upstreamFailure.ClientCredentialErrorCode()
+			if upstreamFailure.QuotaExhausted || upstreamFailure.FreeQuotaExhausted || upstreamFailure.HTTPStatus == http.StatusPaymentRequired {
+				clientCode = "upstream_unavailable"
+			}
 			status, errorType, message = http.StatusServiceUnavailable, "overloaded_error", credentialErrorMessage(clientCode)
 		} else {
 			status, message = upstreamFailure.HTTPStatus, upstreamFailure.PublicMessage
@@ -1544,6 +1547,10 @@ func writeGatewayAnthropicError(c *gin.Context, err error) {
 func isUpstreamCredentialStatus(status int) bool {
 	// Include 402 so official "add credits / upgrade SuperGrok" bodies never reach clients (Grok CLI, etc.).
 	return status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusPaymentRequired
+}
+
+func isSanitizedUpstreamAvailabilityFailure(failure *gateway.UpstreamFailure) bool {
+	return failure != nil && (isUpstreamCredentialStatus(failure.HTTPStatus) || failure.QuotaExhausted || failure.FreeQuotaExhausted)
 }
 
 func selectionErrorResponse(c *gin.Context, failure *gateway.SelectionUnavailableError) (int, string, string) {

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -179,6 +179,19 @@ func TestGatewayErrorHidesUpstreamCredentialStatus(t *testing.T) {
 		t.Fatalf("Anthropic status=%d body=%s", anthropicRecorder.Code, anthropicRecorder.Body.String())
 	}
 
+	quotaRouter := gin.New()
+	quotaRouter.GET("/", func(c *gin.Context) {
+		writeGatewayAnthropicError(c, &gateway.UpstreamFailure{
+			HTTPStatus: http.StatusTooManyRequests, Code: "upstream_rate_limited", PublicMessage: "official upgrade prompt",
+			QuotaExhausted: true,
+		})
+	})
+	quotaRecorder := httptest.NewRecorder()
+	quotaRouter.ServeHTTP(quotaRecorder, httptest.NewRequest(http.MethodGet, "/", nil))
+	if quotaRecorder.Code != http.StatusServiceUnavailable || !strings.Contains(quotaRecorder.Body.String(), `"type":"overloaded_error"`) || strings.Contains(quotaRecorder.Body.String(), "upgrade") {
+		t.Fatalf("Anthropic quota status=%d body=%s", quotaRecorder.Code, quotaRecorder.Body.String())
+	}
+
 	credentialRouter := gin.New()
 	credentialRouter.GET("/", func(c *gin.Context) {
 		writeGatewayAnthropicError(c, &gateway.UpstreamFailure{


### PR DESCRIPTION
## Summary

Makes Grok2API behave like a mid-tier relay for **Grok Build 402 `personal-team-blocked:spending-limit`** failures:

1. **Always rotate accounts on 402** — ignore upstream `X-Should-Retry: false` for payment-required so multi-account failover actually runs.
2. **Pause exhausted accounts** — free / unrecognized billing profiles are removed from the hot pool for `freeQuotaRecoveryPause` (**2h**, was hardcoded 24h for free recovery). Paid profiles with a known period end still wait until period end. Failed probes re-apply the pause.
3. **Never surface upgrade/credit prompts to clients** — map 402 / quota exhaustion to a sanitized **503 `upstream_unavailable`** so Grok CLI / OpenAI-compatible clients do not pop "Add credits / SuperGrok" dialogs.

### Motivation

In production we observed:

- Upstream returns `402` + body `personal-team-blocked:spending-limit` / "You have run out of credits..."
- Adapter/gateway treated `X-Should-Retry: false` as final → **attempt_count=1** and **raw 402 body passthrough**
- `MarkPaidQuotaExhausted` returned `false` when billing plan fields were empty → accounts only got short cooldown and re-entered the pool
- Grok CLI interpreted the passthrough body as a billing wall (upgrade / buy credits UI)

### Behavior after this change

| Event | Behavior |
|------|----------|
| Single account 402 | Exclude account, try next (up to `routing.maxAttempts`) |
| Free/unknown billing 402 | `quota_recovery` free exhausted, `next_probe_at = now+2h` |
| Paid with period end | `quota_recovery` paid exhausted until period end |
| All attempts fail | Client gets **503** sanitized error, not official upgrade text |
| Success on later account | Normal 200 stream/JSON |

## Test plan

- [x] Unit: `TestPaymentRequiredAlwaysRetriesDespiteUpstreamVeto` — 402 + `X-Should-Retry: false` remains retryable
- [x] Production smoke (self-hosted multi-account pool):
  - [x] Normal chat → 200
  - [x] Same request_id logs multiple `upstream_request_failed` with different `account_id` on 402
  - [x] Client HTTP status becomes **503** after pool failure (not 402)
  - [x] Exhausted accounts appear in `account_quota_recovery` with ~2h `next_probe_at`
  - [x] Response body does **not** contain "Add credits" / "supergrok"

```bash
go test ./backend/internal/application/gateway/ -count=1
```

## Notes / non-goals

- Does **not** invent quota that does not exist: if every account is exhausted, clients still get a temporary error (503), which is preferable to a fake upgrade wall.
- `freeQuotaRecoveryPause = 2h` is a product choice for mid-tier relay freshness; happy to make it a `routing` / runtime setting in a follow-up if maintainers prefer.
