### PR TITLE
fix: correct Anthropic cached input token accounting

### DIFF
--- a/backend/internal/infra/provider/conversation/conversation_test.go
+++ b/backend/internal/infra/provider/conversation/conversation_test.go
@@ -531,6 +531,19 @@ func TestConvertResponsesJSONToChatAndMessages(t *testing.T) {
 	if messagesUsage["cost_in_usd_ticks"] != float64(158500) || messagesUsage["num_server_side_tools_used"] != float64(2) || messagesUsage["context_details"].(map[string]any)["output_tokens"] != float64(4) {
 		t.Fatalf("messages usage = %#v", messagesUsage)
 	}
+	if messagesUsage["input_tokens"] != float64(8) || messagesUsage["cache_read_input_tokens"] != float64(2) {
+		t.Fatalf("messages cache usage = %#v", messagesUsage)
+	}
+}
+
+func TestAnthropicUsageClampsCacheReadToTotalInput(t *testing.T) {
+	usage := responseUsage{InputTokens: 10, OutputTokens: 2}
+	usage.InputTokensDetails.CachedTokens = 12
+
+	converted := anthropicUsage(usage, 0)
+	if converted["input_tokens"] != int64(0) || converted["cache_read_input_tokens"] != int64(10) {
+		t.Fatalf("clamped messages usage = %#v", converted)
+	}
 }
 
 func TestConvertResponsesJSONToMessagesThinkingAndStop(t *testing.T) {
@@ -883,7 +896,7 @@ func TestConvertResponsesStreamMergesPartialUsageFrames(t *testing.T) {
 		want      []string
 	}{
 		{operation: OperationChat, want: []string{`"prompt_tokens":120`, `"completion_tokens":30`, `"cached_tokens":80`, `"reasoning_tokens":12`, `"cost_in_usd_ticks":9000`}},
-		{operation: OperationMessages, want: []string{`"input_tokens":120`, `"output_tokens":30`, `"cache_read_input_tokens":80`, `"cost_in_usd_ticks":9000`}},
+		{operation: OperationMessages, want: []string{`"input_tokens":40`, `"output_tokens":30`, `"cache_read_input_tokens":80`, `"cost_in_usd_ticks":9000`}},
 	}
 	for _, test := range tests {
 		converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), test.operation))

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -105,9 +105,11 @@ func nullableAnthropicString(value string) any {
 }
 
 func anthropicUsage(value responseUsage, webSearchRequests int) map[string]any {
+	inputTokens := max(int64(0), value.InputTokens)
+	cacheReadInputTokens := min(inputTokens, max(int64(0), value.InputTokensDetails.CachedTokens))
 	usage := map[string]any{
-		"input_tokens": value.InputTokens, "output_tokens": value.OutputTokens,
-		"cache_creation_input_tokens": 0, "cache_read_input_tokens": value.InputTokensDetails.CachedTokens,
+		"input_tokens": inputTokens - cacheReadInputTokens, "output_tokens": value.OutputTokens,
+		"cache_creation_input_tokens": 0, "cache_read_input_tokens": cacheReadInputTokens,
 		"cost_in_usd_ticks":          value.CostInUSDTicks,
 		"num_sources_used":           value.NumSourcesUsed,
 		"num_server_side_tools_used": value.NumServerSideToolsUsed,

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"net/url"
@@ -945,7 +946,7 @@ func (h *Handler) writeProtocolResult(c *gin.Context, result *gateway.Result, st
 			result.RecordStreamFailure(*metadata.StreamFailure)
 		}
 	} else {
-		metadata, copyErr := copyJSON(c.Writer, result.Body)
+		metadata, copyErr := copyJSON(c.Writer, result.Body, protocol)
 		usage, responseID, err = metadata.Usage, metadata.ResponseID, copyErr
 	}
 	if err != nil {
@@ -965,10 +966,11 @@ func (h *Handler) writeProtocolResult(c *gin.Context, result *gateway.Result, st
 }
 
 type responseMetadata struct {
-	Usage         gateway.Usage
-	ResponseID    string
-	Model         string
-	StreamFailure *gateway.StreamFailureDiagnostic
+	Usage                    gateway.Usage
+	cacheCreationInputTokens int64
+	ResponseID               string
+	Model                    string
+	StreamFailure            *gateway.StreamFailureDiagnostic
 }
 
 func copyStream(writer gin.ResponseWriter, source io.Reader, protocol streamProtocol) (responseMetadata, error) {
@@ -1005,7 +1007,7 @@ func copyStream(writer gin.ResponseWriter, source io.Reader, protocol streamProt
 	}
 }
 
-func copyJSON(writer gin.ResponseWriter, source io.Reader) (responseMetadata, error) {
+func copyJSON(writer gin.ResponseWriter, source io.Reader, protocol streamProtocol) (responseMetadata, error) {
 	buffer := make([]byte, responseCopyBufferBytes)
 	metadataBody := make([]byte, 0, responseCopyBufferBytes)
 	metadataComplete := true
@@ -1036,7 +1038,7 @@ func copyJSON(writer gin.ResponseWriter, source io.Reader) (responseMetadata, er
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
 				if metadataComplete {
-					return extractMetadata(metadataBody), nil
+					return normalizeMetadataUsage(extractMetadata(metadataBody), protocol), nil
 				}
 				return responseMetadata{}, nil
 			}
@@ -1083,12 +1085,41 @@ func (i *responseInspector) Inspect(chunk []byte) {
 					i.metadata.Model = metadata.Model
 					i.metadata.Usage.ResponseModel = metadata.Model
 				}
+				if metadata.cacheCreationInputTokens > 0 {
+					i.metadata.cacheCreationInputTokens = metadata.cacheCreationInputTokens
+				}
 			}
 		}
 	}
 }
 
-func (i *responseInspector) Metadata() responseMetadata { return i.metadata }
+func (i *responseInspector) Metadata() responseMetadata {
+	return normalizeMetadataUsage(i.metadata, i.protocol)
+}
+
+func normalizeMetadataUsage(metadata responseMetadata, protocol streamProtocol) responseMetadata {
+	if protocol != streamProtocolAnthropic {
+		return metadata
+	}
+	inputTokens := saturatingUsageSum(metadata.Usage.InputTokens, metadata.Usage.CachedInputTokens, metadata.cacheCreationInputTokens)
+	metadata.Usage.InputTokens = inputTokens
+	metadata.Usage.TotalTokens = saturatingUsageSum(inputTokens, metadata.Usage.OutputTokens)
+	return metadata
+}
+
+func saturatingUsageSum(values ...int64) int64 {
+	var total int64
+	for _, value := range values {
+		if value <= 0 {
+			continue
+		}
+		if value > math.MaxInt64-total {
+			return math.MaxInt64
+		}
+		total += value
+	}
+	return total
+}
 
 func (i *responseInspector) TerminalError() error {
 	if i.terminalFailure {
@@ -1276,6 +1307,7 @@ func extractMetadata(data []byte) responseMetadata {
 		return metadata
 	}
 	metadata.Usage = usage.toGatewayUsage(metadata.Model)
+	metadata.cacheCreationInputTokens = usage.CacheCreationInputTokens
 	return metadata
 }
 

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -563,10 +564,12 @@ func TestExtractUsageFromCompletedEvent(t *testing.T) {
 }
 
 func TestExtractUsageFromAnthropicMessagesCaches(t *testing.T) {
-	// Anthropic Messages 协议用 cache_read_input_tokens，不得再记为 0。
-	metadata := extractMetadata([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"grok-4.5","usage":{"input_tokens":100,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":80,"cost_in_usd_ticks":1000}}`))
+	metadata := normalizeMetadataUsage(extractMetadata([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"grok-4.5","usage":{"input_tokens":20,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":80,"cost_in_usd_ticks":1000}}`)), streamProtocolAnthropic)
 	if metadata.Usage.CachedInputTokens != 80 || metadata.Usage.InputTokens != 100 || metadata.Usage.OutputTokens != 20 {
 		t.Fatalf("anthropic usage = %#v", metadata.Usage)
+	}
+	if metadata.Usage.TotalTokens != 120 {
+		t.Fatalf("anthropic total usage = %#v", metadata.Usage)
 	}
 }
 
@@ -587,15 +590,49 @@ func TestExtractUsagePrefersResponsesCachedTokensOverAnthropicField(t *testing.T
 }
 
 func TestStreamInspectorMergesCachedTokensAcrossFrames(t *testing.T) {
-	// 模拟流式：先到 input/output，后到带 cache 的 usage 帧。
 	inspector := &responseInspector{protocol: streamProtocolAnthropic}
-	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":100,\"output_tokens\":20}}\n\n"))
+	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":20,\"output_tokens\":20}}\n\n"))
 	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"cache_read_input_tokens\":80}}\n\n"))
 	inspector.Inspect([]byte("data: {\"type\":\"message_stop\"}\n\n"))
 	inspector.Finish()
 	usage := inspector.Metadata().Usage
-	if usage.InputTokens != 100 || usage.OutputTokens != 20 || usage.CachedInputTokens != 80 {
+	if usage.InputTokens != 100 || usage.OutputTokens != 20 || usage.CachedInputTokens != 80 || usage.TotalTokens != 120 {
 		t.Fatalf("merged stream usage = %#v", usage)
+	}
+}
+
+func TestAnthropicUsageReconstructsCacheCreationAndSaturates(t *testing.T) {
+	metadata := responseMetadata{
+		Usage:                    gateway.Usage{InputTokens: 20, CachedInputTokens: 70, OutputTokens: 5},
+		cacheCreationInputTokens: 10,
+	}
+	usage := normalizeMetadataUsage(metadata, streamProtocolAnthropic).Usage
+	if usage.InputTokens != 100 || usage.CachedInputTokens != 70 || usage.TotalTokens != 105 {
+		t.Fatalf("anthropic reconstructed usage = %#v", usage)
+	}
+
+	overflow := responseMetadata{Usage: gateway.Usage{InputTokens: math.MaxInt64, CachedInputTokens: 1, OutputTokens: 1}}
+	usage = normalizeMetadataUsage(overflow, streamProtocolAnthropic).Usage
+	if usage.InputTokens != math.MaxInt64 || usage.TotalTokens != math.MaxInt64 {
+		t.Fatalf("anthropic saturated usage = %#v", usage)
+	}
+}
+
+func TestCopyJSONReconstructsAnthropicTotalInputForAudit(t *testing.T) {
+	payload := []byte(`{"id":"msg_1","type":"message","model":"grok-4.5","usage":{"input_tokens":10899,"output_tokens":227,"cache_creation_input_tokens":0,"cache_read_input_tokens":229504}}`)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+
+	metadata, err := copyJSON(context.Writer, bytes.NewReader(payload), streamProtocolAnthropic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(recorder.Body.Bytes(), payload) {
+		t.Fatalf("forwarded body = %s", recorder.Body.String())
+	}
+	usage := metadata.Usage
+	if usage.InputTokens != 240403 || usage.CachedInputTokens != 229504 || usage.OutputTokens != 227 || usage.TotalTokens != 240630 {
+		t.Fatalf("anthropic audit usage = %#v", usage)
 	}
 }
 
@@ -766,7 +803,7 @@ func TestCopyJSONForwardsBodyBeyondMetadataInspectionLimit(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
 
-	metadata, err := copyJSON(context.Writer, bytes.NewReader(payload))
+	metadata, err := copyJSON(context.Writer, bytes.NewReader(payload), streamProtocolResponses)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Correct Anthropic Messages usage semantics for cached input tokens.
- Report `input_tokens` as uncached input instead of total OpenAI-style input.
- Preserve full input totals for internal audit, billing, and dashboard statistics.
- Apply the fix to both streaming and non-streaming responses.

## Changes

- Convert OpenAI/Responses usage into Anthropic’s mutually exclusive components:
  - `input_tokens = total_input - cache_read`
  - `cache_read_input_tokens = cached_input`
  - `cache_creation_input_tokens = 0`
- Reconstruct total input before internal audit and cost estimation.
- Merge streaming usage frames before normalization.
- Add bounds checks and saturating arithmetic for malformed token values.
- Keep Chat Completions and Responses usage semantics unchanged.

## Validation

- Added regression coverage for streaming, non-streaming, split usage frames, cache creation, invalid cache values, and integer overflow.
- Verified the reported case:
  - uncached input: `10,899`
  - cached input: `229,504`
  - internal total input: `240,403`
- `go test ./... -count=1`
- `go test -race` for affected packages
- `go vet ./...`
- `go build ./cmd/grok2api`