### PR TITLE
fix: avoid cooling proxy nodes on canceled requests

### DIFF
--- a/backend/internal/infra/egress/manager.go
+++ b/backend/internal/infra/egress/manager.go
@@ -43,6 +43,9 @@ const clearanceCacheCleanupInterval = time.Minute
 const clearanceCacheMinIdleTTL = 30 * time.Minute
 const maxCachedClearances = 16384
 const clearanceCacheEvictionBatch = 256
+
+// clientClosedRequestStatus is the conventional proxy status for a client-aborted request.
+const clientClosedRequestStatus = 499
 const egressIPv4ProbeEndpoint = "https://ipinfo.io/json"
 const egressIPv6ProbeEndpoint = "https://v6.ipinfo.io/json"
 const cloudflareIPv4ProbeEndpoint = "https://1.1.1.1/cdn-cgi/trace"
@@ -1341,6 +1344,9 @@ func (m *Manager) Feedback(ctx context.Context, nodeID uint64, status int, trans
 }
 
 func (m *Manager) FeedbackForScope(ctx context.Context, scope domain.Scope, nodeID uint64, status int, transportErr error) {
+	if status == clientClosedRequestStatus || errors.Is(transportErr, context.Canceled) {
+		return
+	}
 	if scope == domain.ScopeBuild && neterrorpkg.IsResponseHeaderTimeout(transportErr) {
 		return
 	}

--- a/backend/internal/infra/egress/manager_test.go
+++ b/backend/internal/infra/egress/manager_test.go
@@ -81,6 +81,50 @@ func TestResponseHeaderTimeoutRetainsWebEgressFeedback(t *testing.T) {
 	}
 }
 
+func TestCanceledRequestDoesNotPenalizeEgress(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		transportErr error
+	}{
+		{name: "canceled transport", transportErr: context.Canceled},
+		{name: "wrapped canceled transport", transportErr: fmt.Errorf("request failed: %w", context.Canceled)},
+		{name: "client closed status", status: clientClosedRequestStatus},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repository := &mutableEgressRepository{node: domain.Node{ID: 1, Name: "fixed", Scope: domain.ScopeBuild, Enabled: true, Health: 1}}
+			manager := NewManager(repository, nil)
+			manager.FeedbackForScope(context.Background(), domain.ScopeBuild, 1, test.status, test.transportErr)
+			if repository.updates != 0 || repository.node.Health != 1 || repository.node.FailureCount != 0 || repository.node.CooldownUntil != nil {
+				t.Fatalf("canceled request changed node health: updates=%d node=%#v", repository.updates, repository.node)
+			}
+		})
+	}
+}
+
+func TestCanceledRequestDoesNotInvalidateDirectClient(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		transportErr error
+	}{
+		{name: "canceled transport", transportErr: context.Canceled},
+		{name: "client closed status", status: clientClosedRequestStatus},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(egressRepositoryTestStub{}, nil)
+			key := clientCacheKey{nodeID: 0, scope: domain.ScopeBuild, fingerprint: "direct"}
+			manager.clients[key] = cachedClient{client: &scriptedRequestClient{}}
+			manager.FeedbackForScope(context.Background(), domain.ScopeBuild, 0, test.status, test.transportErr)
+			if _, exists := manager.clients[key]; !exists {
+				t.Fatal("canceled request invalidated the direct Build client")
+			}
+		})
+	}
+}
+
 func TestProbeEgressNodeLogsSuccessWithoutProxyCredentials(t *testing.T) {
 	cipher, err := security.NewCipher("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
 	if err != nil {

--- a/backend/internal/infra/provider/cli/egress.go
+++ b/backend/internal/infra/provider/cli/egress.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 
@@ -33,7 +34,9 @@ func (t *egressTransport) RoundTrip(request *http.Request) (*http.Response, erro
 	}
 	response, err := lease.Do(request)
 	if err != nil {
-		t.manager.FeedbackForScope(context.WithoutCancel(request.Context()), domainegress.ScopeBuild, lease.NodeID, 0, err)
+		if shouldReportEgressFailure(request.Context(), err) {
+			t.manager.FeedbackForScope(context.WithoutCancel(request.Context()), domainegress.ScopeBuild, lease.NodeID, 0, err)
+		}
 		lease.Release()
 		return nil, err
 	}
@@ -44,6 +47,13 @@ func (t *egressTransport) RoundTrip(request *http.Request) (*http.Response, erro
 	}
 	response.Body = &egressResponseBody{ReadCloser: response.Body, release: lease.Release}
 	return response, nil
+}
+
+func shouldReportEgressFailure(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	return !errors.Is(err, context.Canceled)
 }
 
 type egressResponseBody struct {

--- a/backend/internal/infra/provider/cli/egress_test.go
+++ b/backend/internal/infra/provider/cli/egress_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestShouldReportEgressFailure(t *testing.T) {
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	deadlineContext, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{name: "no error", ctx: context.Background(), err: nil, want: false},
+		{name: "canceled request context", ctx: canceledContext, err: errors.New("connection reset"), want: false},
+		{name: "expired request context", ctx: deadlineContext, err: context.DeadlineExceeded, want: false},
+		{name: "canceled transport", ctx: context.Background(), err: context.Canceled, want: false},
+		{name: "wrapped canceled transport", ctx: context.Background(), err: fmt.Errorf("round trip: %w", context.Canceled), want: false},
+		{name: "connection failure", ctx: context.Background(), err: errors.New("connection refused"), want: true},
+		{name: "independent transport timeout", ctx: context.Background(), err: context.DeadlineExceeded, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldReportEgressFailure(test.ctx, test.err); got != test.want {
+				t.Fatalf("shouldReportEgressFailure() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Prevent client-canceled requests from incorrectly penalizing egress proxy nodes or triggering cooldowns.

### Changes

- Ignore `context.Canceled` and wrapped cancellation errors when reporting egress failures.
- Ignore HTTP `499`, which represents a client-closed request.
- Skip egress health degradation, failure-count increments, cooldown creation, and client invalidation for canceled requests.
- Prevent canceled requests from invalidating direct Build clients.
- Continue reporting genuine proxy failures, including connection refusals, proxy handshake errors, and independent transport timeouts.
- Add regression tests covering fixed nodes, direct clients, wrapped cancellation errors, request deadlines, and real transport failures.

### Validation

- `go test ./... -count=1`
- `go test -race ./internal/infra/egress ./internal/infra/provider/cli -count=1`
- `go vet ./...`
- `git diff --check`

All checks passed.