### PR TITLE
docs: explain Python account migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ The frontend runs at `http://127.0.0.1:5173` by default and proxies API requests
 
 After the administrator has been created, change its password and remove `bootstrapAdmin` from the configuration. Keep `credentialEncryptionKey` permanently: changing it makes existing encrypted credentials unreadable.
 
+### Migrating accounts from the Python version
+
+The **Grok Web SSO tokens** used by the Python version can be migrated, but its database or original pool JSON cannot be imported directly. Export **TXT (one token per line)** from the Python v2 admin page, or extract the raw SSO tokens from the old storage. Then open `/accounts` in the Go version, select **Grok Web**, and use **Connect account → Quick import SSO** or **Import account files**.
+
+The Go Web importer accepts:
+
+- TXT: one raw token per line; `sso=<token>` and `sso=<token>; ...` are also accepted
+- JSON: `{"provider":"grok_web","accounts":[{"sso_token":"...","name":"optional","tier":"auto|basic|super|heavy"}]}`
+
+Python pool assignments, tags, status, quota, usage, cooldown, proxy, and Cloudflare metadata are not migrated. TXT imports use tier `auto` and resync upstream state. The Python version did not contain Grok Build OAuth credentials, so its pools cannot be imported under the **Grok Build** tab. Each import is limited to 1,000 files, 30 MiB total, and 10,000 accounts; wait for identity, quota, and model-capability synchronization after importing.
+
 ## Models and routing
 
 Public model names are unqualified by default. Internally, `Build/`, `Web/`, and `Console/` are used as stable route IDs. Qualified names remain available for explicitly selecting a source, but they are not shown as ordinary model names.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,6 +212,17 @@ pnpm dev
 
 管理员创建成功后，建议修改密码并从配置中删除 `bootstrapAdmin`。`credentialEncryptionKey` 必须长期保留，更换后已有凭据将无法解密。
 
+### 从 Python 版迁移账号
+
+可以迁移 Python 版使用的 **Grok Web SSO Token**，但不能直接导入旧数据库或原始号池 JSON。请先从 Python v2 管理页导出 **TXT（每行一个 Token）**，或自行从旧存储中提取裸 SSO Token；然后在 Go 版 `/accounts` 的 **Grok Web** 页签选择“连接账号”→“快速导入 SSO”或“导入账号文件”。
+
+Go 版 Web 导入支持以下格式：
+
+- TXT：每行一个裸 Token，也接受 `sso=<token>` 或 `sso=<token>; ...`
+- JSON：`{"provider":"grok_web","accounts":[{"sso_token":"...","name":"可选","tier":"auto|basic|super|heavy"}]}`
+
+Python 版的 pool、标签、状态、额度、使用统计、冷却、代理/Cloudflare 配置等元数据不会迁移；TXT 导入时等级按 `auto` 重新同步。Python 版不含 Grok Build OAuth 凭据，因此不能将其号池导入 Go 版的 **Grok Build** 页签。单次最多 1,000 个文件、总计 30 MiB / 10,000 个账号；导入后请等待身份、额度和模型能力同步完成。
+
 ## 模型与路由
 
 公开模型名默认不带来源前缀。内部使用 `Build/`、`Web/`、`Console/` 作为稳定路由 ID；带前缀名称仍可用于显式指定来源，但不会作为普通模型名展示。


### PR DESCRIPTION
## Summary

- explain which credentials can be migrated from the Python version
- document the supported TXT and JSON import formats in both READMEs
- clarify that legacy pool metadata is not migrated and is resynced by the Go version
- document the current import limits and the Grok Web UI path

This addresses the migration question in #736.

## Verification

- `git diff --check`
- verified the documented TXT/JSON shapes against `backend/internal/infra/provider/web/import.go`
- verified the legacy pool JSON rejection against `backend/internal/infra/provider/web/import_test.go`
- verified the 1,000-file / 30 MiB limits against `backend/internal/transport/http/account/handler.go`
- verified the quick/file import actions against `frontend/src/features/accounts/accounts-page.tsx`
- ran README content and source-contract assertions locally

Documentation-only change; the local environment does not currently have the Go toolchain installed.
