### PR TITLE
perf: reduce database I/O with deferred credential hydration

### DIFF
--- a/backend/internal/app/startup.go
+++ b/backend/internal/app/startup.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -186,7 +187,17 @@ func readinessSnapshot(
 			continue
 		}
 		for _, candidate := range candidates {
-			if startupCandidateUsable(candidate, now, providers) {
+			if !startupCandidateUsable(candidate, now, providers) {
+				continue
+			}
+			material, materialErr := accounts.GetCredentialMaterial(ctx, candidate.Credential.ID, candidate.Credential.Provider)
+			if materialErr != nil {
+				if !errors.Is(materialErr, repository.ErrNotFound) {
+					providerErrors[route.Provider] = true
+				}
+				continue
+			}
+			if material.EncryptedAccessToken != "" {
 				usable[route.Provider] = true
 				break
 			}
@@ -262,7 +273,7 @@ func newReadinessStartupReport(report startupReport) *httpserver.ReadinessStartu
 
 func startupCandidateUsable(candidate accountdomain.RoutingCandidate, now time.Time, providers *provider.Registry) bool {
 	credential := candidate.Credential
-	if credential.EncryptedAccessToken == "" || credential.AuthStatus != accountdomain.AuthStatusActive {
+	if credential.AuthType == "" || credential.AuthStatus != accountdomain.AuthStatusActive {
 		return false
 	}
 	refreshable := credential.AuthType == accountdomain.AuthTypeOAuth

--- a/backend/internal/app/startup_test.go
+++ b/backend/internal/app/startup_test.go
@@ -70,6 +70,43 @@ func TestReadinessKeepsBuildReadyWhenWebIsUnavailable(t *testing.T) {
 	}
 }
 
+func TestReadinessRejectsAccountWithoutAccessToken(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "readiness-missing-access.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	models := relational.NewModelRepository(database)
+	now := time.Now().UTC()
+	build, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderBuild, AuthType: accountdomain.AuthTypeOAuth,
+		Name: "refresh-only", SourceKey: "refresh-only", EncryptedRefreshToken: "refresh",
+		ExpiresAt: now.Add(time.Hour), Enabled: true, AuthStatus: accountdomain.AuthStatusActive, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := models.UpsertRoutes(ctx, []modeldomain.Route{{
+		PublicID: "build-model", Provider: accountdomain.ProviderBuild, UpstreamModel: "build-model", Capability: modeldomain.CapabilityResponses, Enabled: true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := models.ReplaceAccountCapabilities(ctx, build.ID, []string{"build-model"}, now); err != nil {
+		t.Fatal(err)
+	}
+	state := newStartupState(0)
+	state.setPhase("running")
+	snapshot := readinessSnapshot(ctx, state, func(context.Context) error { return nil }, models, accounts, provider.NewRegistry(), nil)
+	if snapshot.Ready || snapshot.Components["grok_build"].State != "unavailable" {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+}
+
 func TestReadinessRestoresPersistedCooldownWithoutUpstreamProbe(t *testing.T) {
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "cooldown-readiness.db"))

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -37,6 +37,8 @@ const modelAccessDeniedCooldown = 5 * time.Minute
 
 const defaultFreeQuotaRecoveryPause = 24 * time.Hour
 
+var errRoutingCredentialStale = errors.New("routing credential is no longer available")
+
 type quotaRecoveryHints struct {
 	Billing *account.Billing
 }
@@ -206,6 +208,7 @@ type Selector struct {
 	candidates             map[candidateCacheKey]candidateSnapshot
 	routingBases           map[routingBaseCacheKey]routingBaseSnapshot
 	routingOverlays        map[routingOverlayCacheKey]routingOverlaySnapshot
+	routingAccountProvider map[uint64]account.Provider
 	baseGlobalVersion      uint64
 	overlayGlobalVersion   uint64
 	baseProviderVersion    map[account.Provider]uint64
@@ -224,7 +227,7 @@ func NewSelector(accounts repository.AccountRepository, concurrency repository.C
 	if len(capacityWait) > 0 && capacityWait[0] > 0 {
 		wait = capacityWait[0]
 	}
-	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
+	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), routingAccountProvider: make(map[uint64]account.Provider), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
 }
 
 func (s *Selector) UpdateConfig(stickyTTL, cooldownBase, cooldownMax time.Duration, capacityWait ...time.Duration) {
@@ -342,6 +345,8 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 		return nil, &SelectionUnavailableError{Reason: reason, RetryAfter: retryDelay(now, earliestRetry)}
 	}
 	if len(probeCandidates) > 0 {
+		staleClaims := 0
+		capacityMisses := 0
 		plan, err := s.planCandidateIndexes(ctx, values, probeCandidates, now, s.resolveTierOrder(provider, upstreamModel))
 		if err != nil {
 			return nil, err
@@ -349,9 +354,14 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 		for candidate, ok := plan.Next(); ok; candidate, ok = plan.Next() {
 			lease, err := s.claimAccountSlot(ctx, candidate.Credential)
 			if err != nil {
+				if errors.Is(err, errRoutingCredentialStale) {
+					staleClaims++
+					continue
+				}
 				return nil, err
 			}
 			if lease == nil {
+				capacityMisses++
 				continue
 			}
 			claimed, err := s.accounts.ClaimQuotaProbe(ctx, candidate.Credential.ID, now, now.Add(quotaProbeLease))
@@ -366,6 +376,9 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 			lease.QuotaProbeKind = candidate.QuotaRecovery.Kind
 			lease.Billing = candidate.Billing
 			return lease, nil
+		}
+		if len(normalCandidates) == 0 && staleClaims > 0 && capacityMisses == 0 {
+			return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
 		}
 	}
 	var saturatedStickyID uint64
@@ -393,10 +406,13 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 						lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
 						return lease, nil
 					}
-					if !isSelectionUnavailable(acquireErr, SelectionSaturated) {
+					if errors.Is(acquireErr, errRoutingCredentialStale) {
+						_ = s.sticky.DeleteByAccount(ctx, stickyID)
+					} else if !isSelectionUnavailable(acquireErr, SelectionSaturated) {
 						return nil, acquireErr
+					} else {
+						saturatedStickyID = stickyID
 					}
-					saturatedStickyID = stickyID
 				}
 			}
 		}
@@ -414,6 +430,9 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 			}
 			lease, claimErr := s.claimAccountSlot(ctx, candidate.Credential)
 			if claimErr != nil {
+				if errors.Is(claimErr, errRoutingCredentialStale) {
+					continue
+				}
 				return nil, claimErr
 			}
 			if lease == nil {
@@ -435,6 +454,8 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 	waitDeadline := time.Now().Add(capacityWait)
 	for {
 		currentTime := time.Now().UTC()
+		staleClaims := 0
+		capacityMisses := 0
 		plan, err := s.planCandidateIndexes(ctx, values, normalCandidates, currentTime, s.resolveTierOrder(provider, upstreamModel))
 		if err != nil {
 			return nil, err
@@ -442,9 +463,14 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 		for candidate, ok := plan.Next(); ok; candidate, ok = plan.Next() {
 			lease, err := s.claimAccountSlot(ctx, candidate.Credential)
 			if err != nil {
+				if errors.Is(err, errRoutingCredentialStale) {
+					staleClaims++
+					continue
+				}
 				return nil, err
 			}
 			if lease == nil {
+				capacityMisses++
 				continue
 			}
 			if stickyKey != "" {
@@ -463,7 +489,13 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 							boundLease.QuotaMode = effectiveQuotaMode(boundCandidate, quotaMode)
 							return boundLease, nil
 						}
-						if !isSelectionUnavailable(boundErr, SelectionSaturated) {
+						if errors.Is(boundErr, errRoutingCredentialStale) {
+							_ = s.sticky.DeleteByAccount(ctx, boundID)
+							if err := s.sticky.Set(ctx, stickyKey, candidate.Credential.ID, currentTime.Add(stickyTTL)); err != nil {
+								lease.Release()
+								return nil, fmt.Errorf("重建会话粘滞状态: %w", err)
+							}
+						} else if !isSelectionUnavailable(boundErr, SelectionSaturated) {
 							lease.Release()
 							return nil, boundErr
 						}
@@ -477,6 +509,9 @@ func (s *Selector) Acquire(ctx context.Context, provider account.Provider, model
 			lease.Billing = candidate.Billing
 			lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
 			return lease, nil
+		}
+		if staleClaims > 0 && capacityMisses == 0 {
+			return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
 		}
 		if capacityWait <= 0 {
 			return nil, &SelectionUnavailableError{Reason: SelectionSaturated, RetryAfter: time.Second}
@@ -550,6 +585,9 @@ func (s *Selector) AcquirePinned(ctx context.Context, provider account.Provider,
 				}
 				lease, err := s.acquirePinnedCapacity(ctx, value)
 				if err != nil {
+					if errors.Is(err, errRoutingCredentialStale) {
+						return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
+					}
 					return nil, err
 				}
 				claimed, err := s.accounts.ClaimQuotaProbe(ctx, value.ID, now, now.Add(quotaProbeLease))
@@ -578,6 +616,9 @@ func (s *Selector) AcquirePinned(ctx context.Context, provider account.Provider,
 		}
 		lease, err := s.acquirePinnedCapacity(ctx, value)
 		if err != nil {
+			if errors.Is(err, errRoutingCredentialStale) {
+				return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
+			}
 			return nil, err
 		}
 		lease.Billing = candidate.Billing
@@ -889,6 +930,14 @@ func (s *Selector) loadRoutingBases(ctx context.Context, layered repository.Rout
 		currentVersion := s.routingBaseVersionLocked(provider)
 		if currentVersion == checkVersion {
 			s.routingBases[key] = routingBaseSnapshot{values: values, version: checkVersion, expiresAt: checkTime.Add(candidateCacheTTL)}
+			for accountID, cachedProvider := range s.routingAccountProvider {
+				if cachedProvider == provider {
+					delete(s.routingAccountProvider, accountID)
+				}
+			}
+			for _, value := range values {
+				s.routingAccountProvider[value.Credential.ID] = provider
+			}
 		}
 		s.candidateMu.Unlock()
 		return routingBaseLoadResult{values: values, version: checkVersion}, nil
@@ -972,28 +1021,40 @@ func (s *Selector) ApplyInvalidation(event repository.InvalidationEvent) {
 		return
 	}
 	s.candidateMu.Lock()
+	provider := event.Provider
+	if provider == "" && event.AccountID != 0 {
+		provider = s.routingAccountProvider[event.AccountID]
+		if provider == "" {
+			for key, snapshot := range s.candidates {
+				if _, ok := snapshot.byAccount[event.AccountID]; ok {
+					provider = key.provider
+					break
+				}
+			}
+		}
+	}
 	base := event.Layer() == repository.InvalidationLayerBase
 	overlay := event.Layer() == repository.InvalidationLayerOverlay || event.Layer() == repository.InvalidationLayerRoute
 	if base {
-		if event.Provider == "" {
+		if provider == "" {
 			s.baseGlobalVersion++
 			clearRoutingBases(s.routingBases, "")
 		} else {
-			s.baseProviderVersion[event.Provider]++
-			clearRoutingBases(s.routingBases, event.Provider)
+			s.baseProviderVersion[provider]++
+			clearRoutingBases(s.routingBases, provider)
 		}
 	}
 	if overlay {
-		if event.Provider == "" {
+		if provider == "" {
 			s.overlayGlobalVersion++
 			clearRoutingOverlays(s.routingOverlays, "")
 		} else {
-			s.overlayProviderVersion[event.Provider]++
-			clearRoutingOverlays(s.routingOverlays, event.Provider)
+			s.overlayProviderVersion[provider]++
+			clearRoutingOverlays(s.routingOverlays, provider)
 		}
 	}
 	for key := range s.candidates {
-		if event.Provider == "" || key.provider == event.Provider {
+		if provider == "" || key.provider == provider {
 			delete(s.candidates, key)
 		}
 	}
@@ -1078,12 +1139,33 @@ func (s *Selector) claimAccountSlot(ctx context.Context, value account.Credentia
 	if !acquired {
 		return nil, nil
 	}
+	releaseSlot := func() {
+		release()
+		s.announceLeaseReturn()
+	}
+	if s.accounts != nil {
+		material, loadErr := s.accounts.GetCredentialMaterial(ctx, value.ID, value.Provider)
+		if loadErr != nil {
+			releaseSlot()
+			if errors.Is(loadErr, repository.ErrNotFound) {
+				s.ApplyInvalidation(repository.InvalidationEvent{Kind: repository.InvalidationAccountStateChanged, Provider: value.Provider, AccountID: value.ID})
+				return nil, errRoutingCredentialStale
+			}
+			return nil, fmt.Errorf("加载账号执行凭据: %w", loadErr)
+		}
+		hydrated, matched := material.ApplyTo(value)
+		if !matched {
+			releaseSlot()
+			s.ApplyInvalidation(repository.InvalidationEvent{Kind: repository.InvalidationAccountStateChanged, Provider: value.Provider, AccountID: value.ID})
+			return nil, errRoutingCredentialStale
+		}
+		value = hydrated
+	}
 	s.selectionMu.Lock()
 	s.lastSelectedAt[value.ID] = time.Now().UTC()
 	s.selectionMu.Unlock()
 	return &accountLease{Credential: value, release: func() {
-		release()
-		s.announceLeaseReturn()
+		releaseSlot()
 	}}, nil
 }
 

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -789,7 +789,17 @@ func (s *Selector) ConsumeQuota(provider account.Provider, accountID uint64, mod
 }
 
 func (s *Selector) MarkFailure(ctx context.Context, credential account.Credential, status int, retryAfter time.Duration) {
-	failureCount := credential.FailureCount + 1
+	_ = s.markFailure(ctx, credential, credential.FailureCount+1, status, retryAfter)
+}
+
+// MarkFailureAfterSuccess records a stream failure from a fresh health baseline.
+// The upstream already returned a successful response header, so failures that
+// preceded this request must not be carried into the new cooldown calculation.
+func (s *Selector) MarkFailureAfterSuccess(ctx context.Context, credential account.Credential, status int, retryAfter time.Duration) error {
+	return s.markFailure(ctx, credential, 1, status, retryAfter)
+}
+
+func (s *Selector) markFailure(ctx context.Context, credential account.Credential, failureCount, status int, retryAfter time.Duration) error {
 	_, cooldownBase, cooldownMax, _ := s.routingConfig()
 	cooldown := cooldownBase
 	for i := 1; i < failureCount && cooldown < cooldownMax; i++ {
@@ -802,11 +812,12 @@ func (s *Selector) MarkFailure(ctx context.Context, credential account.Credentia
 		cooldown = retryAfter
 	}
 	until := time.Now().UTC().Add(cooldown)
-	_ = s.accounts.UpdateHealth(ctx, credential.ID, failureCount, &until, fmt.Sprintf("upstream status %d", status), false)
+	healthErr := s.accounts.UpdateHealth(ctx, credential.ID, failureCount, &until, fmt.Sprintf("upstream status %d", status), false)
 	s.invalidateCandidates(credential.Provider)
 	if status == 401 || status == 402 || status == 403 || status == 429 {
 		_ = s.sticky.DeleteByAccount(ctx, credential.ID)
 	}
+	return healthErr
 }
 
 func (s *Selector) loadCandidates(ctx context.Context, provider account.Provider, modelRouteID uint64, upstreamModel, quotaMode string, now time.Time) ([]account.RoutingCandidate, error) {

--- a/backend/internal/application/gateway/selector_layered_test.go
+++ b/backend/internal/application/gateway/selector_layered_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	"github.com/chenyme/grok2api/backend/internal/domain/model"
 	"github.com/chenyme/grok2api/backend/internal/infra/persistence/relational"
+	"github.com/chenyme/grok2api/backend/internal/infra/runtime/memory"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 )
 
@@ -28,6 +30,9 @@ type layeredAccountRepository struct {
 	baseHook       func()
 	combined       []account.RoutingCandidate
 	combinedCalls  int
+	materialErrors map[uint64]error
+	materials      map[uint64]account.CredentialMaterial
+	materialCalls  []uint64
 }
 
 func (r *layeredAccountRepository) ListRoutingAccountBases(context.Context, account.Provider, string) ([]account.RoutingAccountBase, error) {
@@ -56,6 +61,19 @@ func (r *layeredAccountRepository) ListRoutingCandidates(context.Context, accoun
 	defer r.mu.Unlock()
 	r.combinedCalls++
 	return r.combined, nil
+}
+
+func (r *layeredAccountRepository) GetCredentialMaterial(_ context.Context, accountID uint64, provider account.Provider) (account.CredentialMaterial, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.materialCalls = append(r.materialCalls, accountID)
+	if err := r.materialErrors[accountID]; err != nil {
+		return account.CredentialMaterial{}, err
+	}
+	if material, ok := r.materials[accountID]; ok {
+		return material, nil
+	}
+	return account.CredentialMaterial{AccountID: accountID, Provider: provider, AuthType: account.AuthTypeOAuth, EncryptedAccessToken: "encrypted"}, nil
 }
 
 func (r *layeredAccountRepository) ListRoutingAccountOverlays(_ context.Context, _ account.Provider, modelRouteID uint64, upstreamModel string) (account.RoutingOverlaySnapshot, error) {
@@ -179,6 +197,43 @@ func TestSelectorAppliesOutOfOrderInvalidationsSafely(t *testing.T) {
 	}
 }
 
+func TestSelectorScopesAccountInvalidationToCachedProvider(t *testing.T) {
+	selector := NewSelector(nil, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	expiresAt := time.Now().Add(time.Hour)
+	selector.routingBases[routingBaseCacheKey{provider: account.ProviderBuild}] = routingBaseSnapshot{expiresAt: expiresAt}
+	selector.routingBases[routingBaseCacheKey{provider: account.ProviderWeb}] = routingBaseSnapshot{expiresAt: expiresAt}
+	selector.routingAccountProvider[42] = account.ProviderBuild
+
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountBillingChanged, AccountID: 42,
+	})
+
+	if _, ok := selector.routingBases[routingBaseCacheKey{provider: account.ProviderBuild}]; ok {
+		t.Fatal("Build routing base survived its account invalidation")
+	}
+	if _, ok := selector.routingBases[routingBaseCacheKey{provider: account.ProviderWeb}]; !ok {
+		t.Fatal("unrelated Web routing base was invalidated")
+	}
+	if selector.baseGlobalVersion != 0 || selector.baseProviderVersion[account.ProviderBuild] != 1 || selector.baseProviderVersion[account.ProviderWeb] != 0 {
+		t.Fatalf("base versions = global:%d providers:%v", selector.baseGlobalVersion, selector.baseProviderVersion)
+	}
+}
+
+func TestSelectorFallsBackToGlobalInvalidationForUnknownAccount(t *testing.T) {
+	selector := NewSelector(nil, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	expiresAt := time.Now().Add(time.Hour)
+	selector.routingBases[routingBaseCacheKey{provider: account.ProviderBuild}] = routingBaseSnapshot{expiresAt: expiresAt}
+	selector.routingBases[routingBaseCacheKey{provider: account.ProviderWeb}] = routingBaseSnapshot{expiresAt: expiresAt}
+
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountBillingChanged, AccountID: 99,
+	})
+
+	if len(selector.routingBases) != 0 || selector.baseGlobalVersion != 1 {
+		t.Fatalf("unknown account did not trigger safe global invalidation: bases=%d global=%d", len(selector.routingBases), selector.baseGlobalVersion)
+	}
+}
+
 func TestSelectorFallsBackWhenLayerVersionsKeepChanging(t *testing.T) {
 	repo := newLayeredRepositoryFixture()
 	repo.combined = []account.RoutingCandidate{{Credential: account.Credential{ID: 9, Provider: account.ProviderBuild}}}
@@ -194,6 +249,131 @@ func TestSelectorFallsBackWhenLayerVersionsKeepChanging(t *testing.T) {
 	defer repo.mu.Unlock()
 	if repo.baseCalls != 4 || repo.combinedCalls != 1 {
 		t.Fatalf("base calls=%d combined calls=%d", repo.baseCalls, repo.combinedCalls)
+	}
+}
+
+func TestSelectorHydratesOnlyClaimedCredentialAndSkipsStaleCandidate(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.bases = []account.RoutingAccountBase{
+		{Credential: account.Credential{ID: 1, Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive, Priority: 20}},
+		{Credential: account.Credential{ID: 2, Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive, Priority: 10}},
+	}
+	repo.materialErrors = map[uint64]error{1: repository.ErrNotFound}
+	repo.materials = map[uint64]account.CredentialMaterial{
+		2: {AccountID: 2, Provider: account.ProviderBuild, AuthType: account.AuthTypeOAuth, EncryptedAccessToken: "selected-secret"},
+	}
+	selector := NewSelector(repo, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	lease, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	if lease.Credential.ID != 2 || lease.Credential.EncryptedAccessToken != "selected-secret" {
+		t.Fatalf("lease credential = %#v", lease.Credential)
+	}
+	if !reflect.DeepEqual(repo.materialCalls, []uint64{1, 2}) {
+		t.Fatalf("material calls = %v, want [1 2]", repo.materialCalls)
+	}
+}
+
+func TestSelectorReportsNoAccountsWhenEveryCredentialIsStale(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.materialErrors = map[uint64]error{1: repository.ErrNotFound}
+	selector := NewSelector(repo, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	_, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionNoAccounts {
+		t.Fatalf("error = %v, want no accounts", err)
+	}
+}
+
+func TestSelectorPinnedCredentialDoesNotSwitchWhenMaterialIsStale(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.bases = append(repo.bases,
+		account.RoutingAccountBase{Credential: account.Credential{ID: 2, Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive}},
+	)
+	repo.materialErrors = map[uint64]error{1: repository.ErrNotFound}
+	selector := NewSelector(repo, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	_, err := selector.AcquirePinned(context.Background(), account.ProviderBuild, 1, 0, "model-a", "", true)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionNoAccounts {
+		t.Fatalf("error = %v, want no accounts", err)
+	}
+	if !reflect.DeepEqual(repo.materialCalls, []uint64{1}) {
+		t.Fatalf("material calls = %v, want pinned account only", repo.materialCalls)
+	}
+}
+
+func TestSelectorRebindsStickySessionAfterCredentialBecomesStale(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.bases = []account.RoutingAccountBase{
+		{Credential: account.Credential{ID: 1, Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive, Priority: 20}},
+		{Credential: account.Credential{ID: 2, Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive, Priority: 10}},
+	}
+	repo.materialErrors = map[uint64]error{1: repository.ErrNotFound}
+	sticky := memory.NewStickyStore()
+	affinity := "stale-session"
+	if err := sticky.Set(context.Background(), stickySessionKey(affinity), 1, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(repo, memory.NewConcurrencyLimiter(), sticky, nil, time.Hour, time.Second, time.Minute)
+
+	lease, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model-a", "", affinity, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	if lease.Credential.ID != 2 {
+		t.Fatalf("selected account = %d, want fallback account 2", lease.Credential.ID)
+	}
+	boundID, ok, err := sticky.Get(context.Background(), stickySessionKey(affinity), time.Now())
+	if err != nil || !ok || boundID != 2 {
+		t.Fatalf("sticky binding = %d, ok=%v, err=%v", boundID, ok, err)
+	}
+}
+
+func TestSelectorReleasesCapacityWhenCredentialHydrationFails(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	loadErr := errors.New("credential storage unavailable")
+	repo.materialErrors = map[uint64]error{1: loadErr}
+	limiter := memory.NewConcurrencyLimiter()
+	selector := NewSelector(repo, limiter, memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	_, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("error = %v, want credential storage error", err)
+	}
+	current, currentErr := limiter.Current(context.Background(), repository.AccountConcurrencyKey(1))
+	if currentErr != nil {
+		t.Fatal(currentErr)
+	}
+	if current != 0 {
+		t.Fatalf("current concurrency = %d, want released slot", current)
+	}
+}
+
+func TestSelectorRejectsCrossProviderCredentialMaterial(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.materials = map[uint64]account.CredentialMaterial{
+		1: {AccountID: 1, Provider: account.ProviderWeb, AuthType: account.AuthTypeSSO, EncryptedAccessToken: "wrong-provider-secret"},
+	}
+	limiter := memory.NewConcurrencyLimiter()
+	selector := NewSelector(repo, limiter, memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute)
+
+	_, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionNoAccounts {
+		t.Fatalf("error = %v, want no accounts", err)
+	}
+	current, currentErr := limiter.Current(context.Background(), repository.AccountConcurrencyKey(1))
+	if currentErr != nil {
+		t.Fatal(currentErr)
+	}
+	if current != 0 {
+		t.Fatalf("current concurrency = %d, want released slot", current)
 	}
 }
 

--- a/backend/internal/application/gateway/selector_segmented_active.go
+++ b/backend/internal/application/gateway/selector_segmented_active.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"time"
 
@@ -18,6 +19,12 @@ type segmentedSelectorActiveRequest struct {
 type segmentedSelectorCohortBucket struct {
 	cohort  segmentedSelectorCohort
 	indexes []int
+}
+
+type segmentedClaimResult struct {
+	lease          *accountLease
+	staleClaims    int
+	capacityMisses int
 }
 
 const segmentedWindowsBeforeFullFallback = 4
@@ -55,14 +62,18 @@ func (s *Selector) acquireSegmentedCandidates(ctx context.Context, values []acco
 				observeSegmentedActive(request.provider, "error", "full_fallback", startedAt, windowsScanned, candidatesScanned)
 				return nil, err
 			}
-			lease, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, "full_fallback")
+			claim, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, "full_fallback")
 			if err != nil {
 				observeSegmentedActive(request.provider, "error", "full_fallback", startedAt, windowsScanned, candidatesScanned)
 				return nil, err
 			}
-			if lease != nil {
+			if claim.lease != nil {
 				observeSegmentedActive(request.provider, "selected", "full_fallback", startedAt, windowsScanned, candidatesScanned)
-				return lease, nil
+				return claim.lease, nil
+			}
+			if claim.staleClaims > 0 && claim.capacityMisses == 0 {
+				observeSegmentedActive(request.provider, "unavailable", "full_fallback", startedAt, windowsScanned, candidatesScanned)
+				return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
 			}
 		} else {
 			concurrencyHints := make([]int, len(values))
@@ -81,14 +92,14 @@ func (s *Selector) acquireSegmentedCandidates(ctx context.Context, values []acco
 						return nil, err
 					}
 					stage := segmentedActiveSelectionStage(cohortIndex, windowOffset)
-					lease, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, stage)
+					claim, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, stage)
 					if err != nil {
 						observeSegmentedActive(request.provider, "error", "claim", startedAt, windowsScanned, candidatesScanned)
 						return nil, err
 					}
-					if lease != nil {
+					if claim.lease != nil {
 						observeSegmentedActive(request.provider, "selected", stage, startedAt, windowsScanned, candidatesScanned)
-						return lease, nil
+						return claim.lease, nil
 					}
 					if roundWindows >= segmentedWindowsBeforeFullFallback {
 						fallbackToFull = true
@@ -110,14 +121,18 @@ func (s *Selector) acquireSegmentedCandidates(ctx context.Context, values []acco
 					observeSegmentedActive(request.provider, "error", "full_fallback", startedAt, windowsScanned, candidatesScanned)
 					return nil, err
 				}
-				lease, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, "full_fallback")
+				claim, err := s.claimSegmentedPlan(ctx, plan, request.provider, quotaMode, "full_fallback")
 				if err != nil {
 					observeSegmentedActive(request.provider, "error", "full_fallback", startedAt, windowsScanned, candidatesScanned)
 					return nil, err
 				}
-				if lease != nil {
+				if claim.lease != nil {
 					observeSegmentedActive(request.provider, "selected", "full_fallback", startedAt, windowsScanned, candidatesScanned)
-					return lease, nil
+					return claim.lease, nil
+				}
+				if claim.staleClaims > 0 && claim.capacityMisses == 0 {
+					observeSegmentedActive(request.provider, "unavailable", "full_fallback", startedAt, windowsScanned, candidatesScanned)
+					return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
 				}
 			}
 			fullPlannerOnly = true
@@ -138,21 +153,28 @@ func (s *Selector) acquireSegmentedCandidates(ctx context.Context, values []acco
 	}
 }
 
-func (s *Selector) claimSegmentedPlan(ctx context.Context, plan *candidatePlan, provider account.Provider, quotaMode, stage string) (*accountLease, error) {
+func (s *Selector) claimSegmentedPlan(ctx context.Context, plan *candidatePlan, provider account.Provider, quotaMode, stage string) (segmentedClaimResult, error) {
+	result := segmentedClaimResult{}
 	for candidate, ok := plan.Next(); ok; candidate, ok = plan.Next() {
 		lease, err := s.claimAccountSlot(ctx, candidate.Credential)
 		if err != nil {
-			return nil, err
+			if errors.Is(err, errRoutingCredentialStale) {
+				result.staleClaims++
+				continue
+			}
+			return segmentedClaimResult{}, err
 		}
 		if lease == nil {
+			result.capacityMisses++
 			continue
 		}
 		lease.Billing = candidate.Billing
 		lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
 		lease.selectorObservation = &selectorLeaseObservation{provider: provider, stage: stage}
-		return lease, nil
+		result.lease = lease
+		return result, nil
 	}
-	return nil, nil
+	return result, nil
 }
 
 func segmentedCandidateCohorts(values []account.RoutingCandidate, indexes []int, now time.Time, tierOrder []account.WebTier, preferFreeBuild bool) []segmentedSelectorCohortBucket {

--- a/backend/internal/application/gateway/selector_segmented_active_test.go
+++ b/backend/internal/application/gateway/selector_segmented_active_test.go
@@ -252,6 +252,22 @@ func TestSegmentedActiveScansEveryCandidateBeforeSaturated(t *testing.T) {
 	}
 }
 
+func TestSegmentedActiveReportsNoAccountsWhenEveryCredentialIsStale(t *testing.T) {
+	selector := newSegmentedActiveTestSelector(8, newSegmentedSelectiveLimiter(), nil)
+	selector.UpdateSegmentedSelector(true, 8, 4)
+	repo := selector.accounts.(*layeredAccountRepository)
+	repo.materialErrors = make(map[uint64]error, 8)
+	for accountID := uint64(1); accountID <= 8; accountID++ {
+		repo.materialErrors[accountID] = repository.ErrNotFound
+	}
+
+	_, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model", "", "", nil, false)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionNoAccounts {
+		t.Fatalf("error = %v, want no accounts", err)
+	}
+}
+
 func TestSegmentedActiveFallsBackToFullPlannerAfterBoundedWindows(t *testing.T) {
 	limiter := newSegmentedSelectiveLimiter()
 	priorities := make(map[uint64]int)

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1057,14 +1057,15 @@ attemptLoop:
 			once.Do(func() {
 				successful := response.StatusCode >= 200 && response.StatusCode < 300 && errorCode == ""
 				lease.completeSelectorObservation(successful)
-				lease.Release()
 				budget := newFinalizationBudget(string(operation), string(route.Provider))
 				if isUpstreamStreamFailure(errorCode) {
-					_ = budget.run("account_health", finalizationHealthBudget, func(stageCtx context.Context) error {
-						s.selector.MarkFailure(stageCtx, credential, http.StatusBadGateway, 0)
-						return nil
-					})
+					if err := budget.run("account_health", finalizationHealthBudget, func(stageCtx context.Context) error {
+						return s.selector.MarkFailureAfterSuccess(stageCtx, credential, http.StatusBadGateway, 0)
+					}); err != nil {
+						s.logger.Warn("stream_failure_health_write_failed", "account_id", credential.ID, "provider", credential.Provider, "error", err)
+					}
 				}
+				lease.Release()
 				now := time.Now().UTC()
 				record := auditBase
 				record.AccountID = &accountID

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -273,20 +273,69 @@ func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 	}
 
 	adapter.resetAttempts()
+	expiredCooldown := time.Now().UTC().Add(-time.Minute)
+	for _, accountID := range []uint64{first.ID, second.ID} {
+		if err := accountRepo.UpdateHealth(ctx, accountID, 3, &expiredCooldown, "previous upstream failures", false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	selector.ApplyInvalidation(repository.InvalidationEvent{Kind: repository.InvalidationAccountStateChanged, Provider: account.ProviderBuild})
 	interrupted, err := service.CreateResponse(ctx, Input{RequestID: "req-stream-cut", ClientKey: clientKey, PublicModel: "grok-test", Body: []byte(`{"model":"grok-test"}`), PromptCacheSeed: "other-session"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, _ = io.ReadAll(interrupted.Body)
-	interrupted.Finalize(Usage{}, "", "upstream_stream_incomplete")
-	_ = interrupted.Body.Close()
+	healthBlocker := &blockingHealthAccountRepository{
+		AccountRepository: accountRepo, started: make(chan struct{}), release: make(chan struct{}),
+	}
+	selector.accounts = healthBlocker
+	finalized := make(chan struct{})
+	go func() {
+		interrupted.Finalize(Usage{}, "", "upstream_stream_incomplete")
+		close(finalized)
+	}()
+	select {
+	case <-healthBlocker.started:
+	case <-time.After(time.Second):
+		t.Fatal("stream failure health update did not start")
+	}
 	if len(adapter.attempts) != 1 {
 		t.Fatalf("interrupted attempts = %#v", adapter.attempts)
 	}
+	selectedAccountID := adapter.attempts[0]
+	if current, currentErr := concurrency.Current(ctx, accountConcurrencyKey(selectedAccountID)); currentErr != nil || current != 1 {
+		t.Fatalf("account lease was released before stream failure cooldown: current=%d err=%v", current, currentErr)
+	}
+	close(healthBlocker.release)
+	select {
+	case <-finalized:
+	case <-time.After(time.Second):
+		t.Fatal("stream failure finalization did not finish")
+	}
+	_ = interrupted.Body.Close()
 	interruptedAccount, err := accountRepo.Get(ctx, adapter.attempts[0])
 	if err != nil || interruptedAccount.FailureCount != 1 || interruptedAccount.CooldownUntil == nil {
 		t.Fatalf("interrupted account health = %#v, err=%v", interruptedAccount, err)
 	}
+}
+
+type blockingHealthAccountRepository struct {
+	repository.AccountRepository
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingHealthAccountRepository) UpdateHealth(ctx context.Context, id uint64, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error {
+	if !success {
+		r.once.Do(func() { close(r.started) })
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return r.AccountRepository.UpdateHealth(ctx, id, failureCount, cooldownUntil, lastError, success)
 }
 
 func TestRoutingAttemptPolicy(t *testing.T) {

--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -301,6 +301,12 @@ func (s *Service) runVideoJob(parent context.Context, job media.Job, route model
 		return
 	}
 	defer lease.Release()
+	credential, err := s.accounts.EnsureCredential(ctx, lease.Credential, false)
+	if err != nil {
+		s.failVideoJob(parent, job, "account_unavailable", err)
+		return
+	}
+	lease.Credential = credential
 	adapter, ok := s.providers.Videos(route.Provider)
 	if !ok {
 		s.failVideoJob(parent, job, "provider_unavailable", ErrNoAvailableAccount)

--- a/backend/internal/domain/account/account.go
+++ b/backend/internal/domain/account/account.go
@@ -197,6 +197,46 @@ type Credential struct {
 	UpdatedAt          time.Time
 }
 
+// CredentialMaterial contains the encrypted provider secrets and refresh
+// metadata loaded only after routing selects an account.
+type CredentialMaterial struct {
+	AccountID                 uint64
+	Provider                  Provider
+	AuthType                  AuthType
+	OIDCClientID              string
+	EncryptedAccessToken      string
+	EncryptedRefreshToken     string
+	EncryptedCloudflareCookie string
+	ExpiresAt                 time.Time
+	RefreshDueAt              *time.Time
+	LastRefreshAt             *time.Time
+	RefreshFailureCount       int
+	LastRefreshErrorCode      string
+	RefreshPermanent          bool
+	UpdatedAt                 time.Time
+}
+
+// ApplyTo merges credential material into the matching routing account.
+// A mismatch leaves the value unchanged so callers cannot attach one
+// account's secrets to another account.
+func (m CredentialMaterial) ApplyTo(value Credential) (Credential, bool) {
+	if m.AccountID == 0 || value.ID != m.AccountID || m.Provider == "" || value.Provider != m.Provider {
+		return value, false
+	}
+	value.AuthType = m.AuthType
+	value.OIDCClientID = m.OIDCClientID
+	value.EncryptedAccessToken = m.EncryptedAccessToken
+	value.EncryptedRefreshToken = m.EncryptedRefreshToken
+	value.EncryptedCloudflareCookie = m.EncryptedCloudflareCookie
+	value.ExpiresAt = m.ExpiresAt
+	value.RefreshDueAt = m.RefreshDueAt
+	value.LastRefreshAt = m.LastRefreshAt
+	value.RefreshFailureCount = m.RefreshFailureCount
+	value.LastRefreshErrorCode = m.LastRefreshErrorCode
+	value.RefreshPermanent = m.RefreshPermanent
+	return value, true
+}
+
 // CredentialRefreshDueAt 将账号稳定地分散到到期前 5~8 分钟，避免同批导入账号同时刷新。
 func CredentialRefreshDueAt(accountID uint64, expiresAt time.Time) time.Time {
 	if expiresAt.IsZero() {
@@ -353,7 +393,7 @@ type RoutingCandidate struct {
 }
 
 // RoutingAccountBase contains provider-level routing state reusable across
-// models. Credentials remain encrypted until the provider adapter uses them.
+// models. Credential material is hydrated only after an account is selected.
 type RoutingAccountBase struct {
 	Credential    Credential
 	Billing       *Billing

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -196,7 +196,7 @@ func (r *AccountRepository) Summarize(ctx context.Context, now time.Time) ([]rep
 
 // ListRoutingCandidates 批量加载账号、额度、恢复状态和目标模型能力，避免推理热路径按账号逐条查询。
 func (r *AccountRepository) ListRoutingCandidates(ctx context.Context, provider account.Provider, modelRouteID uint64, upstreamModel, quotaMode string) ([]account.RoutingCandidate, error) {
-	values, err := r.ListEnabled(ctx, provider)
+	values, err := r.listRoutingCredentials(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (r *AccountRepository) ListRoutingCandidates(ctx context.Context, provider 
 	for _, value := range values {
 		ids = append(ids, value.ID)
 	}
-	billings, err := r.GetBillings(ctx, ids)
+	billings, err := r.getRoutingBillings(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -231,24 +231,9 @@ func (r *AccountRepository) ListRoutingCandidates(ctx context.Context, provider 
 	if err != nil {
 		return nil, err
 	}
-	quotaWindows := make(map[uint64]account.QuotaWindow, len(ids))
-	if len(ids) > 0 && (provider == account.ProviderWeb || quotaMode != "") {
-		var rows []quotaWindowModel
-		modes := make([]string, 0, 2)
-		if provider == account.ProviderWeb {
-			modes = append(modes, "weekly")
-		}
-		if quotaMode != "" {
-			modes = append(modes, quotaMode)
-		}
-		if err := r.db.db.WithContext(ctx).Where("account_id IN ? AND mode IN ?", ids, modes).Order("CASE WHEN mode = 'weekly' THEN 0 ELSE 1 END").Find(&rows).Error; err != nil {
-			return nil, err
-		}
-		for _, row := range rows {
-			if _, exists := quotaWindows[row.AccountID]; !exists {
-				quotaWindows[row.AccountID] = toQuotaWindowDomain(row)
-			}
-		}
+	quotaWindows, err := r.getRoutingQuotaWindows(ctx, ids, provider, quotaMode)
+	if err != nil {
+		return nil, err
 	}
 	known := make(map[uint64]bool, len(ids))
 	supported := make(map[uint64]bool, len(ids))
@@ -325,7 +310,7 @@ func (r *AccountRepository) ListRoutingCandidates(ctx context.Context, provider 
 }
 
 func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provider account.Provider, quotaMode string) ([]account.RoutingAccountBase, error) {
-	values, err := r.ListEnabled(ctx, provider)
+	values, err := r.listRoutingCredentials(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +318,7 @@ func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provide
 	for _, value := range values {
 		ids = append(ids, value.ID)
 	}
-	billings, err := r.GetBillings(ctx, ids)
+	billings, err := r.getRoutingBillings(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -341,24 +326,9 @@ func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provide
 	if err != nil {
 		return nil, err
 	}
-	quotaWindows := make(map[uint64]account.QuotaWindow, len(ids))
-	if len(ids) > 0 && (provider == account.ProviderWeb || quotaMode != "") {
-		modes := make([]string, 0, 2)
-		if provider == account.ProviderWeb {
-			modes = append(modes, "weekly")
-		}
-		if quotaMode != "" {
-			modes = append(modes, quotaMode)
-		}
-		var rows []quotaWindowModel
-		if err := r.db.db.WithContext(ctx).Where("account_id IN ? AND mode IN ?", ids, modes).Order("CASE WHEN mode = 'weekly' THEN 0 ELSE 1 END").Find(&rows).Error; err != nil {
-			return nil, err
-		}
-		for _, row := range rows {
-			if _, exists := quotaWindows[row.AccountID]; !exists {
-				quotaWindows[row.AccountID] = toQuotaWindowDomain(row)
-			}
-		}
+	quotaWindows, err := r.getRoutingQuotaWindows(ctx, ids, provider, quotaMode)
+	if err != nil {
+		return nil, err
 	}
 	result := make([]account.RoutingAccountBase, 0, len(values))
 	for _, value := range values {
@@ -373,6 +343,93 @@ func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provide
 			base.QuotaWindow = &window
 		}
 		result = append(result, base)
+	}
+	return result, nil
+}
+
+// listRoutingCredentials loads only the account state required to decide which
+// account to use. Provider secrets deliberately stay in account_credentials
+// until a selected account is hydrated for the upstream call.
+func (r *AccountRepository) listRoutingCredentials(ctx context.Context, provider account.Provider) ([]account.Credential, error) {
+	var rows []accountModel
+	err := r.db.db.WithContext(ctx).
+		Preload("Credential", func(query *gorm.DB) *gorm.DB {
+			return query.Select(routingCredentialMetadataColumns)
+		}).
+		Preload("WebProfile").
+		Where("provider = ? AND enabled = ? AND auth_status = ?", provider, true, account.AuthStatusActive).
+		Order("priority DESC, id ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	values := make([]account.Credential, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, toAccountDomain(row))
+	}
+	if err := r.attachRoutingEgressIdentities(ctx, provider, values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// routingCredentialMetadataColumns contains all credential fields used for
+// routing and execution decisions, but deliberately excludes the encrypted
+// access token, refresh token, and Cloudflare cookie.
+var routingCredentialMetadataColumns = []string{
+	"account_id", "auth_type", "client_id", "expires_at", "refresh_due_at", "last_refresh_at",
+	"refresh_failures", "last_refresh_error", "refresh_permanent", "updated_at",
+}
+
+var routingBillingColumns = []string{
+	"account_id", "plan_code", "plan_name", "monthly_limit", "used", "on_demand_cap", "on_demand_used", "prepaid_balance",
+	"credit_usage_percent", "is_unified_billing_user", "on_demand_enabled", "top_up_method", "usage_period_type",
+	"usage_period_start", "usage_period_end", "billing_period_start", "billing_period_end", "synced_at",
+}
+
+func (r *AccountRepository) getRoutingBillings(ctx context.Context, accountIDs []uint64) (map[uint64]account.Billing, error) {
+	result := make(map[uint64]account.Billing, len(accountIDs))
+	if len(accountIDs) == 0 {
+		return result, nil
+	}
+	var rows []billingModel
+	if err := r.db.db.WithContext(ctx).Select(routingBillingColumns).Where("account_id IN ?", accountIDs).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.AccountID] = toRoutingBillingDomain(row)
+	}
+	return result, nil
+}
+
+var routingQuotaWindowColumns = []string{
+	"account_id", "mode", "remaining", "total", "usage_percent", "window_seconds", "reset_at", "synced_at", "source", "updated_at",
+}
+
+func (r *AccountRepository) getRoutingQuotaWindows(ctx context.Context, accountIDs []uint64, provider account.Provider, quotaMode string) (map[uint64]account.QuotaWindow, error) {
+	result := make(map[uint64]account.QuotaWindow, len(accountIDs))
+	if len(accountIDs) == 0 || (provider != account.ProviderWeb && quotaMode == "") {
+		return result, nil
+	}
+	modes := make([]string, 0, 2)
+	if provider == account.ProviderWeb {
+		modes = append(modes, "weekly")
+	}
+	if quotaMode != "" {
+		modes = append(modes, quotaMode)
+	}
+	var rows []quotaWindowModel
+	if err := r.db.db.WithContext(ctx).
+		Select(routingQuotaWindowColumns).
+		Where("account_id IN ? AND mode IN ?", accountIDs, modes).
+		Order("CASE WHEN mode = 'weekly' THEN 0 ELSE 1 END").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if _, exists := result[row.AccountID]; !exists {
+			result[row.AccountID] = toRoutingQuotaWindowDomain(row)
+		}
 	}
 	return result, nil
 }
@@ -617,6 +674,22 @@ func (r *AccountRepository) Get(ctx context.Context, id uint64) (account.Credent
 		return account.Credential{}, err
 	}
 	return values[0], nil
+}
+
+// GetCredentialMaterial hydrates the encrypted provider data for one account
+// after routing has selected it. Routing candidate queries intentionally never
+// load these encrypted columns.
+func (r *AccountRepository) GetCredentialMaterial(ctx context.Context, accountID uint64, provider account.Provider) (account.CredentialMaterial, error) {
+	var row accountCredentialModel
+	if err := r.db.db.WithContext(ctx).
+		Table("account_credentials AS credential").
+		Select("credential.*").
+		Joins("JOIN provider_accounts AS account ON account.id = credential.account_id").
+		Where("credential.account_id = ? AND account.provider = ? AND account.enabled = TRUE AND account.auth_status = ?", accountID, provider, account.AuthStatusActive).
+		Take(&row).Error; err != nil {
+		return account.CredentialMaterial{}, mapError(err)
+	}
+	return toCredentialMaterialDomain(row, provider), nil
 }
 
 func (r *AccountRepository) LinkWebToBuild(ctx context.Context, webAccountID, buildAccountID uint64) error {
@@ -2068,13 +2141,19 @@ func (r *AccountRepository) ListStaleWebQuotaAccountIDs(ctx context.Context, bef
 func toQuotaWindowDomain(row quotaWindowModel) account.QuotaWindow {
 	var serializedBreakdown []quotaBreakdownJSON
 	_ = json.Unmarshal([]byte(row.BreakdownJSON), &serializedBreakdown)
+	result := toRoutingQuotaWindowDomain(row)
 	breakdown := make([]account.QuotaBreakdown, 0, len(serializedBreakdown))
 	for _, item := range serializedBreakdown {
 		breakdown = append(breakdown, account.QuotaBreakdown{ProductCode: item.ProductCode, UsagePercent: item.UsagePercent})
 	}
+	result.Breakdown = breakdown
+	return result
+}
+
+func toRoutingQuotaWindowDomain(row quotaWindowModel) account.QuotaWindow {
 	return account.QuotaWindow{
 		AccountID: row.AccountID, Mode: row.Mode, Remaining: row.Remaining, Total: row.Total,
-		UsagePercent: row.UsagePercent, Breakdown: breakdown, WindowSeconds: row.WindowSeconds,
+		UsagePercent: row.UsagePercent, WindowSeconds: row.WindowSeconds,
 		ResetAt: row.ResetAt, SyncedAt: row.SyncedAt, Source: account.QuotaSource(row.Source), UpdatedAt: row.UpdatedAt,
 	}
 }

--- a/backend/internal/infra/persistence/relational/mapping.go
+++ b/backend/internal/infra/persistence/relational/mapping.go
@@ -87,6 +87,21 @@ func toAccountDomain(value accountModel) account.Credential {
 	}
 }
 
+func toCredentialMaterialDomain(value accountCredentialModel, provider account.Provider) account.CredentialMaterial {
+	var expiresAt time.Time
+	if value.ExpiresAt != nil {
+		expiresAt = *value.ExpiresAt
+	}
+	return account.CredentialMaterial{
+		AccountID: value.AccountID, Provider: provider, AuthType: account.AuthType(value.AuthType), OIDCClientID: value.ClientID,
+		EncryptedAccessToken: value.EncryptedPrimary, EncryptedRefreshToken: value.EncryptedRefresh,
+		EncryptedCloudflareCookie: value.EncryptedCloudflareCookie, ExpiresAt: expiresAt,
+		RefreshDueAt: value.RefreshDueAt, LastRefreshAt: value.LastRefreshAt,
+		RefreshFailureCount: value.RefreshFailures, LastRefreshErrorCode: value.LastRefreshError,
+		RefreshPermanent: value.RefreshPermanent, UpdatedAt: value.UpdatedAt,
+	}
+}
+
 func fromAccountDomain(value account.Credential) accountModel {
 	// entitlement、推理地址与 XAI 回退标记仅对 grok_build 有意义。
 	buildAPIFallback := value.BuildAPIFallback && value.Provider == account.ProviderBuild
@@ -181,7 +196,13 @@ func accountIdentity(value account.Credential) string {
 func toBillingDomain(value billingModel) account.Billing {
 	var history []account.BillingHistoryEntry
 	_ = json.Unmarshal([]byte(value.HistoryJSON), &history)
-	return account.Billing{AccountID: value.AccountID, PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, OnDemandEnabled: value.OnDemandEnabled, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, History: history, SyncedAt: value.SyncedAt}
+	result := toRoutingBillingDomain(value)
+	result.History = history
+	return result
+}
+
+func toRoutingBillingDomain(value billingModel) account.Billing {
+	return account.Billing{AccountID: value.AccountID, PlanCode: value.PlanCode, PlanName: value.PlanName, MonthlyLimit: value.MonthlyLimit, Used: value.Used, OnDemandCap: value.OnDemandCap, OnDemandUsed: value.OnDemandUsed, PrepaidBalance: value.PrepaidBalance, CreditUsagePercent: value.CreditUsagePercent, IsUnifiedBillingUser: value.IsUnifiedBillingUser, OnDemandEnabled: value.OnDemandEnabled, TopUpMethod: value.TopUpMethod, UsagePeriodType: value.UsagePeriodType, UsagePeriodStart: value.UsagePeriodStart, UsagePeriodEnd: value.UsagePeriodEnd, BillingPeriodStart: value.BillingPeriodStart, BillingPeriodEnd: value.BillingPeriodEnd, SyncedAt: value.SyncedAt}
 }
 
 func toModelDomain(value modelRouteModel) model.Route {

--- a/backend/internal/infra/persistence/relational/postgres_integration_test.go
+++ b/backend/internal/infra/persistence/relational/postgres_integration_test.go
@@ -792,6 +792,102 @@ func assertPostgresAuditSettlement(t *testing.T, ctx context.Context, database *
 	}
 }
 
+func TestPostgresRoutingProjectionAndCredentialHydration(t *testing.T) {
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_DSN is not configured")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	database, err := OpenPostgres(ctx, dsn, 10, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Errorf("close PostgreSQL routing projection database: %v", err)
+		}
+	})
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	accounts := NewAccountRepository(database)
+	now := time.Now().UTC().Truncate(time.Second)
+	unique := strconv.FormatInt(now.UnixNano(), 10)
+	created, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderWeb, AuthType: account.AuthTypeSSO, Name: "postgres routing projection",
+		SourceKey: "postgres-routing-projection-" + unique, OIDCClientID: "postgres-client",
+		EncryptedAccessToken: "postgres-access-secret", EncryptedCloudflareCookie: "postgres-cookie-secret",
+		ExpiresAt: now.Add(time.Hour), Enabled: true, AuthStatus: account.AuthStatusActive,
+		Priority: 7, MaxConcurrent: 3, MinimumRemaining: 1.5, WebTier: account.WebTierSuper,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if err := accounts.Delete(cleanupCtx, created.ID); err != nil && !errors.Is(err, repository.ErrNotFound) {
+			t.Errorf("delete PostgreSQL routing projection account: %v", err)
+		}
+	})
+	if err := accounts.SaveBilling(ctx, account.Billing{
+		AccountID: created.ID, PlanCode: "super", MonthlyLimit: 100, Used: 12, SyncedAt: now,
+		History: []account.BillingHistoryEntry{{Year: 2026, Month: 7, IncludedUsed: 12}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resetAt := now.Add(time.Hour)
+	if err := accounts.SaveQuotaWindows(ctx, created.ID, account.WebTierSuper, now, []account.QuotaWindow{{
+		AccountID: created.ID, Mode: "weekly", Remaining: 10, Total: 20, UsagePercent: 50,
+		Breakdown:     []account.QuotaBreakdown{{ProductCode: account.QuotaProductChat, UsagePercent: 50}},
+		WindowSeconds: 3600, ResetAt: &resetAt, SyncedAt: &now, Source: account.QuotaSourceUpstream,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	bases, err := accounts.ListRoutingAccountBases(ctx, account.ProviderWeb, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projected *account.RoutingAccountBase
+	for index := range bases {
+		if bases[index].Credential.ID == created.ID {
+			projected = &bases[index]
+			break
+		}
+	}
+	if projected == nil {
+		t.Fatalf("routing projection account %d not found", created.ID)
+	}
+	assertRoutingProjection(t, projected.Credential, created)
+	if projected.Billing == nil || projected.Billing.PlanCode != "super" || len(projected.Billing.History) != 0 {
+		t.Fatalf("routing billing = %#v, want scalar billing without history", projected.Billing)
+	}
+	if projected.QuotaWindow == nil || projected.QuotaWindow.Remaining != 10 || len(projected.QuotaWindow.Breakdown) != 0 {
+		t.Fatalf("routing quota = %#v, want scalar quota without breakdown", projected.QuotaWindow)
+	}
+
+	material, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderWeb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if material.Provider != account.ProviderWeb || material.EncryptedAccessToken != "postgres-access-secret" || material.EncryptedCloudflareCookie != "postgres-cookie-secret" {
+		t.Fatalf("credential material = %#v", material)
+	}
+	if _, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderBuild); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("cross-provider credential error = %v, want ErrNotFound", err)
+	}
+	disabled := false
+	if _, err := accounts.UpdateMany(ctx, []uint64{created.ID}, repository.AccountUpdates{Enabled: &disabled}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderWeb); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("disabled credential error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestPostgresP1RouteLookupAndBoundedResponseCleanup(t *testing.T) {
 	dsn := os.Getenv("TEST_POSTGRES_DSN")
 	if dsn == "" {

--- a/backend/internal/infra/persistence/relational/routing_projection_benchmark_test.go
+++ b/backend/internal/infra/persistence/relational/routing_projection_benchmark_test.go
@@ -1,0 +1,111 @@
+package relational
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+)
+
+func BenchmarkRoutingAccountBaseProjectionWithLargePayloads(b *testing.B) {
+	const accountCount = 300
+	b.StopTimer()
+	ctx := context.Background()
+	database, err := OpenSQLite(ctx, filepath.Join(b.TempDir(), "routing-payload-benchmark.db"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		b.Fatal(err)
+	}
+	repository := NewAccountRepository(database)
+	secret := strings.Repeat("s", 32<<10)
+	credentials := make([]account.Credential, accountCount)
+	for index := range credentials {
+		credentials[index] = account.Credential{
+			Provider: account.ProviderWeb, AuthType: account.AuthTypeSSO,
+			Name: fmt.Sprintf("payload-%04d", index), SourceKey: fmt.Sprintf("payload-source-%04d", index),
+			EncryptedAccessToken: secret, EncryptedCloudflareCookie: secret,
+			Enabled: true, AuthStatus: account.AuthStatusActive,
+		}
+	}
+	created, err := repository.UpsertManyByIdentity(ctx, credentials)
+	if err != nil {
+		b.Fatal(err)
+	}
+	now := time.Now().UTC()
+	history := make([]account.BillingHistoryEntry, 256)
+	period := strings.Repeat("p", 64)
+	for index := range history {
+		history[index] = account.BillingHistoryEntry{Year: 2026, Month: index%12 + 1, PeriodType: period, PeriodStart: period, PeriodEnd: period}
+	}
+	breakdown := make([]account.QuotaBreakdown, 128)
+	for index := range breakdown {
+		breakdown[index] = account.QuotaBreakdown{ProductCode: index % 7, UsagePercent: 50}
+	}
+	resetAt := now.Add(time.Hour)
+	for _, credential := range created {
+		if err := repository.SaveBilling(ctx, account.Billing{AccountID: credential.ID, PlanName: "SuperGrok", MonthlyLimit: 100, History: history, SyncedAt: now}); err != nil {
+			b.Fatal(err)
+		}
+		if err := repository.SaveQuotaWindows(ctx, credential.ID, account.WebTierSuper, now, []account.QuotaWindow{{
+			AccountID: credential.ID, Mode: "weekly", Remaining: 10, Total: 20,
+			Breakdown: breakdown, ResetAt: &resetAt, SyncedAt: &now, Source: account.QuotaSourceUpstream,
+		}}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(accountCount, "accounts")
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for b.Loop() {
+		values, loadErr := repository.ListRoutingAccountBases(ctx, account.ProviderWeb, "")
+		if loadErr != nil {
+			b.Fatal(loadErr)
+		}
+		if len(values) != accountCount {
+			b.Fatalf("routing bases = %d, want %d", len(values), accountCount)
+		}
+	}
+}
+
+func BenchmarkSelectedCredentialHydration(b *testing.B) {
+	b.StopTimer()
+	ctx := context.Background()
+	database, err := OpenSQLite(ctx, filepath.Join(b.TempDir(), "credential-hydration-benchmark.db"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		b.Fatal(err)
+	}
+	repository := NewAccountRepository(database)
+	created, _, err := repository.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, AuthType: account.AuthTypeOAuth,
+		Name: "selected", SourceKey: "selected", OIDCClientID: "client-id",
+		EncryptedAccessToken: strings.Repeat("a", 32<<10), EncryptedRefreshToken: strings.Repeat("r", 32<<10),
+		Enabled: true, AuthStatus: account.AuthStatusActive,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for b.Loop() {
+		material, loadErr := repository.GetCredentialMaterial(ctx, created.ID, account.ProviderBuild)
+		if loadErr != nil {
+			b.Fatal(loadErr)
+		}
+		if len(material.EncryptedAccessToken) != 32<<10 {
+			b.Fatalf("access token bytes = %d", len(material.EncryptedAccessToken))
+		}
+	}
+}

--- a/backend/internal/infra/persistence/relational/routing_projection_test.go
+++ b/backend/internal/infra/persistence/relational/routing_projection_test.go
@@ -1,0 +1,167 @@
+package relational
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/repository"
+)
+
+func TestRoutingProjectionLeavesSecretsAndLargeJSONOutOfCandidateLoad(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenSQLite(ctx, filepath.Join(t.TempDir(), "routing-projection.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := NewAccountRepository(database)
+	now := time.Now().UTC().Truncate(time.Second)
+	created, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderWeb, AuthType: account.AuthTypeSSO, Name: "routing projection", Email: "route@example.test",
+		SourceKey: "routing:projection", OIDCClientID: "client-id", EncryptedAccessToken: "access-secret",
+		EncryptedCloudflareCookie: "cookie-secret", ExpiresAt: now.Add(time.Hour), Enabled: true,
+		AuthStatus: account.AuthStatusActive, Priority: 9, MaxConcurrent: 3, MinimumRemaining: 1.5,
+		WebTier: account.WebTierSuper,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := accounts.SaveBilling(ctx, account.Billing{
+		AccountID: created.ID, PlanCode: "super", MonthlyLimit: 100, Used: 12, SyncedAt: now,
+		History: []account.BillingHistoryEntry{{Year: 2026, Month: 7, IncludedUsed: 12}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resetAt := now.Add(time.Hour)
+	if err := accounts.SaveQuotaWindows(ctx, created.ID, account.WebTierSuper, now, []account.QuotaWindow{{
+		AccountID: created.ID, Mode: "weekly", Remaining: 10, Total: 20, UsagePercent: 50,
+		Breakdown:     []account.QuotaBreakdown{{ProductCode: account.QuotaProductChat, UsagePercent: 50}},
+		WindowSeconds: 3600, ResetAt: &resetAt, SyncedAt: &now, Source: account.QuotaSourceUpstream,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	bases, err := accounts.ListRoutingAccountBases(ctx, account.ProviderWeb, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bases) != 1 {
+		t.Fatalf("routing bases = %d, want 1", len(bases))
+	}
+	assertRoutingProjection(t, bases[0].Credential, created)
+	if bases[0].Billing == nil || bases[0].Billing.PlanCode != "super" || len(bases[0].Billing.History) != 0 {
+		t.Fatalf("routing billing = %#v, want scalar billing without history", bases[0].Billing)
+	}
+	if bases[0].QuotaWindow == nil || bases[0].QuotaWindow.Remaining != 10 || len(bases[0].QuotaWindow.Breakdown) != 0 {
+		t.Fatalf("routing quota = %#v, want scalar quota without breakdown", bases[0].QuotaWindow)
+	}
+
+	candidates, err := accounts.ListRoutingCandidates(ctx, account.ProviderWeb, 0, "grok-test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("routing candidates = %d, want 1", len(candidates))
+	}
+	assertRoutingProjection(t, candidates[0].Credential, created)
+	if candidates[0].Billing == nil || len(candidates[0].Billing.History) != 0 || candidates[0].QuotaWindow == nil || len(candidates[0].QuotaWindow.Breakdown) != 0 {
+		t.Fatalf("routing candidate loaded large payloads: %#v", candidates[0])
+	}
+
+	// Management reads retain their complete representations.
+	managed, err := accounts.ListEnabled(ctx, account.ProviderWeb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(managed) != 1 || managed[0].EncryptedAccessToken != "access-secret" || managed[0].EncryptedCloudflareCookie != "cookie-secret" {
+		t.Fatalf("management credentials = %#v", managed)
+	}
+	billing, err := accounts.GetBilling(ctx, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(billing.History) != 1 {
+		t.Fatalf("management billing history = %#v, want one entry", billing.History)
+	}
+	windows, err := accounts.GetQuotaWindows(ctx, []uint64{created.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(windows[created.ID]) != 1 || len(windows[created.ID][0].Breakdown) != 1 {
+		t.Fatalf("management quota windows = %#v, want breakdown", windows)
+	}
+}
+
+func TestGetCredentialMaterialHydratesOneAccountAndMapsNotFound(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenSQLite(ctx, filepath.Join(t.TempDir(), "credential-material.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := NewAccountRepository(database)
+	now := time.Now().UTC().Truncate(time.Second)
+	created, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, AuthType: account.AuthTypeOAuth, Name: "hydrate", SourceKey: "credential:material",
+		OIDCClientID: "client-id", EncryptedAccessToken: "access-secret", EncryptedRefreshToken: "refresh-secret",
+		EncryptedCloudflareCookie: "cookie-secret", ExpiresAt: now.Add(time.Hour), Enabled: true, AuthStatus: account.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	material, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderBuild)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if material.AccountID != created.ID || material.Provider != account.ProviderBuild || material.AuthType != account.AuthTypeOAuth || material.OIDCClientID != "client-id" ||
+		material.EncryptedAccessToken != "access-secret" || material.EncryptedRefreshToken != "refresh-secret" || material.EncryptedCloudflareCookie != "cookie-secret" ||
+		!material.ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("credential material = %#v", material)
+	}
+	hydrated, ok := material.ApplyTo(account.Credential{ID: created.ID, Provider: account.ProviderBuild})
+	if !ok || hydrated.EncryptedAccessToken != "access-secret" || hydrated.EncryptedRefreshToken != "refresh-secret" {
+		t.Fatalf("hydrated credential = %#v, ok=%v", hydrated, ok)
+	}
+	if _, ok := material.ApplyTo(account.Credential{ID: created.ID + 1}); ok {
+		t.Fatal("credential material applied to a different account")
+	}
+	if _, ok := material.ApplyTo(account.Credential{ID: created.ID, Provider: account.ProviderWeb}); ok {
+		t.Fatal("credential material applied to a different provider")
+	}
+	if _, err := accounts.GetCredentialMaterial(ctx, created.ID+1, account.ProviderBuild); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("missing credential material error = %v, want ErrNotFound", err)
+	}
+	if _, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderWeb); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("cross-provider credential material error = %v, want ErrNotFound", err)
+	}
+	disabled := false
+	if _, err := accounts.UpdateMany(ctx, []uint64{created.ID}, repository.AccountUpdates{Enabled: &disabled}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := accounts.GetCredentialMaterial(ctx, created.ID, account.ProviderBuild); !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("disabled credential material error = %v, want ErrNotFound", err)
+	}
+}
+
+func assertRoutingProjection(t *testing.T, value, created account.Credential) {
+	t.Helper()
+	if value.ID != created.ID || value.Provider != created.Provider || value.Name != created.Name || value.SourceKey != created.SourceKey ||
+		value.Priority != created.Priority || value.MaxConcurrent != created.MaxConcurrent || value.MinimumRemaining != created.MinimumRemaining || value.WebTier != account.WebTierSuper ||
+		value.AuthType != created.AuthType || value.OIDCClientID != created.OIDCClientID || !value.ExpiresAt.Equal(created.ExpiresAt) {
+		t.Fatalf("routing metadata = %#v", value)
+	}
+	if value.EncryptedAccessToken != "" || value.EncryptedRefreshToken != "" || value.EncryptedCloudflareCookie != "" {
+		t.Fatalf("routing projection includes credential material: %#v", value)
+	}
+}

--- a/backend/internal/infra/runtime/redis/store.go
+++ b/backend/internal/infra/runtime/redis/store.go
@@ -14,17 +14,22 @@ import (
 	"time"
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/pkg/perfmetrics"
 	"github.com/chenyme/grok2api/backend/internal/repository"
 	redisclient "github.com/redis/go-redis/v9"
 )
 
 const (
-	concurrencyLeaseGrace       = time.Minute
-	maxStickyBindingsPerAccount = 10000
-	maxDeviceSessions           = 1000
-	maxQuotaRecoveryEvents      = 100000
-	maxQuotaRefreshDirty        = 100000
-	observedModelStateTTL       = 30 * time.Minute
+	concurrencyLeaseGrace                = time.Minute
+	concurrencyReleaseRetryInterval      = 250 * time.Millisecond
+	concurrencyReleaseRetryTimeout       = 3 * time.Second
+	concurrencyReleaseRetryBatchSize     = 512
+	concurrencyReleaseRetryQueueCapacity = 16384
+	maxStickyBindingsPerAccount          = 10000
+	maxDeviceSessions                    = 1000
+	maxQuotaRecoveryEvents               = 100000
+	maxQuotaRefreshDirty                 = 100000
+	observedModelStateTTL                = 30 * time.Minute
 	// At the per-account cap, one pipeline processes at most 80,000 members.
 	stickyDeletePipelineSize = 8
 )
@@ -276,9 +281,20 @@ type Config struct {
 
 // Store 实现多实例共享的限流、并发租约、粘滞路由、Device OAuth 会话和分布式锁。
 type Store struct {
-	client           *redisclient.Client
-	prefix           string
-	concurrencyLease time.Duration
+	client                  *redisclient.Client
+	prefix                  string
+	concurrencyLease        time.Duration
+	concurrencyReleaseQueue chan concurrencyReleaseRetry
+	concurrencyReleaseStop  chan struct{}
+	concurrencyReleaseDone  chan struct{}
+	closeOnce               sync.Once
+	closeErr                error
+}
+
+type concurrencyReleaseRetry struct {
+	redisKey  string
+	token     string
+	expiresAt time.Time
 }
 
 // Open 连接 Redis；选中的 Redis 不可用时直接返回启动错误。
@@ -296,10 +312,23 @@ func Open(ctx context.Context, cfg Config) (*Store, error) {
 	if lease <= 0 {
 		lease = 3 * time.Hour
 	}
-	return &Store{client: client, prefix: cfg.KeyPrefix, concurrencyLease: lease}, nil
+	store := &Store{
+		client: client, prefix: cfg.KeyPrefix, concurrencyLease: lease,
+		concurrencyReleaseQueue: make(chan concurrencyReleaseRetry, concurrencyReleaseRetryQueueCapacity),
+		concurrencyReleaseStop:  make(chan struct{}), concurrencyReleaseDone: make(chan struct{}),
+	}
+	go store.runConcurrencyReleaseRetries()
+	return store, nil
 }
 
-func (s *Store) Close() error { return s.client.Close() }
+func (s *Store) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.concurrencyReleaseStop)
+		s.closeErr = s.client.Close()
+		<-s.concurrencyReleaseDone
+	})
+	return s.closeErr
+}
 
 func (s *Store) Ping(ctx context.Context) error { return s.client.Ping(ctx).Err() }
 
@@ -438,11 +467,102 @@ func (s *Store) acquireConcurrency(ctx context.Context, key string, limit int) (
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			releaseCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			releaseCtx, cancel := context.WithTimeout(context.Background(), concurrencyReleaseRetryTimeout)
 			defer cancel()
-			_ = releaseLeaseScript.Run(releaseCtx, s.client, []string{redisKey}, token).Err()
+			if err := releaseLeaseScript.Run(releaseCtx, s.client, []string{redisKey}, token).Err(); err != nil {
+				s.enqueueConcurrencyReleaseRetry(concurrencyReleaseRetry{redisKey: redisKey, token: token, expiresAt: expiresAt})
+			}
 		})
 	}, true, nil
+}
+
+func (s *Store) enqueueConcurrencyReleaseRetry(value concurrencyReleaseRetry) {
+	select {
+	case <-s.concurrencyReleaseStop:
+		observeConcurrencyRelease("shutdown", 1)
+		return
+	default:
+	}
+	select {
+	case s.concurrencyReleaseQueue <- value:
+		observeConcurrencyRelease("queued", 1)
+	case <-s.concurrencyReleaseStop:
+		observeConcurrencyRelease("shutdown", 1)
+	default:
+		observeConcurrencyRelease("dropped", 1)
+	}
+}
+
+func (s *Store) runConcurrencyReleaseRetries() {
+	defer close(s.concurrencyReleaseDone)
+	ticker := time.NewTicker(concurrencyReleaseRetryInterval)
+	defer ticker.Stop()
+	pending := make(map[string]concurrencyReleaseRetry)
+	for {
+		select {
+		case value := <-s.concurrencyReleaseQueue:
+			pending[value.token] = value
+		case <-ticker.C:
+			s.retryConcurrencyReleases(pending)
+		case <-s.concurrencyReleaseStop:
+			observeConcurrencyRelease("shutdown", len(pending)+len(s.concurrencyReleaseQueue))
+			return
+		}
+	}
+}
+
+func (s *Store) retryConcurrencyReleases(pending map[string]concurrencyReleaseRetry) {
+	if len(pending) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	expired := 0
+	ctx, cancel := context.WithTimeout(context.Background(), concurrencyReleaseRetryTimeout)
+	defer cancel()
+	pipeline := s.client.Pipeline()
+	type queuedRelease struct {
+		token   string
+		command *redisclient.IntCmd
+	}
+	commands := make([]queuedRelease, 0, min(len(pending), concurrencyReleaseRetryBatchSize))
+	for token, value := range pending {
+		if !now.Before(value.expiresAt) {
+			delete(pending, token)
+			expired++
+			continue
+		}
+		commands = append(commands, queuedRelease{token: token, command: pipeline.ZRem(ctx, value.redisKey, value.token)})
+		if len(commands) >= concurrencyReleaseRetryBatchSize {
+			break
+		}
+	}
+	if len(commands) == 0 {
+		observeConcurrencyRelease("expired", expired)
+		return
+	}
+	_, _ = pipeline.Exec(ctx)
+	recovered := 0
+	failed := 0
+	for _, value := range commands {
+		if value.command.Err() == nil {
+			delete(pending, value.token)
+			recovered++
+		} else {
+			failed++
+		}
+	}
+	observeConcurrencyRelease("expired", expired)
+	observeConcurrencyRelease("recovered", recovered)
+	observeConcurrencyRelease("retry_failed", failed)
+}
+
+func observeConcurrencyRelease(outcome string, count int) {
+	if count <= 0 {
+		return
+	}
+	perfmetrics.Default.Add("runtime_concurrency_release_total", perfmetrics.Labels{
+		Subsystem: "runtime", Operation: "concurrency_lease", Stage: "release", Outcome: outcome,
+	}, int64(count))
 }
 
 func (s *Store) Current(ctx context.Context, key string) (int, error) {

--- a/backend/internal/infra/runtime/redis/store_integration_test.go
+++ b/backend/internal/infra/runtime/redis/store_integration_test.go
@@ -2,6 +2,8 @@ package redis
 
 import (
 	"context"
+	"errors"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -54,6 +56,28 @@ func TestRedisRuntimeStoreIntegration(t *testing.T) {
 		t.Fatalf("duplicate concurrency acquire = %v, err = %v", acquired, err)
 	}
 	release()
+	releaseFailure := &failOnceRedisCommandHook{}
+	store.client.AddHook(releaseFailure)
+	release, acquired, err = limiter.Acquire(ctx, "account:release-retry", 1)
+	if err != nil || !acquired {
+		t.Fatalf("release retry acquire = %v, err = %v", acquired, err)
+	}
+	releaseFailure.arm("evalsha")
+	release()
+	releaseDeadline := time.Now().Add(2 * time.Second)
+	for {
+		current, currentErr := limiter.Current(ctx, "account:release-retry")
+		if currentErr != nil {
+			t.Fatal(currentErr)
+		}
+		if current == 0 {
+			break
+		}
+		if time.Now().After(releaseDeadline) {
+			t.Fatalf("failed concurrency release was not reconciled: current=%d", current)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 	concurrencyKey := store.key("concurrency", "snapshot")
 	now := time.Now().UTC()
 	if err := store.client.ZAdd(ctx, concurrencyKey,
@@ -296,6 +320,42 @@ func TestRedisRuntimeStoreIntegration(t *testing.T) {
 			t.Fatal("settings change notification was not delivered")
 		}
 	}
+}
+
+type failOnceRedisCommandHook struct {
+	mu      sync.Mutex
+	command string
+}
+
+func (h *failOnceRedisCommandHook) arm(command string) {
+	h.mu.Lock()
+	h.command = command
+	h.mu.Unlock()
+}
+
+func (h *failOnceRedisCommandHook) DialHook(next redisclient.DialHook) redisclient.DialHook {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		return next(ctx, network, address)
+	}
+}
+
+func (h *failOnceRedisCommandHook) ProcessHook(next redisclient.ProcessHook) redisclient.ProcessHook {
+	return func(ctx context.Context, command redisclient.Cmder) error {
+		h.mu.Lock()
+		fail := h.command != "" && command.Name() == h.command
+		if fail {
+			h.command = ""
+		}
+		h.mu.Unlock()
+		if fail {
+			return errors.New("injected Redis command failure")
+		}
+		return next(ctx, command)
+	}
+}
+
+func (h *failOnceRedisCommandHook) ProcessPipelineHook(next redisclient.ProcessPipelineHook) redisclient.ProcessPipelineHook {
+	return next
 }
 
 func cleanupRedisTestPrefix(t *testing.T, ctx context.Context, client *redisclient.Client, prefix string) {

--- a/backend/internal/infra/runtime/redis/store_test.go
+++ b/backend/internal/infra/runtime/redis/store_test.go
@@ -1,0 +1,111 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/pkg/perfmetrics"
+	redisclient "github.com/redis/go-redis/v9"
+)
+
+func TestRetryConcurrencyReleases(t *testing.T) {
+	registry := perfmetrics.NewRegistry()
+	previous := perfmetrics.Default
+	perfmetrics.Default = registry
+	t.Cleanup(func() { perfmetrics.Default = previous })
+	tests := []struct {
+		name          string
+		pipelineError error
+		remaining     int
+		outcomes      map[string]int64
+	}{
+		{name: "successful retry removes live and expired entries", outcomes: map[string]int64{"expired": 1, "recovered": 1}},
+		{name: "failed retry retains only live entries", pipelineError: errors.New("Redis unavailable"), remaining: 1, outcomes: map[string]int64{"expired": 1, "retry_failed": 1}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := redisclient.NewClient(&redisclient.Options{Addr: "unused:6379"})
+			client.AddHook(releasePipelineHook{err: test.pipelineError})
+			defer client.Close()
+			store := &Store{client: client}
+			now := time.Now().UTC()
+			pending := map[string]concurrencyReleaseRetry{
+				"live":    {redisKey: "concurrency:1", token: "live", expiresAt: now.Add(time.Minute)},
+				"expired": {redisKey: "concurrency:2", token: "expired", expiresAt: now.Add(-time.Minute)},
+			}
+			store.retryConcurrencyReleases(pending)
+			if len(pending) != test.remaining {
+				t.Fatalf("pending releases = %#v", pending)
+			}
+			if test.remaining == 1 {
+				if _, ok := pending["live"]; !ok {
+					t.Fatalf("live release was discarded: %#v", pending)
+				}
+			}
+			assertConcurrencyReleaseMetrics(t, registry.CollectAndReset(), test.outcomes)
+		})
+	}
+}
+
+func TestEnqueueConcurrencyReleaseRetryMetrics(t *testing.T) {
+	registry := perfmetrics.NewRegistry()
+	previous := perfmetrics.Default
+	perfmetrics.Default = registry
+	t.Cleanup(func() { perfmetrics.Default = previous })
+	store := &Store{
+		concurrencyReleaseQueue: make(chan concurrencyReleaseRetry, 1),
+		concurrencyReleaseStop:  make(chan struct{}),
+	}
+	value := concurrencyReleaseRetry{redisKey: "concurrency:1", token: "token", expiresAt: time.Now().Add(time.Minute)}
+	store.enqueueConcurrencyReleaseRetry(value)
+	store.enqueueConcurrencyReleaseRetry(value)
+	close(store.concurrencyReleaseStop)
+	store.enqueueConcurrencyReleaseRetry(value)
+	assertConcurrencyReleaseMetrics(t, registry.CollectAndReset(), map[string]int64{
+		"queued": 1, "dropped": 1, "shutdown": 1,
+	})
+}
+
+func assertConcurrencyReleaseMetrics(t *testing.T, samples []perfmetrics.Sample, expected map[string]int64) {
+	t.Helper()
+	observed := make(map[string]int64)
+	for _, sample := range samples {
+		if sample.Name == "runtime_concurrency_release_total" {
+			observed[sample.Labels.Outcome] += sample.Total
+		}
+	}
+	for outcome, total := range expected {
+		if observed[outcome] != total {
+			t.Fatalf("metric %s = %d, want %d; samples=%#v", outcome, observed[outcome], total, samples)
+		}
+	}
+}
+
+type releasePipelineHook struct{ err error }
+
+func (h releasePipelineHook) DialHook(next redisclient.DialHook) redisclient.DialHook {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		return next(ctx, network, address)
+	}
+}
+
+func (h releasePipelineHook) ProcessHook(next redisclient.ProcessHook) redisclient.ProcessHook {
+	return next
+}
+
+func (h releasePipelineHook) ProcessPipelineHook(_ redisclient.ProcessPipelineHook) redisclient.ProcessPipelineHook {
+	return func(_ context.Context, commands []redisclient.Cmder) error {
+		for _, command := range commands {
+			command.SetErr(h.err)
+			if h.err == nil {
+				if value, ok := command.(*redisclient.IntCmd); ok {
+					value.SetVal(1)
+				}
+			}
+		}
+		return h.err
+	}
+}

--- a/backend/internal/repository/account.go
+++ b/backend/internal/repository/account.go
@@ -80,6 +80,7 @@ type AccountRepository interface {
 	ListMissingConsoleSyncBatch(ctx context.Context, afterID uint64, limit int) ([]account.Credential, int64, int64, error)
 	HasActive(ctx context.Context, provider account.Provider) (bool, error)
 	ListRoutingCandidates(ctx context.Context, provider account.Provider, modelRouteID uint64, upstreamModel, quotaMode string) ([]account.RoutingCandidate, error)
+	GetCredentialMaterial(ctx context.Context, accountID uint64, provider account.Provider) (account.CredentialMaterial, error)
 	Get(ctx context.Context, id uint64) (account.Credential, error)
 	LinkWebToBuild(ctx context.Context, webAccountID, buildAccountID uint64) error
 	GetBillings(ctx context.Context, accountIDs []uint64) (map[uint64]account.Billing, error)


### PR DESCRIPTION
## 概要

优化账号选号热路径，减少大账号池下 PostgreSQL 向应用重复传输密钥和大 JSON 字段产生的数据库及网络 I/O。

- 候选查询改用轻量账号、Billing 和 Quota 投影。
- 原子取得账号并发租约后，仅加载最终账号的执行凭据。
- 保持现有计费、重试、额度、粘性会话和账号隔离语义。
- 不增加配置项、数据库迁移或凭据缓存。

## 主要改动

### 轻量候选投影

路由候选不再读取：

- 加密 Access Token
- 加密 Refresh Token
- 加密 Cloudflare Cookie
- Billing `history_json`
- Quota `breakdown_json`

管理、同步、额度查询和导出接口仍读取完整数据。

### 最终凭据水合

Selector 完成资格判断、排序并原子取得并发租约后，才按主键读取最终账号的执行凭据。

凭据读取同时校验：

- AccountID
- Provider
- 账号仍处于启用状态
- `auth_status=active`

领域合并阶段再次校验 AccountID 和 Provider，防止跨账号或跨渠道凭据被错误安装。

### 并发与故障处理

- 普通请求遇到已删除、禁用或失效候选时继续尝试下一账号。
- sticky 账号失效时清除旧绑定并重新选择。
- `previous_response_id` 固定账号请求不会跨账号切换。
- 所有候选均失效时返回 `no_accounts`，不误报并发饱和。
- 凭据读取失败会立即释放并发租约。
- 普通数据库错误不会处罚账号或制造错误冷却。
- 视频任务执行前重新确认凭据，避免排队期间 Token 过期。

## 安全与兼容性

- 执行凭据不进入候选快照、Redis 或新的本地缓存。
- Billing、reservation、audit 和最终计费链路未修改。
- 候选缓存 TTL 仍为 1 秒。
- 无数据库 Schema 变更。
- 无新增配置或迁移操作。
- 三个 Provider 均保持独立的账号和凭据边界。

## 性能

固定 300 个 Grok Web 账号，每个账号包含：

- 32 KiB Access Token
- 32 KiB Cloudflare Cookie
- 256 条 Billing history
- 128 条 Quota breakdown

| 指标 | 改造前 | 改造后 | 变化 |
| --- | ---: | ---: | ---: |
| 候选冷加载 | 156.47 ms/op | 13.96 ms/op | -91.1% |
| 内存分配 | 152.24 MB/op | 3.28 MB/op | -97.8% |
| 分配次数 | 313335 | 66644 | -78.7% |

最终账号 64 KiB 合成凭据的单行水合约为 `40–44 µs/op`。

代价是每次物理上游尝试增加一次最终账号的轻量主键读取。

## 验证

- `go test`：Gateway、Relational、App 定向测试通过
- Race：Gateway、Invalidation、Relational、App 通过
- `go vet ./...`
- `go build ./cmd/grok2api`
- 关键 Selector 用例连续 20 轮通过
- 真实 PostgreSQL 临时数据库集成测试通过
- Redis DB 10 + 3000 个持久化账号测试通过
- 双实例 32 路并发下未突破 `MaxConcurrent=1`
- 临时 PostgreSQL 数据库在测试结束后自动删除