### PR TITLE
feat(account): 完善 SSO 失效——补齐 403 正文明确封号（导入 / 额度 / Web && Console 对话）

### DIFF
--- a/backend/internal/application/account/provider_links.go
+++ b/backend/internal/application/account/provider_links.go
@@ -15,10 +15,9 @@ type providerLinkRepository interface {
 	UpdateIdentityMetadata(ctx context.Context, accountID uint64, email, userID, teamID string) error
 }
 
-// SyncAccountIdentity 尽力补充 Web/Console 的稳定上游身份，并据此建立高可信弱关联。
-// Session unauthenticated / blocked、HTTP 401 等映射为 ErrUnauthorized 时，
-// 会将当前 Provider 账号标为 reauthRequired（管理端「失效」）并移出调度；
-// 其他同步失败不影响健康状态。
+// SyncAccountIdentity best-effort fills stable Web/Console identity metadata and reconciles trusted links.
+// Definitive unauthorized signals mark the current Provider account as reauthRequired and remove it from scheduling;
+// other synchronization failures do not affect account health.
 func (s *Service) SyncAccountIdentity(ctx context.Context, id uint64) error {
 	_, err, _ := s.identitySyncs.Do(fmt.Sprintf("%d", id), func() (any, error) {
 		return nil, s.syncAccountIdentity(ctx, id)

--- a/backend/internal/application/account/provider_links.go
+++ b/backend/internal/application/account/provider_links.go
@@ -16,7 +16,9 @@ type providerLinkRepository interface {
 }
 
 // SyncAccountIdentity 尽力补充 Web/Console 的稳定上游身份，并据此建立高可信弱关联。
-// 只有明确的 401 会将当前 Provider 账号移出号池；其他同步失败不影响健康状态。
+// Session unauthenticated / blocked、HTTP 401 等映射为 ErrUnauthorized 时，
+// 会将当前 Provider 账号标为 reauthRequired（管理端「失效」）并移出调度；
+// 其他同步失败不影响健康状态。
 func (s *Service) SyncAccountIdentity(ctx context.Context, id uint64) error {
 	_, err, _ := s.identitySyncs.Do(fmt.Sprintf("%d", id), func() (any, error) {
 		return nil, s.syncAccountIdentity(ctx, id)

--- a/backend/internal/application/gateway/failure.go
+++ b/backend/internal/application/gateway/failure.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 	neterrorpkg "github.com/chenyme/grok2api/backend/internal/pkg/neterror"
 )
 
@@ -195,7 +196,7 @@ func isPermanentAccountDenial(text string) bool {
 }
 
 func isDefinitiveAccountBlock(text string) bool {
-	return containsAny(text, "blocked-user", "user is blocked")
+	return provider.IsDefinitiveAccountBlockText(text)
 }
 
 func isPaidQuotaExhaustion(text string) bool {

--- a/backend/internal/application/gateway/failure_test.go
+++ b/backend/internal/application/gateway/failure_test.go
@@ -55,6 +55,14 @@ func TestHTTPUpstreamFailureClassifiesBuildForbiddenBodies(t *testing.T) {
 			accountScoped: true, accountBlocked: true, upstreamCode: "unauthorized:blocked-user",
 		},
 		{
+			// Web chat nested error; numeric code alone must not decide AccountBlocked.
+			name: "web nested blocked-user message", body: `{"error":{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}}`,
+			accountScoped: true, accountBlocked: true, upstreamCode: "", // numeric JSON code is not stringified by extractors
+		},
+		{
+			name: "forbidden without block text", body: `{"error":{"code":7,"message":"Something went wrong","details":[]}}`,
+		},
+		{
 			name: "top-level permanent chat denial", body: `{"status_code":403,"code":"permission-denied","error":"Access to the chat endpoint is denied. Please update the permissions."}`,
 			accountScoped: true, permanentAccountDenial: true, upstreamCode: "permission-denied",
 		},

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -739,17 +740,35 @@ attemptLoop:
 		}
 		egressForbidden := s.providers.RetryForbiddenAsEgress(credential.Provider) && response.StatusCode == http.StatusForbidden
 		finalEgressForbidden := egressForbidden && (attempt > 0 || attempt+1 >= attempts)
+		// 403 必须先按响应体分类：contains blocked-user / user is blocked 时账号失效并换号；
+		// 仅当未命中封号正文时，才把 403 当作出口反爬重试（不惩罚账号）。禁止仅凭状态码或数字 code 失效。
+		if response.StatusCode == http.StatusForbidden {
+			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
+			body, _ := readRetryableBody(response.Body)
+			lastFailure = newHTTPUpstreamFailure(response.StatusCode, body, credential.ID, credential.Name)
+			if lastFailure.AccountBlocked {
+				failureHandled := s.markReauthRequired(ctx, input.RequestID, credential, fmt.Sprintf("%s account is blocked", credential.Provider))
+				if lastFailure.AccountScoped && !failureHandled {
+					s.selector.MarkFailure(ctx, credential, response.StatusCode, retryAfter)
+				}
+				lease.Release()
+				lastErr = fmt.Errorf("上游返回 %d", response.StatusCode)
+				s.logger.Warn("upstream_request_failed", "request_id", input.RequestID, "account_id", credential.ID, "provider", credential.Provider, "status", response.StatusCode, "upstream_code", lastFailure.UpstreamCode, "account_scoped", lastFailure.AccountScoped, "account_blocked", true)
+				continue
+			}
+			if egressForbidden && !finalEgressForbidden {
+				// 非封号 403：出口/反爬会话问题，不惩罚账号。
+				delete(excluded, credential.ID)
+				lease.Release()
+				lastErr = fmt.Errorf("上游出口会话被拒绝")
+				continue
+			}
+			// 最终一次非封号 403：body 已读，回填后走通用可重试/收尾逻辑。
+			response.Body = io.NopCloser(bytes.NewReader(body))
+		}
 		if isRetryableResponse(response, route.Provider) && !finalEgressForbidden {
 			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
 			body, _ := readRetryableBody(response.Body)
-			if egressForbidden {
-				// Web 403/code 7 means the browser session at the egress was rejected; the Provider rebuilt it and reduced node health, so do not penalize the account.
-				delete(excluded, credential.ID)
-				lease.Release()
-				lastErr = fmt.Errorf("Grok Web 出口会话被反机器人规则拒绝")
-				lastFailure = newHTTPUpstreamFailure(response.StatusCode, body, credential.ID, credential.Name)
-				continue
-			}
 			lastFailure = newHTTPUpstreamFailure(response.StatusCode, body, credential.ID, credential.Name)
 			buildForbiddenReauth := credential.Provider == accountdomain.ProviderBuild && s.shouldInvalidateBuildForbidden(lastFailure)
 			if buildForbiddenReauth {

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -740,8 +740,8 @@ attemptLoop:
 		}
 		egressForbidden := s.providers.RetryForbiddenAsEgress(credential.Provider) && response.StatusCode == http.StatusForbidden
 		finalEgressForbidden := egressForbidden && (attempt > 0 || attempt+1 >= attempts)
-		// 403 必须先按响应体分类：contains blocked-user / user is blocked 时账号失效并换号；
-		// 仅当未命中封号正文时，才把 403 当作出口反爬重试（不惩罚账号）。禁止仅凭状态码或数字 code 失效。
+		// Classify 403 bodies before egress retry. Definitive blocked-account signals invalidate and rotate the account;
+		// all other 403 responses retain the egress retry path without penalizing the account.
 		if response.StatusCode == http.StatusForbidden {
 			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
 			body, _ := readRetryableBody(response.Body)
@@ -757,13 +757,13 @@ attemptLoop:
 				continue
 			}
 			if egressForbidden && !finalEgressForbidden {
-				// 非封号 403：出口/反爬会话问题，不惩罚账号。
+				// A non-blocking 403 is an egress/browser-session failure and must not penalize the account.
 				delete(excluded, credential.ID)
 				lease.Release()
 				lastErr = fmt.Errorf("上游出口会话被拒绝")
 				continue
 			}
-			// 最终一次非封号 403：body 已读，回填后走通用可重试/收尾逻辑。
+			// Restore the consumed final non-blocking 403 body for the common response path.
 			response.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		if isRetryableResponse(response, route.Provider) && !finalEgressForbidden {

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -292,86 +292,103 @@ func TestGatewaySSOUnauthorizedMarksInvalidAndSwitchesAccount(t *testing.T) {
 	for _, providerValue := range []account.Provider{account.ProviderWeb, account.ProviderConsole} {
 		providerValue := providerValue
 		t.Run(string(providerValue), func(t *testing.T) {
-			ctx := context.Background()
-			database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "sso-401.db"))
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer database.Close()
-			if err := database.InitializeSchema(ctx); err != nil {
-				t.Fatal(err)
-			}
-			accountRepo := relational.NewAccountRepository(database)
-			modelRepo := relational.NewModelRepository(database)
-			auditRepo := relational.NewAuditRepository(database)
-			responseRepo := relational.NewResponseRepository(database)
-			keyRepo := relational.NewClientKeyRepository(database)
-			credentials := make([]account.Credential, 0, 2)
-			for index, name := range []string{"rejected", "healthy"} {
-				credential, _, createErr := accountRepo.UpsertByIdentity(ctx, account.Credential{
-					Provider: providerValue, AuthType: account.AuthTypeSSO, Name: name, SourceKey: string(providerValue) + "-" + name,
-					EncryptedAccessToken: "encrypted-" + name, Enabled: true, AuthStatus: account.AuthStatusActive,
-					Priority: 200 - index*100, MaxConcurrent: 1,
-				})
-				if createErr != nil {
-					t.Fatal(createErr)
-				}
-				credentials = append(credentials, credential)
-			}
-			modelName := "grok-sso-401"
-			if err := modelRepo.UpsertDiscovered(ctx, providerValue, []string{modelName}); err != nil {
-				t.Fatal(err)
-			}
-			for _, credential := range credentials {
-				if err := modelRepo.ReplaceAccountCapabilities(ctx, credential.ID, []string{modelName}, time.Now().UTC()); err != nil {
-					t.Fatal(err)
-				}
-			}
-			key, err := keyRepo.Create(ctx, clientkey.Key{
-				Name: "sso-401-key", Prefix: "sso-401", SecretHash: strings.Repeat("e", 64), EncryptedSecret: "encrypted-key",
-				Enabled: true, RPMLimit: 60, MaxConcurrent: 4,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			adapter := &ssoUnauthorizedAdapter{providerValue: providerValue, rejectedID: credentials[0].ID}
-			registry := provider.NewRegistry(adapter)
-			sticky := memory.NewStickyStore()
-			accountService := accountapp.NewService(accountRepo, auditRepo, memory.NewDeviceSessionStore(), sticky, registry, testCipher(t), nil)
-			selector := NewSelector(accountRepo, memory.NewConcurrencyLimiter(), sticky, registry, time.Hour, time.Second, time.Minute)
-			service := NewService(modelRepo, auditRepo, accountService, clientkeyapp.NewService(nil, nil, nil, 60, 4, nil), registry, selector, responseRepo, 2)
-
-			result, err := service.CreateResponse(ctx, Input{
-				RequestID: "req-sso-401", ClientKey: key, PublicModel: modelName,
-				Body: []byte(`{"model":"grok-sso-401","input":"hello"}`),
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-			body, err := io.ReadAll(result.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			result.Finalize(Usage{}, "", "")
-			_ = result.Body.Close()
-			if string(body) != "ok" {
-				t.Fatalf("body = %q", body)
-			}
-			if attempts := adapter.Attempts(); len(attempts) != 2 || attempts[0] != credentials[0].ID || attempts[1] != credentials[1].ID {
-				t.Fatalf("attempts = %#v", attempts)
-			}
-			rejected, err := accountRepo.Get(ctx, credentials[0].ID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if rejected.AuthStatus != account.AuthStatusReauthRequired || !rejected.Enabled {
-				t.Fatalf("rejected account = %#v", rejected)
-			}
-			healthy, err := accountRepo.Get(ctx, credentials[1].ID)
-			if err != nil || healthy.AuthStatus != account.AuthStatusActive {
-				t.Fatalf("healthy account = %#v, err = %v", healthy, err)
-			}
+			testGatewaySSOFailureMarksInvalidAndSwitchesAccount(t, providerValue, http.StatusUnauthorized, `{"error":{"code":"unauthorized","message":"credential rejected"}}`)
 		})
+	}
+}
+
+func TestGatewaySSOBlockedForbiddenMarksInvalidAndSwitchesAccount(t *testing.T) {
+	for _, providerValue := range []account.Provider{account.ProviderWeb, account.ProviderConsole} {
+		providerValue := providerValue
+		t.Run(string(providerValue), func(t *testing.T) {
+			testGatewaySSOFailureMarksInvalidAndSwitchesAccount(t, providerValue, http.StatusForbidden, `{"error":{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]"}}`)
+		})
+	}
+}
+
+func testGatewaySSOFailureMarksInvalidAndSwitchesAccount(t *testing.T, providerValue account.Provider, failureStatus int, failureBody string) {
+	t.Helper()
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "sso-failure.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accountRepo := relational.NewAccountRepository(database)
+	modelRepo := relational.NewModelRepository(database)
+	auditRepo := relational.NewAuditRepository(database)
+	responseRepo := relational.NewResponseRepository(database)
+	keyRepo := relational.NewClientKeyRepository(database)
+	credentials := make([]account.Credential, 0, 2)
+	for index, name := range []string{"rejected", "healthy"} {
+		credential, _, createErr := accountRepo.UpsertByIdentity(ctx, account.Credential{
+			Provider: providerValue, AuthType: account.AuthTypeSSO, Name: name, SourceKey: string(providerValue) + "-" + name,
+			EncryptedAccessToken: "encrypted-" + name, Enabled: true, AuthStatus: account.AuthStatusActive,
+			Priority: 200 - index*100, MaxConcurrent: 1,
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		credentials = append(credentials, credential)
+	}
+	modelName := "grok-sso-401"
+	if err := modelRepo.UpsertDiscovered(ctx, providerValue, []string{modelName}); err != nil {
+		t.Fatal(err)
+	}
+	for _, credential := range credentials {
+		if err := modelRepo.ReplaceAccountCapabilities(ctx, credential.ID, []string{modelName}, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	key, err := keyRepo.Create(ctx, clientkey.Key{
+		Name: "sso-401-key", Prefix: "sso-401", SecretHash: strings.Repeat("e", 64), EncryptedSecret: "encrypted-key",
+		Enabled: true, RPMLimit: 60, MaxConcurrent: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &ssoFailureAdapter{
+		providerValue: providerValue, rejectedID: credentials[0].ID,
+		failureStatus: failureStatus, failureBody: failureBody,
+	}
+	registry := provider.NewRegistry(adapter)
+	sticky := memory.NewStickyStore()
+	accountService := accountapp.NewService(accountRepo, auditRepo, memory.NewDeviceSessionStore(), sticky, registry, testCipher(t), nil)
+	selector := NewSelector(accountRepo, memory.NewConcurrencyLimiter(), sticky, registry, time.Hour, time.Second, time.Minute)
+	service := NewService(modelRepo, auditRepo, accountService, clientkeyapp.NewService(nil, nil, nil, 60, 4, nil), registry, selector, responseRepo, 2)
+
+	result, err := service.CreateResponse(ctx, Input{
+		RequestID: "req-sso-401", ClientKey: key, PublicModel: modelName,
+		Body: []byte(`{"model":"grok-sso-401","input":"hello"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Finalize(Usage{}, "", "")
+	_ = result.Body.Close()
+	if string(body) != "ok" {
+		t.Fatalf("body = %q", body)
+	}
+	if attempts := adapter.Attempts(); len(attempts) != 2 || attempts[0] != credentials[0].ID || attempts[1] != credentials[1].ID {
+		t.Fatalf("attempts = %#v", attempts)
+	}
+	rejected, err := accountRepo.Get(ctx, credentials[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rejected.AuthStatus != account.AuthStatusReauthRequired || !rejected.Enabled {
+		t.Fatalf("rejected account = %#v", rejected)
+	}
+	healthy, err := accountRepo.Get(ctx, credentials[1].ID)
+	if err != nil || healthy.AuthStatus != account.AuthStatusActive {
+		t.Fatalf("healthy account = %#v, err = %v", healthy, err)
 	}
 }
 
@@ -1552,30 +1569,39 @@ type failoverAdapter struct {
 	resourceStatus         int
 }
 
-type ssoUnauthorizedAdapter struct {
+type ssoFailureAdapter struct {
 	mu            sync.Mutex
 	providerValue account.Provider
 	rejectedID    uint64
+	failureStatus int
+	failureBody   string
 	attempts      []uint64
 }
 
-func (a *ssoUnauthorizedAdapter) Provider() account.Provider { return a.providerValue }
-func (a *ssoUnauthorizedAdapter) Definition() provider.Definition {
+func (a *ssoFailureAdapter) Provider() account.Provider { return a.providerValue }
+func (a *ssoFailureAdapter) Definition() provider.Definition {
 	return testConversationDefinition(a.providerValue)
 }
-func (a *ssoUnauthorizedAdapter) ForwardResponse(_ context.Context, request provider.ResponseResourceRequest) (*provider.Response, error) {
+func (a *ssoFailureAdapter) ForwardResponse(_ context.Context, request provider.ResponseResourceRequest) (*provider.Response, error) {
 	a.mu.Lock()
 	a.attempts = append(a.attempts, request.Credential.ID)
 	a.mu.Unlock()
 	if request.Credential.ID == a.rejectedID {
+		status := a.failureStatus
+		if status == 0 {
+			status = http.StatusUnauthorized
+		}
+		body := a.failureBody
+		if body == "" {
+			body = `{"error":{"code":"unauthorized","message":"credential rejected"}}`
+		}
 		return &provider.Response{
-			StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized", Header: make(http.Header),
-			Body: io.NopCloser(strings.NewReader(`{"error":{"code":"unauthorized","message":"credential rejected"}}`)),
+			StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)),
 		}, nil
 	}
 	return &provider.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header), Body: io.NopCloser(strings.NewReader("ok"))}, nil
 }
-func (a *ssoUnauthorizedAdapter) Attempts() []uint64 {
+func (a *ssoFailureAdapter) Attempts() []uint64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return append([]uint64(nil), a.attempts...)
@@ -1970,7 +1996,10 @@ func testConversationDefinition(providerValue account.Provider) provider.Definit
 	}
 	if providerValue == account.ProviderWeb {
 		definition.Quota = provider.QuotaRemoteWindow
-		definition.Inference = provider.InferencePolicy{Usage: provider.UsageEstimated, RetryForbiddenAsEgress: true}
+		definition.Inference.Usage = provider.UsageEstimated
+	}
+	if providerValue == account.ProviderWeb || providerValue == account.ProviderConsole {
+		definition.Inference.RetryForbiddenAsEgress = true
 	}
 	return definition
 }

--- a/backend/internal/infra/egress/manager.go
+++ b/backend/internal/infra/egress/manager.go
@@ -70,16 +70,35 @@ type requestClient interface {
 }
 
 func (l *Lease) Do(request *http.Request) (*http.Response, error) {
+	return l.doRequest(request, true)
+}
+
+// DoDeferredForbidden executes an HTTP request while leaving 403 clearance
+// invalidation to the caller after it has classified the response body.
+func (l *Lease) DoDeferredForbidden(request *http.Request) (*http.Response, error) {
+	return l.doRequest(request, false)
+}
+
+func (l *Lease) doRequest(request *http.Request, invalidateForbidden bool) (*http.Response, error) {
 	if l == nil || l.client == nil {
 		return nil, errors.New("出口客户端未初始化")
 	}
 	response, err := l.do(request)
 	recordPhysicalCall(request.Context(), response, err)
-	if err == nil && response != nil && response.StatusCode == http.StatusForbidden && l.clearanceManager != nil && l.clearanceKey != "" {
-		l.clearanceManager.invalidateClearanceKey(l.clearanceKey, l.client)
+	if invalidateForbidden && err == nil && response != nil && response.StatusCode == http.StatusForbidden {
+		l.InvalidateClearance()
 	}
 	return response, err
 }
+
+// InvalidateClearance invalidates the exact browser-session binding used by
+// this lease after a 403 has been classified as egress-related.
+func (l *Lease) InvalidateClearance() {
+	if l != nil && l.clearanceManager != nil && l.clearanceKey != "" {
+		l.clearanceManager.invalidateClearanceKey(l.clearanceKey, l.client)
+	}
+}
+
 func (l *Lease) Release() {
 	if l != nil && l.release != nil {
 		l.release()

--- a/backend/internal/infra/egress/sticky_retry_test.go
+++ b/backend/internal/infra/egress/sticky_retry_test.go
@@ -90,6 +90,36 @@ func TestStickyLeaseDoesNotRetryUnsafeUpstreamOutcomes(t *testing.T) {
 	}
 }
 
+func TestLeaseDefersForbiddenClearanceInvalidationUntilClassification(t *testing.T) {
+	client := &scriptedRequestClient{do: func(int, *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusForbidden, Header: make(http.Header), Body: http.NoBody}, nil
+	}}
+	manager := &Manager{clearances: map[string]clearanceState{"account-bound": {}}}
+	lease := &Lease{client: client, clearanceManager: manager, clearanceKey: "account-bound"}
+	request, err := http.NewRequest(http.MethodPost, "https://example.com/generate", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := lease.DoDeferredForbidden(request)
+	if err != nil || response.StatusCode != http.StatusForbidden {
+		t.Fatalf("response=%#v err=%v", response, err)
+	}
+	manager.clearanceMu.Lock()
+	invalidBeforeClassification := manager.clearances["account-bound"].invalid
+	manager.clearanceMu.Unlock()
+	if invalidBeforeClassification || client.closedIdle != 0 {
+		t.Fatalf("clearance invalid=%v closedIdle=%d before classification", invalidBeforeClassification, client.closedIdle)
+	}
+
+	lease.InvalidateClearance()
+	manager.clearanceMu.Lock()
+	invalidAfterClassification := manager.clearances["account-bound"].invalid
+	manager.clearanceMu.Unlock()
+	if !invalidAfterClassification || client.closedIdle != 1 {
+		t.Fatalf("clearance invalid=%v closedIdle=%d after classification", invalidAfterClassification, client.closedIdle)
+	}
+}
+
 func TestStickyLeaseDoesNotRetryAfterRequestWasWritten(t *testing.T) {
 	client := &scriptedRequestClient{do: func(_ int, request *http.Request) (*http.Response, error) {
 		trace := httptrace.ContextClientTrace(request.Context())

--- a/backend/internal/infra/provider/account_block.go
+++ b/backend/internal/infra/provider/account_block.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// IsDefinitiveAccountBlockBody accepts only explicit error code or message signals.
+func IsDefinitiveAccountBlockBody(body []byte) bool {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return IsDefinitiveAccountBlockText(string(body))
+	}
+	values := []string{
+		jsonStringField(payload, "code"),
+		jsonStringField(payload, "message"),
+		jsonStringField(payload, "error"),
+	}
+	if nested, ok := payload["error"].(map[string]any); ok {
+		values = append(values,
+			jsonStringField(nested, "code"),
+			jsonStringField(nested, "message"),
+			jsonStringField(nested, "error"),
+		)
+	}
+	return IsDefinitiveAccountBlockText(strings.Join(values, " "))
+}
+
+func IsDefinitiveAccountBlockText(value string) bool {
+	value = strings.ToLower(value)
+	return strings.Contains(value, "blocked-user") || strings.Contains(value, "user is blocked")
+}
+
+func jsonStringField(value map[string]any, key string) string {
+	result, _ := value[key].(string)
+	return result
+}

--- a/backend/internal/infra/provider/account_block_test.go
+++ b/backend/internal/infra/provider/account_block_test.go
@@ -1,0 +1,26 @@
+package provider
+
+import "testing"
+
+func TestIsDefinitiveAccountBlockBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "top-level message", body: `{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]"}`, want: true},
+		{name: "nested error", body: `{"error":{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]"}}`, want: true},
+		{name: "console error", body: `{"code":"unauthorized:blocked-user","error":"User is blocked"}`, want: true},
+		{name: "plain text", body: `User is blocked`, want: true},
+		{name: "generic rejection", body: `{"message":"temporary rejection"}`, want: false},
+		{name: "unrelated details", body: `{"message":"temporary rejection","details":["blocked-user is an internal enum"]}`, want: false},
+		{name: "numeric code only", body: `{"code":7,"message":"anti-bot rejection"}`, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsDefinitiveAccountBlockBody([]byte(test.body)); got != test.want {
+				t.Fatalf("IsDefinitiveAccountBlockBody() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/backend/internal/infra/provider/console/adapter.go
+++ b/backend/internal/infra/provider/console/adapter.go
@@ -144,7 +144,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 	if request.Streaming {
 		upstream.Header.Set("Accept", "text/event-stream")
 	}
-	response, err := lease.Do(upstream)
+	response, err := lease.DoDeferredForbidden(upstream)
 	if err != nil {
 		a.egress.FeedbackForScope(context.WithoutCancel(ctx), egressdomain.ScopeConsole, lease.NodeID, 0, err)
 		lease.Release()
@@ -162,7 +162,34 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			return nil, err
 		}
 	}
+	responseReleased := false
+	if response.StatusCode == http.StatusForbidden {
+		data, truncated, readErr := provider.ReadDiagnosticBody(response.Body)
+		_ = response.Body.Close()
+		if readErr != nil {
+			lease.Release()
+			cancel()
+			return nil, readErr
+		}
+		if !provider.IsDefinitiveAccountBlockBody(data) {
+			lease.InvalidateClearance()
+			a.egress.FeedbackForScope(context.WithoutCancel(ctx), egressdomain.ScopeConsole, lease.NodeID, response.StatusCode, nil)
+		}
+		lease.Release()
+		cancel()
+		responseReleased = true
+		responseBodyTruncated = responseBodyTruncated || truncated
+		response.Body = io.NopCloser(bytes.NewReader(data))
+		response.ContentLength = int64(len(data))
+		response.Header.Set("Content-Length", strconv.Itoa(len(data)))
+		if truncated {
+			response.Header.Set("X-Grok2API-Body-Truncated", "1")
+		}
+	}
 	release := func() {
+		if responseReleased {
+			return
+		}
 		a.egress.FeedbackForScope(context.WithoutCancel(ctx), egressdomain.ScopeConsole, lease.NodeID, response.StatusCode, nil)
 		lease.Release()
 		cancel()

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -348,6 +349,59 @@ func TestAdapterAttachesConsoleRateLimitMetadata(t *testing.T) {
 	}
 }
 
+func TestAdapterDoesNotPenalizeEgressForBlockedAccount(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantUpdates int
+	}{
+		{name: "blocked account", body: `{"code":"unauthorized:blocked-user","error":"User is blocked"}`, wantUpdates: 0},
+		{name: "anti-bot rejection", body: `{"error":{"code":7,"message":"Request rejected by anti-bot rules."}}`, wantUpdates: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				writer.WriteHeader(http.StatusForbidden)
+				_, _ = io.WriteString(writer, test.body)
+			}))
+			defer server.Close()
+
+			cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			encrypted, err := cipher.Encrypt("test-sso")
+			if err != nil {
+				t.Fatal(err)
+			}
+			repository := &recordingConsoleEgressRepository{node: egressdomain.Node{
+				ID: 1, Name: "console", Scope: egressdomain.ScopeConsole, Enabled: true, Health: 1,
+			}}
+			adapter := NewAdapter(Config{BaseURL: server.URL, TimeoutSeconds: 5}, infraegress.NewManager(repository, cipher), cipher)
+			credential := account.Credential{ID: 1, Provider: account.ProviderConsole, AuthType: account.AuthTypeSSO, EncryptedAccessToken: encrypted}
+			response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+				Credential: credential, Method: http.MethodPost, Path: "/responses", Model: "grok-4.3",
+				Operation: conversation.OperationResponses, NormalizeBody: true, Body: []byte(`{"model":"grok-4.3","input":"hello"}`),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = response.Body.Close()
+			if response.StatusCode != http.StatusForbidden || string(body) != test.body {
+				t.Fatalf("status=%d body=%s", response.StatusCode, body)
+			}
+			if updates := repository.UpdateCount(); updates != test.wantUpdates {
+				t.Fatalf("egress updates = %d, want %d", updates, test.wantUpdates)
+			}
+		})
+	}
+}
+
 func TestAdapterForwardsConsoleHeadersAndNormalizedBody(t *testing.T) {
 	var received map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -493,4 +547,47 @@ func (consoleEgressRepositoryStub) UpdateEgressNode(context.Context, egressdomai
 
 func (consoleEgressRepositoryStub) DeleteEgressNode(context.Context, uint64) error {
 	return errors.New("unsupported")
+}
+
+type recordingConsoleEgressRepository struct {
+	mu      sync.Mutex
+	node    egressdomain.Node
+	updates int
+}
+
+func (r *recordingConsoleEgressRepository) ListEgressNodes(_ context.Context, scope egressdomain.Scope, _ repository.SortQuery) ([]egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.node.Scope != scope {
+		return nil, nil
+	}
+	return []egressdomain.Node{r.node}, nil
+}
+
+func (r *recordingConsoleEgressRepository) GetEgressNode(context.Context, uint64) (egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.node, nil
+}
+
+func (r *recordingConsoleEgressRepository) CreateEgressNode(context.Context, egressdomain.Node) (egressdomain.Node, error) {
+	return egressdomain.Node{}, errors.New("unsupported")
+}
+
+func (r *recordingConsoleEgressRepository) UpdateEgressNode(_ context.Context, value egressdomain.Node) (egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.node = value
+	r.updates++
+	return value, nil
+}
+
+func (r *recordingConsoleEgressRepository) DeleteEgressNode(context.Context, uint64) error {
+	return errors.New("unsupported")
+}
+
+func (r *recordingConsoleEgressRepository) UpdateCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.updates
 }

--- a/backend/internal/infra/provider/sessionidentity/session.go
+++ b/backend/internal/infra/provider/sessionidentity/session.go
@@ -96,8 +96,7 @@ func Parse(body []byte) (provider.AccountIdentity, error) {
 	if err := json.Unmarshal(body, &value); err != nil {
 		return provider.AccountIdentity{}, fmt.Errorf("解析 Grok Session: %w", err)
 	}
-	// unauthenticated / blocked 表示当前 SSO 对上游不可用，必须在采纳身份字段之前判定，
-	// 避免 status=blocked 仍携带 userId/email 时被当成有效身份继续调度。
+	// Reject unavailable sessions before accepting residual identity fields that may still be present.
 	status := strings.TrimSpace(value.Status)
 	if strings.EqualFold(status, "unauthenticated") {
 		return provider.AccountIdentity{}, provider.ErrUnauthorized

--- a/backend/internal/infra/provider/sessionidentity/session.go
+++ b/backend/internal/infra/provider/sessionidentity/session.go
@@ -105,8 +105,14 @@ func Parse(body []byte) (provider.AccountIdentity, error) {
 	identity.Email = strings.TrimSpace(identity.Email)
 	identity.TeamID = strings.TrimSpace(identity.TeamID)
 	if identity.UserID == "" && identity.Email == "" {
-		if strings.EqualFold(strings.TrimSpace(value.Status), "unauthenticated") {
+		status := strings.TrimSpace(value.Status)
+		// unauthenticated / blocked 均表示当前 SSO 对上游不可用，统一映射为 ErrUnauthorized，
+		// 以便导入与身份同步路径将账号标为 reauthRequired（管理端「失效」）并移出调度。
+		if strings.EqualFold(status, "unauthenticated") {
 			return provider.AccountIdentity{}, provider.ErrUnauthorized
+		}
+		if strings.EqualFold(status, "blocked") {
+			return provider.AccountIdentity{}, fmt.Errorf("%w: session status blocked", provider.ErrUnauthorized)
 		}
 		return provider.AccountIdentity{}, fmt.Errorf("Grok Session 缺少账号身份")
 	}

--- a/backend/internal/infra/provider/sessionidentity/session.go
+++ b/backend/internal/infra/provider/sessionidentity/session.go
@@ -96,6 +96,15 @@ func Parse(body []byte) (provider.AccountIdentity, error) {
 	if err := json.Unmarshal(body, &value); err != nil {
 		return provider.AccountIdentity{}, fmt.Errorf("解析 Grok Session: %w", err)
 	}
+	// unauthenticated / blocked 表示当前 SSO 对上游不可用，必须在采纳身份字段之前判定，
+	// 避免 status=blocked 仍携带 userId/email 时被当成有效身份继续调度。
+	status := strings.TrimSpace(value.Status)
+	if strings.EqualFold(status, "unauthenticated") {
+		return provider.AccountIdentity{}, provider.ErrUnauthorized
+	}
+	if strings.EqualFold(status, "blocked") {
+		return provider.AccountIdentity{}, fmt.Errorf("%w: session status blocked", provider.ErrUnauthorized)
+	}
 	identity := provider.AccountIdentity{
 		UserID: firstNonEmpty(value.Session.UserID, value.User.ID, value.User.UserID, value.User.Sub, value.ID, value.UserID, value.Sub),
 		Email:  firstNonEmpty(value.Session.Email, value.User.Email, value.Email),
@@ -105,15 +114,6 @@ func Parse(body []byte) (provider.AccountIdentity, error) {
 	identity.Email = strings.TrimSpace(identity.Email)
 	identity.TeamID = strings.TrimSpace(identity.TeamID)
 	if identity.UserID == "" && identity.Email == "" {
-		status := strings.TrimSpace(value.Status)
-		// unauthenticated / blocked 均表示当前 SSO 对上游不可用，统一映射为 ErrUnauthorized，
-		// 以便导入与身份同步路径将账号标为 reauthRequired（管理端「失效」）并移出调度。
-		if strings.EqualFold(status, "unauthenticated") {
-			return provider.AccountIdentity{}, provider.ErrUnauthorized
-		}
-		if strings.EqualFold(status, "blocked") {
-			return provider.AccountIdentity{}, fmt.Errorf("%w: session status blocked", provider.ErrUnauthorized)
-		}
 		return provider.AccountIdentity{}, fmt.Errorf("Grok Session 缺少账号身份")
 	}
 	return identity, nil

--- a/backend/internal/infra/provider/sessionidentity/session_test.go
+++ b/backend/internal/infra/provider/sessionidentity/session_test.go
@@ -1,0 +1,46 @@
+package sessionidentity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chenyme/grok2api/backend/internal/infra/provider"
+)
+
+func TestParseBlockedSessionIsUnauthorized(t *testing.T) {
+	t.Parallel()
+	_, err := Parse([]byte(`{"status":"blocked"}`))
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestParseUnauthenticatedSessionIsUnauthorized(t *testing.T) {
+	t.Parallel()
+	_, err := Parse([]byte(`{"status":"unauthenticated"}`))
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestParseMissingIdentityWithoutStatusStaysGeneric(t *testing.T) {
+	t.Parallel()
+	_, err := Parse([]byte(`{}`))
+	if err == nil || errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want generic missing-identity error", err)
+	}
+}
+
+func TestParseAuthenticatedSession(t *testing.T) {
+	t.Parallel()
+	identity, err := Parse([]byte(`{
+		"status":"authenticated",
+		"session":{"userId":"user-1","email":"a@example.com","organizationId":"org-1"}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.UserID != "user-1" || identity.Email != "a@example.com" || identity.TeamID != "org-1" {
+		t.Fatalf("identity = %#v", identity)
+	}
+}

--- a/backend/internal/infra/provider/sessionidentity/session_test.go
+++ b/backend/internal/infra/provider/sessionidentity/session_test.go
@@ -15,11 +15,27 @@ func TestParseBlockedSessionIsUnauthorized(t *testing.T) {
 	}
 }
 
+func TestParseBlockedSessionWithIdentityFieldsIsUnauthorized(t *testing.T) {
+	t.Parallel()
+	_, err := Parse([]byte(`{"status":"blocked","userId":"user-1","email":"a@example.com","session":{"userId":"user-1","email":"a@example.com"}}`))
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized even when identity fields are present", err)
+	}
+}
+
 func TestParseUnauthenticatedSessionIsUnauthorized(t *testing.T) {
 	t.Parallel()
 	_, err := Parse([]byte(`{"status":"unauthenticated"}`))
 	if !errors.Is(err, provider.ErrUnauthorized) {
 		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestParseUnauthenticatedSessionWithIdentityFieldsIsUnauthorized(t *testing.T) {
+	t.Parallel()
+	_, err := Parse([]byte(`{"status":"unauthenticated","userId":"user-1","email":"a@example.com"}`))
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized even when identity fields are present", err)
 	}
 }
 

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -185,10 +185,35 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 		previous = currentPrevious
 		if upstream.StatusCode < 200 || upstream.StatusCode >= 300 {
 			if upstream.StatusCode == http.StatusForbidden {
+				// 先读正文：blocked-user 必须直接交给 gateway 标失效，禁止 Statsig 重试吞掉首包。
+				body, readErr := io.ReadAll(io.LimitReader(upstream.Body, 4<<20))
+				_ = upstream.Body.Close()
+				if readErr != nil {
+					lease.Release()
+					return nil, readErr
+				}
+				if bodyLooksLikeAccountBlocked(body) {
+					return &provider.Response{
+						StatusCode: upstream.StatusCode, Status: upstream.Status, Header: http.Header(upstream.Header),
+						UpstreamURL: responseUpstreamURL(upstream),
+						Body: &releaseBody{ReadCloser: io.NopCloser(bytes.NewReader(body)), release: func() {
+							a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, upstream.StatusCode, nil)
+							lease.Release()
+						}},
+					}, nil
+				}
 				if attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, statsigTarget) {
-					a.releaseStatsigRetry(upstream, lease)
+					lease.Release()
 					continue
 				}
+				return &provider.Response{
+					StatusCode: upstream.StatusCode, Status: upstream.Status, Header: http.Header(upstream.Header),
+					UpstreamURL: responseUpstreamURL(upstream),
+					Body: &releaseBody{ReadCloser: io.NopCloser(bytes.NewReader(body)), release: func() {
+						a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, upstream.StatusCode, nil)
+						lease.Release()
+					}},
+				}, nil
 			}
 			return &provider.Response{
 				StatusCode: upstream.StatusCode, Status: upstream.Status, Header: http.Header(upstream.Header),

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -185,23 +185,23 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 		previous = currentPrevious
 		if upstream.StatusCode < 200 || upstream.StatusCode >= 300 {
 			if upstream.StatusCode == http.StatusForbidden {
-				// 先读正文：blocked-user 必须直接交给 gateway 标失效，禁止 Statsig 重试吞掉首包。
+				// Preserve definitive account-block signals before a Statsig retry can discard the first response.
 				body, readErr := io.ReadAll(io.LimitReader(upstream.Body, 4<<20))
 				_ = upstream.Body.Close()
 				if readErr != nil {
 					lease.Release()
 					return nil, readErr
 				}
-				if bodyLooksLikeAccountBlocked(body) {
+				if provider.IsDefinitiveAccountBlockBody(body) {
 					return &provider.Response{
 						StatusCode: upstream.StatusCode, Status: upstream.Status, Header: http.Header(upstream.Header),
 						UpstreamURL: responseUpstreamURL(upstream),
 						Body: &releaseBody{ReadCloser: io.NopCloser(bytes.NewReader(body)), release: func() {
-							a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, upstream.StatusCode, nil)
 							lease.Release()
 						}},
 					}, nil
 				}
+				lease.InvalidateClearance()
 				if attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, statsigTarget) {
 					lease.Release()
 					continue
@@ -374,7 +374,7 @@ func (a *Adapter) openChat(ctx context.Context, credential account.Credential, p
 	request.Header = buildHeaders(token, lease, "application/json")
 	applyAppHeaders(request.Header, cfg.BaseURL, cfg.BaseURL+"/")
 	a.applySignedStatsig(requestCtx, request, token, lease)
-	response, err := lease.Do(request)
+	response, err := lease.DoDeferredForbidden(request)
 	if err != nil {
 		cancel()
 		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, 0, err)

--- a/backend/internal/infra/provider/web/quota.go
+++ b/backend/internal/infra/provider/web/quota.go
@@ -162,6 +162,11 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 			return account.QuotaWindow{}, err
 		}
 		if response.StatusCode == http.StatusForbidden {
+			// 封号正文优先于 Statsig 重试：首包 blocked-user 不得因 invalidate 被丢弃。
+			if bodyLooksLikeAccountBlocked(body) {
+				a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
+				return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
+			}
 			if attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, endpoint) {
 				continue
 			}
@@ -173,8 +178,7 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 		if response.StatusCode == http.StatusUnauthorized {
 			return account.QuotaWindow{}, provider.ErrUnauthorized
 		}
-		// 403 + blocked-user 与对话封号同源；映射为 ErrUnauthorized 以便额度同步将账号标为失效。
-		// 其它 403（如临时 anti-bot）保持普通错误，避免误杀。
+		// 循环内已处理封号 403；此处兜底防止路径遗漏。
 		if response.StatusCode == http.StatusForbidden && bodyLooksLikeAccountBlocked(body) {
 			return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
 		}

--- a/backend/internal/infra/provider/web/quota.go
+++ b/backend/internal/infra/provider/web/quota.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
@@ -151,7 +150,7 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 		request.Header = buildHeaders(token, lease, "application/json")
 		applyAppHeaders(request.Header, cfg.BaseURL, cfg.BaseURL+"/")
 		a.applySignedStatsig(requestCtx, request, token, lease)
-		response, err = lease.Do(request)
+		response, err = lease.DoDeferredForbidden(request)
 		if err != nil {
 			a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, 0, err)
 			return account.QuotaWindow{}, err
@@ -162,11 +161,11 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 			return account.QuotaWindow{}, err
 		}
 		if response.StatusCode == http.StatusForbidden {
-			// 封号正文优先于 Statsig 重试：首包 blocked-user 不得因 invalidate 被丢弃。
-			if bodyLooksLikeAccountBlocked(body) {
-				a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
+			// Preserve definitive account-block signals before a Statsig retry can discard the first response.
+			if provider.IsDefinitiveAccountBlockBody(body) {
 				return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
 			}
+			lease.InvalidateClearance()
 			if attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, endpoint) {
 				continue
 			}
@@ -174,14 +173,13 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 		break
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
 		if response.StatusCode == http.StatusUnauthorized {
 			return account.QuotaWindow{}, provider.ErrUnauthorized
 		}
-		// 循环内已处理封号 403；此处兜底防止路径遗漏。
-		if response.StatusCode == http.StatusForbidden && bodyLooksLikeAccountBlocked(body) {
+		if response.StatusCode == http.StatusForbidden && provider.IsDefinitiveAccountBlockBody(body) {
 			return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
 		}
+		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
 		return account.QuotaWindow{}, fmt.Errorf("Grok Web 额度接口返回 %d", response.StatusCode)
 	}
 	a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
@@ -232,7 +230,7 @@ func (a *Adapter) syncWeeklyCredits(ctx context.Context, credential account.Cred
 	request.Header.Set("x-grpc-web", "1")
 	request.Header.Set("x-user-agent", "connect-es/2.1.1")
 
-	response, err := lease.Do(request)
+	response, err := lease.DoDeferredForbidden(request)
 	if err != nil {
 		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, 0, err)
 		return account.QuotaWindow{}, err
@@ -243,10 +241,16 @@ func (a *Adapter) syncWeeklyCredits(ctx context.Context, credential account.Cred
 		return account.QuotaWindow{}, err
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
 		if response.StatusCode == http.StatusUnauthorized {
 			return account.QuotaWindow{}, provider.ErrUnauthorized
 		}
+		if response.StatusCode == http.StatusForbidden && provider.IsDefinitiveAccountBlockBody(body) {
+			return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
+		}
+		if response.StatusCode == http.StatusForbidden {
+			lease.InvalidateClearance()
+		}
+		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
 		return account.QuotaWindow{}, fmt.Errorf("Grok Web 周额度接口返回 %d", response.StatusCode)
 	}
 	window, err := parseWeeklyCreditsResponse(body, credential.ID, time.Now().UTC())
@@ -483,11 +487,4 @@ func parseQuotaBreakdown(message []byte) (account.QuotaBreakdown, bool) {
 		return account.QuotaBreakdown{}, false
 	}
 	return result, true
-}
-
-
-// bodyLooksLikeAccountBlocked 识别额度接口上明确的账号封禁响应（与 gateway AccountBlocked 同信号）。
-func bodyLooksLikeAccountBlocked(body []byte) bool {
-	text := strings.ToLower(string(body))
-	return strings.Contains(text, "blocked-user") || strings.Contains(text, "user is blocked")
 }

--- a/backend/internal/infra/provider/web/quota.go
+++ b/backend/internal/infra/provider/web/quota.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
@@ -171,6 +172,11 @@ func (a *Adapter) SyncQuotaMode(ctx context.Context, credential account.Credenti
 		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, response.StatusCode, nil)
 		if response.StatusCode == http.StatusUnauthorized {
 			return account.QuotaWindow{}, provider.ErrUnauthorized
+		}
+		// 403 + blocked-user 与对话封号同源；映射为 ErrUnauthorized 以便额度同步将账号标为失效。
+		// 其它 403（如临时 anti-bot）保持普通错误，避免误杀。
+		if response.StatusCode == http.StatusForbidden && bodyLooksLikeAccountBlocked(body) {
+			return account.QuotaWindow{}, fmt.Errorf("%w: account blocked", provider.ErrUnauthorized)
 		}
 		return account.QuotaWindow{}, fmt.Errorf("Grok Web 额度接口返回 %d", response.StatusCode)
 	}
@@ -473,4 +479,11 @@ func parseQuotaBreakdown(message []byte) (account.QuotaBreakdown, bool) {
 		return account.QuotaBreakdown{}, false
 	}
 	return result, true
+}
+
+
+// bodyLooksLikeAccountBlocked 识别额度接口上明确的账号封禁响应（与 gateway AccountBlocked 同信号）。
+func bodyLooksLikeAccountBlocked(body []byte) bool {
+	text := strings.ToLower(string(body))
+	return strings.Contains(text, "blocked-user") || strings.Contains(text, "user is blocked")
 }

--- a/backend/internal/infra/provider/web/quota_test.go
+++ b/backend/internal/infra/provider/web/quota_test.go
@@ -175,6 +175,42 @@ func TestSyncQuotaBlockedForbiddenIsUnauthorized(t *testing.T) {
 	}
 }
 
+func TestSyncQuotaBlockedForbiddenSkipsStatsigRetryInURLMode(t *testing.T) {
+	var rateLimitCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		// URL mode may also probe the base URL for Statsig meta; only count quota endpoint.
+		if request.URL.Path == "/rest/rate-limits" {
+			rateLimitCalls.Add(1)
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusForbidden)
+			_, _ = writer.Write([]byte(`{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}`))
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("blocked-sso-url")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// URL mode would invalidate Statsig and retry unless blocked body is classified first.
+	adapter := NewAdapter(Config{
+		BaseURL: server.URL, StatsigMode: "url", StatsigSignerURL: "https://signer.example/sign",
+	}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+	_, err = adapter.SyncQuota(context.Background(), account.Credential{ID: 6, WebTier: account.WebTierAuto, EncryptedAccessToken: encrypted})
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if rateLimitCalls.Load() != 1 {
+		t.Fatalf("blocked credential made %d rate-limits requests, want 1 (no Statsig retry)", rateLimitCalls.Load())
+	}
+}
+
 func TestSyncQuotaGenericForbiddenIsNotUnauthorized(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")

--- a/backend/internal/infra/provider/web/quota_test.go
+++ b/backend/internal/infra/provider/web/quota_test.go
@@ -143,6 +143,72 @@ func TestSyncQuotaStopsAfterFirstUnauthorizedMode(t *testing.T) {
 	}
 }
 
+
+func TestSyncQuotaBlockedForbiddenIsUnauthorized(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}`))
+	}))
+	defer server.Close()
+
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("blocked-sso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{
+		BaseURL: server.URL, StatsigMode: "manual", StatsigManualValue: "test-signature",
+	}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+	_, err = adapter.SyncQuota(context.Background(), account.Credential{ID: 4, WebTier: account.WebTierAuto, EncryptedAccessToken: encrypted})
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	// manual Statsig mode does not invalidate/retry; SyncQuota stops after the first unauthorized mode.
+	if calls.Load() != 1 {
+		t.Fatalf("blocked credential made %d quota requests, want 1", calls.Load())
+	}
+}
+
+func TestSyncQuotaGenericForbiddenIsNotUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{"message":"temporary rejection"}`))
+	}))
+	defer server.Close()
+
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("generic-sso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{
+		BaseURL: server.URL, StatsigMode: "manual", StatsigManualValue: "test-signature",
+	}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+	_, err = adapter.SyncQuota(context.Background(), account.Credential{ID: 5, WebTier: account.WebTierAuto, EncryptedAccessToken: encrypted})
+	if err == nil || errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want generic forbidden error", err)
+	}
+}
+
+func TestBodyLooksLikeAccountBlocked(t *testing.T) {
+	if !bodyLooksLikeAccountBlocked([]byte(`{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]"}`)) {
+		t.Fatal("expected blocked body to match")
+	}
+	if bodyLooksLikeAccountBlocked([]byte(`{"message":"temporary rejection"}`)) {
+		t.Fatal("expected generic body not to match")
+	}
+}
+
 func TestInferWebTierFromUpstreamQuota(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/internal/infra/provider/web/quota_test.go
+++ b/backend/internal/infra/provider/web/quota_test.go
@@ -9,14 +9,17 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	egressdomain "github.com/chenyme/grok2api/backend/internal/domain/egress"
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 	"github.com/chenyme/grok2api/backend/internal/infra/security"
+	"github.com/chenyme/grok2api/backend/internal/repository"
 )
 
 const capturedWeeklyCreditsHex = "00000000630a610d0000304112001a00220c089abbccd2061080f2d1fc012a0c089ab0f1d2061080f2d1fc013a07080515000020413a070804150000803f3a020802421e0802120c089abbccd2061080f2d1fc011a0c089ab0f1d2061080f2d1fc01580162006801800000000f677270632d7374617475733a300d0a"
@@ -143,7 +146,6 @@ func TestSyncQuotaStopsAfterFirstUnauthorizedMode(t *testing.T) {
 	}
 }
 
-
 func TestSyncQuotaBlockedForbiddenIsUnauthorized(t *testing.T) {
 	var calls atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -162,9 +164,12 @@ func TestSyncQuotaBlockedForbiddenIsUnauthorized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	egressRepository := &recordingWebEgressRepository{node: egressdomain.Node{
+		ID: 1, Name: "web", Scope: egressdomain.ScopeWeb, Enabled: true, Health: 1,
+	}}
 	adapter := NewAdapter(Config{
 		BaseURL: server.URL, StatsigMode: "manual", StatsigManualValue: "test-signature",
-	}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+	}, infraegress.NewManager(egressRepository, cipher), cipher, nil, nil)
 	_, err = adapter.SyncQuota(context.Background(), account.Credential{ID: 4, WebTier: account.WebTierAuto, EncryptedAccessToken: encrypted})
 	if !errors.Is(err, provider.ErrUnauthorized) {
 		t.Fatalf("err = %v, want ErrUnauthorized", err)
@@ -172,6 +177,9 @@ func TestSyncQuotaBlockedForbiddenIsUnauthorized(t *testing.T) {
 	// manual Statsig mode does not invalidate/retry; SyncQuota stops after the first unauthorized mode.
 	if calls.Load() != 1 {
 		t.Fatalf("blocked credential made %d quota requests, want 1", calls.Load())
+	}
+	if updates := egressRepository.UpdateCount(); updates != 0 {
+		t.Fatalf("blocked account changed egress health %d times", updates)
 	}
 }
 
@@ -236,12 +244,33 @@ func TestSyncQuotaGenericForbiddenIsNotUnauthorized(t *testing.T) {
 	}
 }
 
-func TestBodyLooksLikeAccountBlocked(t *testing.T) {
-	if !bodyLooksLikeAccountBlocked([]byte(`{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]"}`)) {
-		t.Fatal("expected blocked body to match")
+func TestSyncWeeklyCreditsBlockedForbiddenIsUnauthorized(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		calls.Add(1)
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{"code":"unauthorized:blocked-user","error":"User is blocked"}`))
+	}))
+	defer server.Close()
+
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if bodyLooksLikeAccountBlocked([]byte(`{"message":"temporary rejection"}`)) {
-		t.Fatal("expected generic body not to match")
+	encrypted, err := cipher.Encrypt("blocked-weekly-sso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{
+		BaseURL: server.URL, StatsigMode: "manual", StatsigManualValue: "test-signature",
+	}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+	_, err = adapter.SyncQuotaMode(context.Background(), account.Credential{ID: 7, EncryptedAccessToken: encrypted}, weeklyQuotaMode)
+	if !errors.Is(err, provider.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("blocked weekly credential made %d requests, want 1", calls.Load())
 	}
 }
 
@@ -308,6 +337,49 @@ func TestResolveWebTierUsesFreshWebQuotaOverStoredTier(t *testing.T) {
 	if tier != account.WebTierAuto || useWeekly {
 		t.Fatalf("auto should not be promoted when modes unavailable: got %q, weekly=%v", tier, useWeekly)
 	}
+}
+
+type recordingWebEgressRepository struct {
+	mu      sync.Mutex
+	node    egressdomain.Node
+	updates int
+}
+
+func (r *recordingWebEgressRepository) ListEgressNodes(_ context.Context, scope egressdomain.Scope, _ repository.SortQuery) ([]egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.node.Scope != scope {
+		return nil, nil
+	}
+	return []egressdomain.Node{r.node}, nil
+}
+
+func (r *recordingWebEgressRepository) GetEgressNode(context.Context, uint64) (egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.node, nil
+}
+
+func (r *recordingWebEgressRepository) CreateEgressNode(context.Context, egressdomain.Node) (egressdomain.Node, error) {
+	return egressdomain.Node{}, errors.New("unsupported")
+}
+
+func (r *recordingWebEgressRepository) UpdateEgressNode(_ context.Context, value egressdomain.Node) (egressdomain.Node, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.node = value
+	r.updates++
+	return value, nil
+}
+
+func (r *recordingWebEgressRepository) DeleteEgressNode(context.Context, uint64) error {
+	return errors.New("unsupported")
+}
+
+func (r *recordingWebEgressRepository) UpdateCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.updates
 }
 
 func TestSyncQuotaCorrectsStoredSuperFromFreshWebQuota(t *testing.T) {


### PR DESCRIPTION
## Summary

本 PR 在既有 SSO 账号失效机制上做补齐。

项目已支持将不可用账号标为 `auth_status=reauthRequired`（管理端「失效」）并移出调度，例如对话 **401**、凭据拒绝等路径。此前若上游以 **HTTP 403** 返回、且响应**正文**明确表示账号被封，账号可能仍保持 `active` 并继续被选中。

本次改动使下列路径在收到**明确封号 / Session 不可用**信号时，同样写入 `reauthRequired` 与 `last_error` 并停止调度：

| 类型 | 路径 |
|------|------|
| 主动 | 导入 / Session 身份同步 |
| 主动 | Web 额度同步（`POST /rest/rate-limits`） |
| 被动 | Web 与 Console 对话（正文命中后 mark，并换号） |

**判定依据是明确封号信号，不是裸 HTTP 403。** 反爬、出口、Statsig 等无封号正文的 403 不惩罚账号。

### 匹配规则

HTTP 错误响应正文（解析后的 code / message，小写 contains）：

```text
contains "blocked-user"  OR  contains "user is blocked"
```

Session 身份接口：

- `status=blocked` 或 `status=unauthenticated` → `provider.ErrUnauthorized`
- 在采纳 `userId` / `email` **之前**判断，避免 `status=blocked` 仍带身份字段时被当作有效账号

| 不在此列（不因此失效） | 说明 |
|------------------------|------|
| 裸 HTTP 403 | 正文无封号词 |
| 仅数字 `code: 7` | 无封号文案 |
| 反爬 / 出口 / Statsig 类 403 | 保持既有重试，不 mark 账号 |

调度语义不变：仅 `enabled=true` 且 `auth_status=active` 参与选号。

---

## 上游响应原文（对照）

### Session（导入 / 身份同步）

HTTP 200，body 表示会话不可用：

```json
{"status":"blocked"}
```

### Web 额度 `POST /rest/rate-limits`

HTTP 403：

```json
{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}
```

### Web 对话 `POST /rest/app-chat/conversations/new`

HTTP 403：

```json
{"error":{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}}
```

### Console 对话

HTTP 403：

```json
{"code":"unauthorized:blocked-user","error":"User is blocked"}
```

### 非封号 403（对照，不失效）

```json
{"error":{"code":7,"message":"Request rejected by anti-bot rules.","details":[]}}
```

说明：同一 SSO 可能从 403 blocked-user 退化为 401 invalid-credentials；两类均应出池。401 为既有路径，本 PR 不削弱。对话轮询受 `maxAttempts` 等策略约束时，仅本轮被 attempt 打到的账号会 mark。

---

## Changes

三个提交，按顺序：

1. **`feat(account): mark SSO invalid on session blocked and quota blocked-user`**  
   Session Parse 与 Web 额度在明确封号 / 不可用时映射为 `ErrUnauthorized`，经既有 mark 路径落库为 `reauthRequired`。

2. **`fix(gateway): invalidate SSO on chat 403 blocked-user body`**  
   对话链路对 403 **先按响应正文分类**：命中封号则 `markReauthRequired` 并换号；非封号 403 仍按 egress 重试，不惩罚账号。

3. **`fix(web,session): prefer block signals before identity and Statsig retry`**  
   Session 优先识别 blocked / unauthenticated；Web 对话与额度在 Statsig invalidate / 重试之前识别封号正文，避免首包明确封号被丢弃。

主要文件：`sessionidentity/session.go`、`web/quota.go`、`web/chat.go`、`gateway/service.go` 及对应测试。

---

## 行为对照

| 场景 | 结果 |
|------|------|
| 导入 Session `blocked` / `unauthenticated` | `reauthRequired`，不参与调度 |
| Web 额度 403 正文命中封号 | `reauthRequired` |
| Web / Console 对话 403 正文命中封号 | `reauthRequired` + 换号 |
| 403 无封号正文 | 账号保持 `active` |
| 对话 401 | 既有失效路径，仍出池 |
| 正常 SSO 对话 | 不受影响 |

---

## 范围

- 补齐 403 正文明确封号的主动检测与被动 mark（含 Web && Console 对话）
- 不修改 Build 可配置 403 作废策略
- 不引入「裸 403 一律失效」

---

## Test plan

- [x] 相关包单测通过：`sessionidentity` / `web` / `gateway` / `account`
- [x] Session `blocked` / `unauthenticated` 导入后为 `reauthRequired`
- [x] Web 额度 403 封号正文 → 失效；无封号词 403 → 不失效
- [x] Web && Console 对话 403 封号正文 → 失效；有可用号时换号
- [x] 反爬类 403 不误杀账号；正常 SSO 与既有 401 路径回归正常