### PR TITLE
fix(cli): normalize nullable function parameter roots

### DIFF
--- a/backend/internal/infra/provider/cli/responses_tool_declarations.go
+++ b/backend/internal/infra/provider/cli/responses_tool_declarations.go
@@ -171,6 +171,17 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 			return nil, nil
 		}
 		converted := cloneJSONObject(tool)
+		if parameters, exists := converted["parameters"]; exists {
+			normalized, changed, normalizeErr := normalizeBuildFunctionParametersRoot(parameters, param+".parameters")
+			if normalizeErr != nil {
+				return nil, normalizeErr
+			}
+			if changed {
+				converted["parameters"] = normalized
+				c.changed = true
+				c.addWarning("function_parameters_nullable_root_normalized")
+			}
+		}
 		identity := responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name}
 		alias := c.alias(identity)
 		converted["name"] = alias
@@ -256,6 +267,148 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 			return nil, &responsesRequestError{Message: param + ".type 不能为空", Param: param + ".type", Code: "invalid_parameter"}
 		}
 		return nil, unsupportedBuildToolError(kind, param)
+	}
+}
+
+// normalizeBuildFunctionParametersRoot removes root-level nullability from function schemas.
+// Build requires the parameter root to be an object, while Codex can emit `object | null`
+// for tools with an optional argument object. Nested nullable fields remain untouched.
+func normalizeBuildFunctionParametersRoot(value any, param string) (any, bool, error) {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return value, false, nil
+	}
+	normalized := cloneJSONObject(schema)
+	changed := false
+
+	if rawTypes, ok := normalized["type"].([]any); ok {
+		filtered, removedNull := withoutNullSchemaTypes(rawTypes)
+		if removedNull {
+			changed = true
+			switch len(filtered) {
+			case 0:
+				return nil, false, invalidBuildFunctionParametersRoot(param)
+			case 1:
+				if filtered[0] != "object" {
+					return nil, false, invalidBuildFunctionParametersRoot(param)
+				}
+				normalized["type"] = "object"
+			default:
+				return nil, false, invalidBuildFunctionParametersRoot(param)
+			}
+		}
+	}
+
+	for _, keyword := range []string{"anyOf", "oneOf"} {
+		rawBranches, exists := normalized[keyword]
+		if !exists {
+			continue
+		}
+		branches, ok := rawBranches.([]any)
+		if !ok {
+			continue
+		}
+		filtered := make([]any, 0, len(branches))
+		removedNull := false
+		for _, rawBranch := range branches {
+			if isNullOnlySchema(rawBranch) {
+				removedNull = true
+				continue
+			}
+			filtered = append(filtered, rawBranch)
+		}
+		if !removedNull {
+			continue
+		}
+		changed = true
+		if len(filtered) == 0 {
+			return nil, false, invalidBuildFunctionParametersRoot(param)
+		}
+		if len(filtered) == 1 {
+			branch, ok := filtered[0].(map[string]any)
+			if !ok || !isObjectRootSchema(branch) {
+				return nil, false, invalidBuildFunctionParametersRoot(param)
+			}
+			if len(normalized) == 1 {
+				normalized = cloneJSONObject(branch)
+				normalized["type"] = "object"
+				continue
+			}
+			normalized[keyword] = cloneJSONArray(filtered)
+			normalized["type"] = "object"
+			continue
+		}
+		for _, rawBranch := range filtered {
+			branch, ok := rawBranch.(map[string]any)
+			if !ok || !isObjectRootSchema(branch) {
+				return nil, false, invalidBuildFunctionParametersRoot(param)
+			}
+		}
+		normalized[keyword] = cloneJSONArray(filtered)
+		normalized["type"] = "object"
+	}
+
+	return normalized, changed, nil
+}
+
+func withoutNullSchemaTypes(types []any) ([]any, bool) {
+	filtered := make([]any, 0, len(types))
+	removed := false
+	for _, value := range types {
+		if value == "null" {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, value)
+	}
+	return filtered, removed
+}
+
+func isNullOnlySchema(value any) bool {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	if schema["type"] == "null" {
+		return true
+	}
+	types, ok := schema["type"].([]any)
+	if !ok || len(types) == 0 {
+		return false
+	}
+	for _, value := range types {
+		if value != "null" {
+			return false
+		}
+	}
+	return true
+}
+
+func isObjectRootSchema(schema map[string]any) bool {
+	rawType, hasType := schema["type"]
+	if rawType == "object" {
+		return true
+	}
+	if types, ok := rawType.([]any); ok && len(types) > 0 {
+		for _, value := range types {
+			if value != "object" {
+				return false
+			}
+		}
+		return true
+	}
+	if hasType {
+		return false
+	}
+	_, hasProperties := schema["properties"]
+	return hasProperties
+}
+
+func invalidBuildFunctionParametersRoot(param string) error {
+	return &responsesRequestError{
+		Message: param + " 顶层必须是非 nullable 的 object schema",
+		Param:   param,
+		Code:    "invalid_parameter",
 	}
 }
 

--- a/backend/internal/infra/provider/cli/responses_tool_declarations.go
+++ b/backend/internal/infra/provider/cli/responses_tool_declarations.go
@@ -326,7 +326,7 @@ func normalizeBuildFunctionParametersRoot(value any, param string) (any, bool, e
 		}
 		if len(filtered) == 1 {
 			branch, ok := filtered[0].(map[string]any)
-			if !ok || !isObjectRootSchema(branch) {
+			if !ok || !isObjectRootSchema(branch, normalized, nil) {
 				return nil, false, invalidBuildFunctionParametersRoot(param)
 			}
 			if len(normalized) == 1 {
@@ -340,7 +340,7 @@ func normalizeBuildFunctionParametersRoot(value any, param string) (any, bool, e
 		}
 		for _, rawBranch := range filtered {
 			branch, ok := rawBranch.(map[string]any)
-			if !ok || !isObjectRootSchema(branch) {
+			if !ok || !isObjectRootSchema(branch, normalized, nil) {
 				return nil, false, invalidBuildFunctionParametersRoot(param)
 			}
 		}
@@ -384,7 +384,7 @@ func isNullOnlySchema(value any) bool {
 	return true
 }
 
-func isObjectRootSchema(schema map[string]any) bool {
+func isObjectRootSchema(schema, root map[string]any, visited map[string]struct{}) bool {
 	rawType, hasType := schema["type"]
 	if rawType == "object" {
 		return true
@@ -400,8 +400,48 @@ func isObjectRootSchema(schema map[string]any) bool {
 	if hasType {
 		return false
 	}
-	_, hasProperties := schema["properties"]
-	return hasProperties
+	if _, hasProperties := schema["properties"]; hasProperties {
+		return true
+	}
+	ref, ok := schema["$ref"].(string)
+	if !ok {
+		return false
+	}
+	if visited == nil {
+		visited = make(map[string]struct{})
+	}
+	if _, seen := visited[ref]; seen {
+		return false
+	}
+	resolved, ok := resolveLocalSchemaRef(root, ref)
+	if !ok {
+		return false
+	}
+	visited[ref] = struct{}{}
+	return isObjectRootSchema(resolved, root, visited)
+}
+
+func resolveLocalSchemaRef(root map[string]any, ref string) (map[string]any, bool) {
+	if ref == "#" {
+		return root, true
+	}
+	if !strings.HasPrefix(ref, "#/") {
+		return nil, false
+	}
+	var current any = root
+	for _, encoded := range strings.Split(strings.TrimPrefix(ref, "#/"), "/") {
+		segment := strings.ReplaceAll(strings.ReplaceAll(encoded, "~1", "/"), "~0", "~")
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+	resolved, ok := current.(map[string]any)
+	return resolved, ok
 }
 
 func invalidBuildFunctionParametersRoot(param string) error {

--- a/backend/internal/infra/provider/cli/responses_tools_test.go
+++ b/backend/internal/infra/provider/cli/responses_tools_test.go
@@ -266,6 +266,108 @@ func TestNormalizeResponsesRequestKeepsOrdinaryFunctionsOnNativePath(t *testing.
 	}
 }
 
+func TestNormalizeResponsesRequestRemovesNullableFunctionParameterRoot(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[{"type":"function","name":"automation_update","parameters":{
+			"anyOf":[
+				{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false},
+				{"type":"null"}
+			]
+		}}]
+	}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "function_parameters_nullable_root_normalized") {
+		t.Fatalf("compatibility = %#v", compatibility)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	parameters := payload["tools"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	if parameters["type"] != "object" || parameters["anyOf"] != nil || parameters["additionalProperties"] != false {
+		t.Fatalf("upstream parameters = %#v", parameters)
+	}
+	properties := parameters["properties"].(map[string]any)
+	if properties["title"].(map[string]any)["type"] != "string" {
+		t.Fatalf("upstream properties = %#v", properties)
+	}
+	visibleParameters := compatibility.visibleTools[0].(map[string]any)["parameters"].(map[string]any)
+	if _, exists := visibleParameters["anyOf"]; !exists || visibleParameters["type"] != nil {
+		t.Fatalf("visible parameters were mutated = %#v", visibleParameters)
+	}
+}
+
+func TestNormalizeResponsesRequestRejectsNullableNonObjectFunctionRoot(t *testing.T) {
+	_, _, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[{"type":"function","name":"invalid","parameters":{
+			"anyOf":[{"type":"object"},{"type":"string"},{"type":"null"}]
+		}}]
+	}`), "grok-4.5")
+	requestErr, ok := err.(*responsesRequestError)
+	if !ok || requestErr.Param != "tools[0].parameters" || requestErr.Code != "invalid_parameter" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestNormalizeBuildFunctionParametersRootVariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema map[string]any
+		check  func(*testing.T, map[string]any, bool)
+	}{
+		{
+			name:   "type array",
+			schema: map[string]any{"type": []any{"object", "null"}, "properties": map[string]any{}},
+			check: func(t *testing.T, normalized map[string]any, changed bool) {
+				if !changed || normalized["type"] != "object" {
+					t.Fatalf("normalized=%#v changed=%v", normalized, changed)
+				}
+			},
+		},
+		{
+			name: "oneOf",
+			schema: map[string]any{"oneOf": []any{
+				map[string]any{"type": "object", "additionalProperties": false},
+				map[string]any{"type": "null"},
+			}},
+			check: func(t *testing.T, normalized map[string]any, changed bool) {
+				if !changed || normalized["type"] != "object" || normalized["oneOf"] != nil {
+					t.Fatalf("normalized=%#v changed=%v", normalized, changed)
+				}
+			},
+		},
+		{
+			name: "nested nullable unchanged",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{"value": map[string]any{
+					"anyOf": []any{map[string]any{"type": "string"}, map[string]any{"type": "null"}},
+				}},
+			},
+			check: func(t *testing.T, normalized map[string]any, changed bool) {
+				properties := normalized["properties"].(map[string]any)
+				value := properties["value"].(map[string]any)
+				if changed || value["anyOf"] == nil {
+					t.Fatalf("normalized=%#v changed=%v", normalized, changed)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, changed, err := normalizeBuildFunctionParametersRoot(test.schema, "tools[0].parameters")
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.check(t, value.(map[string]any), changed)
+		})
+	}
+}
+
 func TestResponsesCompatibilityRestoresNamespaceAndToolSearchStream(t *testing.T) {
 	_, compatibility, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"hello",

--- a/backend/internal/infra/provider/cli/responses_tools_test.go
+++ b/backend/internal/infra/provider/cli/responses_tools_test.go
@@ -313,6 +313,59 @@ func TestNormalizeResponsesRequestRejectsNullableNonObjectFunctionRoot(t *testin
 	}
 }
 
+func TestNormalizeResponsesRequestRemovesNullableLocalRefFunctionRoot(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[{"type":"function","name":"lookup","parameters":{
+			"$defs":{"Args":{
+				"type":"object",
+				"properties":{"query":{"type":"string"}},
+				"required":["query"]
+			}},
+			"anyOf":[{"$ref":"#/$defs/Args"},{"type":"null"}]
+		}}]
+	}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "function_parameters_nullable_root_normalized") {
+		t.Fatalf("compatibility = %#v", compatibility)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	parameters := payload["tools"].([]any)[0].(map[string]any)["parameters"].(map[string]any)
+	if parameters["type"] != "object" {
+		t.Fatalf("upstream parameters = %#v", parameters)
+	}
+	branches := parameters["anyOf"].([]any)
+	if len(branches) != 1 || branches[0].(map[string]any)["$ref"] != "#/$defs/Args" {
+		t.Fatalf("upstream branches = %#v", branches)
+	}
+	visibleParameters := compatibility.visibleTools[0].(map[string]any)["parameters"].(map[string]any)
+	visibleBranches := visibleParameters["anyOf"].([]any)
+	if len(visibleBranches) != 2 || visibleParameters["type"] != nil {
+		t.Fatalf("visible parameters were mutated = %#v", visibleParameters)
+	}
+}
+
+func TestNormalizeResponsesRequestRejectsNullableExternalRefFunctionRoot(t *testing.T) {
+	_, _, err := normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"hello",
+		"tools":[{"type":"function","name":"lookup","parameters":{
+			"anyOf":[
+				{"$ref":"https://example.com/schema.json#/$defs/Args"},
+				{"type":"null"}
+			]
+		}}]
+	}`), "grok-4.5")
+	requestErr, ok := err.(*responsesRequestError)
+	if !ok || requestErr.Param != "tools[0].parameters" || requestErr.Code != "invalid_parameter" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
 func TestNormalizeBuildFunctionParametersRootVariants(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

- normalize root-level `object | null` function parameter schemas before forwarding requests to Grok Build
- support nullable roots expressed through `type` arrays, `anyOf`, or `oneOf`
- preserve the original client-visible tool declaration and leave nested nullable fields unchanged
- reject nullable unions that still contain a non-object root branch

## Problem

Codex can emit an optional tool argument object as a root-level nullable JSON Schema, for example:

```json
{"anyOf":[{"type":"object","properties":{}},{"type":"null"}]}
```

The schema is valid JSON Schema, but Grok Build requires function parameters to have a non-nullable object root and rejects the request before inference. This patch removes only root nullability inside the existing Responses compatibility layer.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/infra/provider/cli`
