### PR TITLE
feat: enhance credential refresh error handling with detailed diagnostics

### DIFF
--- a/backend/internal/application/account/credential_refresh_test.go
+++ b/backend/internal/application/account/credential_refresh_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chenyme/grok2api/backend/internal/infra/persistence/relational"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 	"github.com/chenyme/grok2api/backend/internal/infra/runtime/memory"
+	"github.com/chenyme/grok2api/backend/internal/repository"
 )
 
 func TestEnsureCredentialReusesRotatedTokenAndThrottlesForcedRefresh(t *testing.T) {
@@ -324,7 +325,7 @@ func TestCredentialRefreshFailureDistinguishesTransientAndPermanent(t *testing.T
 	service, credential, adapter := newCredentialRefreshTestService(t, now)
 	service.now = func() time.Time { return now }
 
-	adapter.refreshErr = &provider.CredentialRefreshError{Status: 503, Code: "oauth_unavailable"}
+	adapter.refreshErr = &provider.CredentialRefreshError{Status: 503, Code: "oauth_unavailable", Message: "Please retry later", Response: `{"error":"oauth_unavailable","message":"Please retry later"}`}
 	if _, err := service.EnsureCredential(ctx, credential, true); err == nil {
 		t.Fatal("transient refresh unexpectedly succeeded")
 	}
@@ -332,12 +333,12 @@ func TestCredentialRefreshFailureDistinguishesTransientAndPermanent(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if transient.AuthStatus != accountdomain.AuthStatusActive || transient.RefreshFailureCount != 1 || transient.LastRefreshErrorCode != "oauth_unavailable" || transient.RefreshPermanent || transient.RefreshDueAt == nil || !transient.RefreshDueAt.After(now) {
+	if transient.AuthStatus != accountdomain.AuthStatusActive || transient.RefreshFailureCount != 1 || transient.LastRefreshErrorStatus != 503 || transient.LastRefreshErrorCode != "oauth_unavailable" || transient.LastRefreshErrorMessage != "Please retry later" || transient.LastRefreshErrorResponse == "" || transient.RefreshPermanent || transient.RefreshDueAt == nil || !transient.RefreshDueAt.After(now) {
 		t.Fatalf("transient state = %#v", transient)
 	}
 
 	service.clearRefreshState(credential.ID)
-	adapter.refreshErr = &provider.CredentialRefreshError{Status: 400, Code: "invalid_grant", Permanent: true}
+	adapter.refreshErr = &provider.CredentialRefreshError{Status: 400, Code: "invalid_grant", Message: "Refresh token has expired", Response: `{"error":"invalid_grant","error_description":"Refresh token has expired"}`, Permanent: true}
 	if _, err := service.EnsureCredential(ctx, transient, true); err == nil {
 		t.Fatal("permanent refresh unexpectedly succeeded")
 	}
@@ -345,7 +346,7 @@ func TestCredentialRefreshFailureDistinguishesTransientAndPermanent(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if permanent.AuthStatus != accountdomain.AuthStatusActive || permanent.RefreshFailureCount != 2 || permanent.LastRefreshErrorCode != "invalid_grant" || !permanent.RefreshPermanent || permanent.RefreshDueAt == nil || !permanent.RefreshDueAt.Equal(permanent.ExpiresAt) {
+	if permanent.AuthStatus != accountdomain.AuthStatusActive || permanent.RefreshFailureCount != 2 || permanent.LastRefreshErrorStatus != 400 || permanent.LastRefreshErrorCode != "invalid_grant" || permanent.LastRefreshErrorMessage != "Refresh token has expired" || permanent.LastRefreshErrorResponse == "" || !permanent.RefreshPermanent || permanent.RefreshDueAt == nil || !permanent.RefreshDueAt.Equal(permanent.ExpiresAt) {
 		t.Fatalf("permanent with valid token should stay active: %#v", permanent)
 	}
 	dueIDs, err := service.accounts.ListDueCredentialRefreshIDs(ctx, now, credentialRefreshBatchSize)
@@ -413,7 +414,7 @@ func TestCredentialDecryptFailedAllowsRetryAfterKeyRecovery(t *testing.T) {
 	service.now = func() time.Time { return now }
 
 	// 旧行为会把 decrypt_failed 标 permanent；模拟已落库的 permanent 状态。
-	if err := service.accounts.UpdateCredentialRefreshFailure(ctx, credential.ID, 1, now.Add(time.Hour), "credential_decrypt_failed", true); err != nil {
+	if err := service.accounts.UpdateCredentialRefreshFailure(ctx, credential.ID, repository.CredentialRefreshFailure{Count: 1, RetryAt: now.Add(time.Hour), Code: "credential_decrypt_failed", Message: "Stored credential could not be decrypted", Permanent: true}); err != nil {
 		t.Fatal(err)
 	}
 	stuck, err := service.accounts.Get(ctx, credential.ID)
@@ -428,7 +429,7 @@ func TestCredentialDecryptFailedAllowsRetryAfterKeyRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("force refresh after decrypt_failed should retry: %v", err)
 	}
-	if recovered.RefreshPermanent || recovered.LastRefreshErrorCode != "" || adapter.refreshCount.Load() < 1 {
+	if recovered.RefreshPermanent || recovered.LastRefreshErrorStatus != 0 || recovered.LastRefreshErrorCode != "" || recovered.LastRefreshErrorMessage != "" || recovered.LastRefreshErrorResponse != "" || adapter.refreshCount.Load() < 1 {
 		t.Fatalf("decrypt_failed was not cleared after successful refresh: %#v count=%d", recovered, adapter.refreshCount.Load())
 	}
 

--- a/backend/internal/application/account/service.go
+++ b/backend/internal/application/account/service.go
@@ -2184,6 +2184,9 @@ func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential
 	}
 	failureCount := credential.RefreshFailureCount + 1
 	errorCode := "oauth_transport_error"
+	errorMessage := "OAuth request failed"
+	errorStatus := 0
+	errorResponse := ""
 	permanent := false
 	retryAfter := time.Duration(0)
 	var typed *provider.CredentialRefreshError
@@ -2192,10 +2195,16 @@ func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential
 		if errorCode == "" {
 			errorCode = "oauth_refresh_error"
 		}
+		errorStatus = typed.Status
 		permanent = typed.Permanent
 		retryAfter = typed.RetryAfter
+		if message := normalizeCredentialRefreshErrorMessage(typed.Message); message != "" {
+			errorMessage = message
+		}
+		errorResponse = normalizeCredentialRefreshErrorResponse(typed.Response)
 	} else if errors.Is(refreshErr, context.DeadlineExceeded) {
 		errorCode = "oauth_timeout"
+		errorMessage = "OAuth request timed out"
 	}
 	// 真正的 OAuth 永久失败（invalid_grant 等）只能由成功换 token 清除。
 	// credential_decrypt_failed 是可恢复本地错误：不得被旧 permanent 粘住，也不得把本次可恢复失败抬升为永久。
@@ -2214,7 +2223,10 @@ func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential
 	} else if permanent {
 		retryAt = now
 	}
-	if err := s.accounts.UpdateCredentialRefreshFailure(ctx, credential.ID, failureCount, retryAt, errorCode, permanent); err != nil {
+	if err := s.accounts.UpdateCredentialRefreshFailure(ctx, credential.ID, repository.CredentialRefreshFailure{
+		Count: failureCount, RetryAt: retryAt, Status: errorStatus, Code: errorCode,
+		Message: errorMessage, Response: errorResponse, Permanent: permanent,
+	}); err != nil {
 		s.logger.Warn("credential_refresh_state_write_failed", "account_id", credential.ID, "error", err)
 	}
 	if permanent && accessTokenAlive {
@@ -2230,6 +2242,39 @@ func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential
 	}
 	s.logger.Warn("credential_refresh_deferred", "account_id", credential.ID, "failure_count", failureCount, "retry_at", retryAt, "error_code", errorCode)
 	s.WakeCredentialRefresh()
+}
+
+func normalizeCredentialRefreshErrorMessage(value string) string {
+	value = strings.Map(func(char rune) rune {
+		switch char {
+		case '\r', '\n', '\t':
+			return ' '
+		}
+		if char < 0x20 || char == 0x7f {
+			return -1
+		}
+		return char
+	}, strings.TrimSpace(value))
+	value = strings.Join(strings.Fields(value), " ")
+	runes := []rune(value)
+	if len(runes) > 512 {
+		value = string(runes[:511]) + "…"
+	}
+	return value
+}
+
+func normalizeCredentialRefreshErrorResponse(value string) string {
+	value = strings.Map(func(char rune) rune {
+		if char < 0x20 || char == 0x7f {
+			return ' '
+		}
+		return char
+	}, strings.TrimSpace(value))
+	runes := []rune(value)
+	if len(runes) > 4096 {
+		value = string(runes[:4095]) + "…"
+	}
+	return value
 }
 
 // resolvePermanentRefreshFailure 阻止再次请求已确认失效的 refresh token，并在 access token 到期后收敛账号状态。

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -1311,7 +1311,7 @@ func TestGatewayRefreshesAndRetriesBuildUnauthorizedOnce(t *testing.T) {
 	if updated.EncryptedAccessToken != "access-new" || updated.AuthStatus != account.AuthStatusActive || updated.RefreshFailureCount != 0 {
 		t.Fatalf("updated credential = %#v", updated)
 	}
-	if err := accountRepo.UpdateCredentialRefreshFailure(ctx, credential.ID, 1, updated.ExpiresAt, "invalid_grant", true); err != nil {
+	if err := accountRepo.UpdateCredentialRefreshFailure(ctx, credential.ID, repository.CredentialRefreshFailure{Count: 1, RetryAt: updated.ExpiresAt, Status: 400, Code: "invalid_grant", Message: "Refresh token has expired", Permanent: true}); err != nil {
 		t.Fatal(err)
 	}
 	adapter.rejectAll.Store(true)

--- a/backend/internal/domain/account/account.go
+++ b/backend/internal/domain/account/account.go
@@ -141,7 +141,10 @@ type Credential struct {
 	RefreshDueAt              *time.Time
 	LastRefreshAt             *time.Time
 	RefreshFailureCount       int
+	LastRefreshErrorStatus    int
 	LastRefreshErrorCode      string
+	LastRefreshErrorMessage   string
+	LastRefreshErrorResponse  string
 	RefreshPermanent          bool
 	Enabled                   bool
 	AuthStatus                AuthStatus
@@ -211,7 +214,10 @@ type CredentialMaterial struct {
 	RefreshDueAt              *time.Time
 	LastRefreshAt             *time.Time
 	RefreshFailureCount       int
+	LastRefreshErrorStatus    int
 	LastRefreshErrorCode      string
+	LastRefreshErrorMessage   string
+	LastRefreshErrorResponse  string
 	RefreshPermanent          bool
 	UpdatedAt                 time.Time
 }
@@ -232,7 +238,10 @@ func (m CredentialMaterial) ApplyTo(value Credential) (Credential, bool) {
 	value.RefreshDueAt = m.RefreshDueAt
 	value.LastRefreshAt = m.LastRefreshAt
 	value.RefreshFailureCount = m.RefreshFailureCount
+	value.LastRefreshErrorStatus = m.LastRefreshErrorStatus
 	value.LastRefreshErrorCode = m.LastRefreshErrorCode
+	value.LastRefreshErrorMessage = m.LastRefreshErrorMessage
+	value.LastRefreshErrorResponse = m.LastRefreshErrorResponse
 	value.RefreshPermanent = m.RefreshPermanent
 	return value, true
 }

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -1655,7 +1655,7 @@ func (r *AccountRepository) UpdateTokens(ctx context.Context, id uint64, accessT
 	refreshDueAt := account.CredentialRefreshDueAt(id, expiresAt)
 	updates := map[string]any{
 		"encrypted_primary": accessToken, "expires_at": expiresAt, "refresh_due_at": refreshDueAt,
-		"last_refresh_at": now, "refresh_failures": 0, "last_refresh_error": "", "refresh_permanent": false, "updated_at": now,
+		"last_refresh_at": now, "refresh_failures": 0, "last_refresh_error_status": 0, "last_refresh_error": "", "last_refresh_error_message": "", "last_refresh_error_response": "", "refresh_permanent": false, "updated_at": now,
 	}
 	if refreshToken != "" {
 		updates["encrypted_refresh"] = refreshToken
@@ -1764,12 +1764,14 @@ func (r *AccountRepository) NextCredentialRefreshDueAt(ctx context.Context) (*ti
 	return &value, nil
 }
 
-func (r *AccountRepository) UpdateCredentialRefreshFailure(ctx context.Context, id uint64, failureCount int, retryAt time.Time, errorCode string, permanent bool) error {
+func (r *AccountRepository) UpdateCredentialRefreshFailure(ctx context.Context, id uint64, failure repository.CredentialRefreshFailure) error {
 	err := r.db.db.WithContext(ctx).Model(&accountCredentialModel{}).Where("account_id = ?", id).Updates(map[string]any{
-		"refresh_due_at": retryAt.UTC(), "refresh_failures": max(0, failureCount),
-		"last_refresh_error": truncate(errorCode, 100), "refresh_permanent": permanent, "updated_at": time.Now().UTC(),
+		"refresh_due_at": failure.RetryAt.UTC(), "refresh_failures": max(0, failure.Count),
+		"last_refresh_error_status": max(0, failure.Status), "last_refresh_error": truncate(failure.Code, 100),
+		"last_refresh_error_message": truncate(failure.Message, 512), "last_refresh_error_response": truncate(failure.Response, 4096),
+		"refresh_permanent": failure.Permanent, "updated_at": time.Now().UTC(),
 	}).Error
-	if err == nil && permanent {
+	if err == nil && failure.Permanent {
 		r.notifyInvalidation(ctx, repository.InvalidationEvent{Kind: repository.InvalidationAccountCredentialChanged, AccountID: id})
 	}
 	return err

--- a/backend/internal/infra/persistence/relational/mapping.go
+++ b/backend/internal/infra/persistence/relational/mapping.go
@@ -26,7 +26,10 @@ func toAccountDomain(value accountModel) account.Credential {
 	var expiresAt time.Time
 	var refreshDueAt, lastRefreshAt *time.Time
 	var refreshFailures int
+	var lastRefreshErrorStatus int
 	var lastRefreshError string
+	var lastRefreshErrorMessage string
+	var lastRefreshErrorResponse string
 	var refreshPermanent bool
 	var authType account.AuthType
 	var clientID, encryptedPrimary, encryptedRefresh, encryptedCloudflareCookie string
@@ -44,7 +47,10 @@ func toAccountDomain(value accountModel) account.Credential {
 		refreshDueAt = value.Credential.RefreshDueAt
 		lastRefreshAt = value.Credential.LastRefreshAt
 		refreshFailures = value.Credential.RefreshFailures
+		lastRefreshErrorStatus = value.Credential.LastRefreshErrorStatus
 		lastRefreshError = value.Credential.LastRefreshError
+		lastRefreshErrorMessage = value.Credential.LastRefreshErrorMessage
+		lastRefreshErrorResponse = value.Credential.LastRefreshErrorResponse
 		refreshPermanent = value.Credential.RefreshPermanent
 	}
 	var webTier account.WebTier
@@ -74,7 +80,7 @@ func toAccountDomain(value accountModel) account.Credential {
 		UserID: value.UserID, TeamID: value.TeamID, SourceKey: value.SourceKey, OIDCClientID: clientID,
 		EncryptedAccessToken: encryptedPrimary, EncryptedRefreshToken: encryptedRefresh, EncryptedCloudflareCookie: encryptedCloudflareCookie,
 		ExpiresAt: expiresAt, RefreshDueAt: refreshDueAt, LastRefreshAt: lastRefreshAt,
-		RefreshFailureCount: refreshFailures, LastRefreshErrorCode: lastRefreshError, RefreshPermanent: refreshPermanent,
+		RefreshFailureCount: refreshFailures, LastRefreshErrorStatus: lastRefreshErrorStatus, LastRefreshErrorCode: lastRefreshError, LastRefreshErrorMessage: lastRefreshErrorMessage, LastRefreshErrorResponse: lastRefreshErrorResponse, RefreshPermanent: refreshPermanent,
 		Enabled: value.Enabled, AuthStatus: account.AuthStatus(value.AuthStatus), ReauthMarkedAt: value.ReauthMarkedAt, Priority: value.Priority,
 		MaxConcurrent: value.MaxConcurrent, MinimumRemaining: value.MinimumRemaining, FailureCount: value.FailureCount,
 		CooldownUntil: value.CooldownUntil, LastError: value.LastError, LastUsedAt: value.LastUsedAt,
@@ -97,7 +103,7 @@ func toCredentialMaterialDomain(value accountCredentialModel, provider account.P
 		EncryptedAccessToken: value.EncryptedPrimary, EncryptedRefreshToken: value.EncryptedRefresh,
 		EncryptedCloudflareCookie: value.EncryptedCloudflareCookie, ExpiresAt: expiresAt,
 		RefreshDueAt: value.RefreshDueAt, LastRefreshAt: value.LastRefreshAt,
-		RefreshFailureCount: value.RefreshFailures, LastRefreshErrorCode: value.LastRefreshError,
+		RefreshFailureCount: value.RefreshFailures, LastRefreshErrorStatus: value.LastRefreshErrorStatus, LastRefreshErrorCode: value.LastRefreshError, LastRefreshErrorMessage: value.LastRefreshErrorMessage, LastRefreshErrorResponse: value.LastRefreshErrorResponse,
 		RefreshPermanent: value.RefreshPermanent, UpdatedAt: value.UpdatedAt,
 	}
 }
@@ -162,7 +168,7 @@ func fromAccountCredentialDomain(value account.Credential) accountCredentialMode
 		EncryptedPrimary: value.EncryptedAccessToken, EncryptedRefresh: value.EncryptedRefreshToken,
 		EncryptedCloudflareCookie: value.EncryptedCloudflareCookie,
 		ExpiresAt:                 expiresAt, RefreshDueAt: refreshDueAt, LastRefreshAt: value.LastRefreshAt,
-		RefreshFailures: value.RefreshFailureCount, LastRefreshError: value.LastRefreshErrorCode, RefreshPermanent: value.RefreshPermanent,
+		RefreshFailures: value.RefreshFailureCount, LastRefreshErrorStatus: value.LastRefreshErrorStatus, LastRefreshError: value.LastRefreshErrorCode, LastRefreshErrorMessage: value.LastRefreshErrorMessage, LastRefreshErrorResponse: value.LastRefreshErrorResponse, RefreshPermanent: value.RefreshPermanent,
 		UpdatedAt: time.Now().UTC(),
 	}
 }

--- a/backend/internal/infra/persistence/relational/models.go
+++ b/backend/internal/infra/persistence/relational/models.go
@@ -77,7 +77,10 @@ type accountCredentialModel struct {
 	RefreshDueAt              *time.Time
 	LastRefreshAt             *time.Time
 	RefreshFailures           int           `gorm:"not null;default:0;check:chk_account_credentials_refresh_failures,refresh_failures >= 0"`
+	LastRefreshErrorStatus    int           `gorm:"not null;default:0;check:chk_account_credentials_refresh_error_status,last_refresh_error_status >= 0"`
 	LastRefreshError          string        `gorm:"size:100;not null;default:'';check:chk_account_credentials_refresh_error,length(last_refresh_error) <= 100"`
+	LastRefreshErrorMessage   string        `gorm:"size:512;not null;default:'';check:chk_account_credentials_refresh_error_message,length(last_refresh_error_message) <= 512"`
+	LastRefreshErrorResponse  string        `gorm:"size:4096;not null;default:'';check:chk_account_credentials_refresh_error_response,length(last_refresh_error_response) <= 4096"`
 	RefreshPermanent          bool          `gorm:"not null;default:false"`
 	UpdatedAt                 time.Time     `gorm:"not null"`
 	Account                   *accountModel `gorm:"foreignKey:AccountID;references:ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`

--- a/backend/internal/infra/persistence/relational/repository_test.go
+++ b/backend/internal/infra/persistence/relational/repository_test.go
@@ -460,7 +460,7 @@ func TestFreshSchemaContract(t *testing.T) {
 		}
 	}
 	assertTableColumns(t, database, "provider_accounts", []string{"provider", "source_key", "auth_status", "build_api_fallback", "build_route_mode", "build_super_entitled"}, []string{"oidc_client_id", "expires_at", "encrypted_access_token", "encrypted_refresh_token"})
-	assertTableColumns(t, database, "account_credentials", []string{"account_id", "auth_type", "client_id", "encrypted_primary", "encrypted_refresh", "expires_at", "refresh_due_at", "last_refresh_at", "refresh_failures", "last_refresh_error", "refresh_permanent"}, nil)
+	assertTableColumns(t, database, "account_credentials", []string{"account_id", "auth_type", "client_id", "encrypted_primary", "encrypted_refresh", "expires_at", "refresh_due_at", "last_refresh_at", "refresh_failures", "last_refresh_error_status", "last_refresh_error", "last_refresh_error_message", "last_refresh_error_response", "refresh_permanent"}, nil)
 	assertTableColumns(t, database, "web_account_profiles", []string{"account_id", "tier", "synced_at", "nsfw_enabled_at"}, nil)
 	assertTableColumns(t, database, "admin_sessions", nil, []string{"revoked_at"})
 	assertTableColumns(t, database, "account_model_capabilities", []string{"account_id", "upstream_model"}, []string{"provider", "synced_at"})

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -706,10 +706,10 @@ func (a *Adapter) RefreshCredential(ctx context.Context, credential account.Cred
 		// Decryption failures are usually temporary or mismatched local encryption keys and are recoverable;
 		// do not mark them permanent, or manual/batch refresh will never retry after the key is fixed.
 		// True permanent OAuth failures such as invalid_grant are returned by oauth.refresh with Permanent=true.
-		return provider.RefreshedCredential{}, &provider.CredentialRefreshError{Code: "credential_decrypt_failed", Permanent: false, Cause: err}
+		return provider.RefreshedCredential{}, &provider.CredentialRefreshError{Code: "credential_decrypt_failed", Message: "Stored refresh credential could not be decrypted", Permanent: false, Cause: err}
 	}
 	if strings.TrimSpace(refreshToken) == "" {
-		return provider.RefreshedCredential{}, &provider.CredentialRefreshError{Code: "missing_refresh_token", Permanent: true}
+		return provider.RefreshedCredential{}, &provider.CredentialRefreshError{Code: "missing_refresh_token", Message: "Refresh token is missing", Permanent: true}
 	}
 	refreshCtx := infraegress.WithCredential(ctx, credential)
 	tokens, err := a.oauth.refresh(refreshCtx, refreshToken)

--- a/backend/internal/infra/provider/cli/oauth.go
+++ b/backend/internal/infra/provider/cli/oauth.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,12 @@ const (
 	defaultDeviceURL     = "https://auth.x.ai/oauth2/device/code"
 	defaultTokenURL      = "https://auth.x.ai/oauth2/token"
 	deviceClientSurface  = "ui"
+)
+
+var (
+	oauthBearerPattern        = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+`)
+	oauthJWTPattern           = regexp.MustCompile(`[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)
+	oauthSensitivePairPattern = regexp.MustCompile(`(?i)(access_token|refresh_token|id_token|token|authorization|cookie|secret|password|credential)=([^&\s"'<>]+)`)
 )
 
 type oauthClient struct {
@@ -70,7 +77,7 @@ func (c *oauthClient) refresh(ctx context.Context, refreshToken string) (tokenPa
 	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {c.clientID}, "refresh_token": {refreshToken}}
 	value, err := c.exchange(ctx, form, refreshToken, false)
 	if errors.Is(err, provider.ErrAuthorizationDenied) {
-		return tokenPayload{}, &provider.CredentialRefreshError{Code: "refresh_denied", Permanent: true, Cause: err}
+		return tokenPayload{}, &provider.CredentialRefreshError{Code: "refresh_denied", Message: "OAuth authorization was denied", Permanent: true, Cause: err}
 	}
 	return value, err
 }
@@ -101,40 +108,182 @@ func (c *oauthClient) exchange(ctx context.Context, form url.Values, fallbackRef
 	if err != nil {
 		return tokenPayload{}, err
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		oauthError := parseOAuthErrorResponse(body, resp.StatusCode)
+		switch oauthError.Code {
+		case "authorization_pending":
+			if deviceFlow {
+				return tokenPayload{}, provider.ErrAuthorizationPending
+			}
+		case "slow_down":
+			if deviceFlow {
+				return tokenPayload{}, provider.ErrSlowDown
+			}
+		case "access_denied", "expired_token":
+			if deviceFlow {
+				return tokenPayload{}, provider.ErrAuthorizationDenied
+			}
+		}
+		return tokenPayload{}, &provider.CredentialRefreshError{
+			Status: resp.StatusCode, Code: oauthError.Code, Message: oauthError.Message, Response: oauthError.Response,
+			Permanent:  resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized,
+			RetryAfter: parseOAuthRetryAfter(resp.Header.Get("Retry-After")),
+		}
+	}
 	var value struct {
-		AccessToken      string `json:"access_token"`
-		RefreshToken     string `json:"refresh_token"`
-		ExpiresIn        int    `json:"expires_in"`
-		IDToken          string `json:"id_token"`
-		Error            string `json:"error"`
-		ErrorDescription string `json:"error_description"`
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		IDToken      string `json:"id_token"`
 	}
 	if err := json.Unmarshal(body, &value); err != nil {
 		return tokenPayload{}, fmt.Errorf("解析 xAI OAuth 响应: %w", err)
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		switch value.Error {
-		case "authorization_pending":
-			return tokenPayload{}, provider.ErrAuthorizationPending
-		case "slow_down":
-			return tokenPayload{}, provider.ErrSlowDown
-		case "access_denied", "expired_token":
-			return tokenPayload{}, provider.ErrAuthorizationDenied
-		default:
-			return tokenPayload{}, &provider.CredentialRefreshError{
-				Status: resp.StatusCode, Code: firstNonEmpty(value.Error, "oauth_http_"+strconv.Itoa(resp.StatusCode)),
-				Permanent:  resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized,
-				RetryAfter: parseOAuthRetryAfter(resp.Header.Get("Retry-After")),
-			}
-		}
-	}
 	if value.AccessToken == "" {
-		return tokenPayload{}, &provider.CredentialRefreshError{Status: resp.StatusCode, Code: "missing_access_token", Permanent: true}
+		return tokenPayload{}, &provider.CredentialRefreshError{Status: resp.StatusCode, Code: "missing_access_token", Message: "OAuth response did not contain access_token", Permanent: true}
 	}
 	if value.ExpiresIn <= 0 {
 		value.ExpiresIn = 3600
 	}
 	return tokenPayload{AccessToken: value.AccessToken, RefreshToken: firstNonEmpty(value.RefreshToken, fallbackRefresh), ExpiresAt: time.Now().UTC().Add(time.Duration(value.ExpiresIn) * time.Second), IDToken: value.IDToken}, nil
+}
+
+type oauthErrorDetails struct {
+	Code     string
+	Message  string
+	Response string
+}
+
+func parseOAuthErrorResponse(body []byte, status int) oauthErrorDetails {
+	result := oauthErrorDetails{Code: "oauth_http_" + strconv.Itoa(status)}
+	var payload any
+	if json.Unmarshal(body, &payload) != nil {
+		redacted := redactOAuthDiagnosticText(string(body))
+		result.Message = normalizeOAuthErrorMessage(redacted, 512)
+		result.Response = normalizeOAuthErrorMessage(redacted, 4096)
+		return result
+	}
+
+	result.Code = firstNonEmpty(
+		jsonStringAt(payload, "error"),
+		jsonStringAt(payload, "error", "code"),
+		jsonStringAt(payload, "error_code"),
+		jsonStringAt(payload, "code"),
+		result.Code,
+	)
+	rootMessage, _ := payload.(string)
+	messages := []string{
+		rootMessage,
+		jsonStringAt(payload, "error_description"),
+		jsonStringAt(payload, "message"),
+		jsonStringAt(payload, "detail"),
+		jsonStringAt(payload, "description"),
+		jsonStringAt(payload, "title"),
+		jsonStringAt(payload, "error", "message"),
+		jsonStringAt(payload, "error", "error_description"),
+		jsonStringAt(payload, "error", "detail"),
+		jsonStringAt(payload, "error", "description"),
+	}
+	seen := make(map[string]struct{}, len(messages))
+	for _, message := range messages {
+		message = normalizeOAuthErrorMessage(message, 512)
+		if message == "" {
+			continue
+		}
+		if _, exists := seen[message]; exists {
+			continue
+		}
+		seen[message] = struct{}{}
+		if result.Message != "" {
+			result.Message += " · "
+		}
+		result.Message += message
+	}
+	redacted, err := json.Marshal(redactOAuthDiagnosticValue("", payload))
+	if err == nil {
+		result.Response = truncateOAuthDiagnostic(string(redacted), 4096)
+	}
+	return result
+}
+
+func jsonStringAt(value any, path ...string) string {
+	current := value
+	for _, key := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current, ok = object[key]
+		if !ok {
+			return ""
+		}
+	}
+	text, _ := current.(string)
+	return text
+}
+
+func redactOAuthDiagnosticValue(key string, value any) any {
+	if isSensitiveOAuthDiagnosticKey(key) {
+		return "[REDACTED]"
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for childKey, child := range typed {
+			result[childKey] = redactOAuthDiagnosticValue(childKey, child)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for index, child := range typed {
+			result[index] = redactOAuthDiagnosticValue(key, child)
+		}
+		return result
+	case string:
+		return redactOAuthDiagnosticText(typed)
+	default:
+		return value
+	}
+}
+
+func isSensitiveOAuthDiagnosticKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), " ", "_"))
+	for _, part := range []string{"token", "authorization", "cookie", "secret", "password", "credential", "assertion", "code_verifier", "device_code"} {
+		if strings.Contains(normalized, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactOAuthDiagnosticText(value string) string {
+	value = oauthBearerPattern.ReplaceAllString(value, "Bearer [REDACTED]")
+	value = oauthJWTPattern.ReplaceAllString(value, "[REDACTED]")
+	value = oauthSensitivePairPattern.ReplaceAllString(value, "$1=[REDACTED]")
+	fields := strings.Fields(value)
+	for index := range fields {
+		trimmed := strings.Trim(fields[index], `"'(),;`)
+		if len(trimmed) >= 80 && !strings.ContainsAny(trimmed, "{}[]<>") {
+			fields[index] = strings.Replace(fields[index], trimmed, "[REDACTED]", 1)
+		}
+	}
+	return strings.Join(fields, " ")
+}
+
+func normalizeOAuthErrorMessage(value string, limit int) string {
+	value = strings.Join(strings.Fields(value), " ")
+	return truncateOAuthDiagnostic(value, limit)
+}
+
+func truncateOAuthDiagnostic(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) > limit {
+		if limit <= 1 {
+			return "…"
+		}
+		return string(runes[:limit-1]) + "…"
+	}
+	return value
 }
 
 func parseOAuthRetryAfter(value string) time.Duration {

--- a/backend/internal/infra/provider/cli/oauth_test.go
+++ b/backend/internal/infra/provider/cli/oauth_test.go
@@ -85,9 +85,12 @@ func TestOAuthRefreshClassifiesPermanentAndTransientFailures(t *testing.T) {
 		retryAfter string
 		permanent  bool
 		code       string
+		message    string
+		response   string
 	}{
 		{name: "transient upstream", status: http.StatusServiceUnavailable, body: `{"error":"temporarily_unavailable"}`, retryAfter: "7", code: "temporarily_unavailable"},
-		{name: "invalid grant", status: http.StatusBadRequest, body: `{"error":"invalid_grant"}`, permanent: true, code: "invalid_grant"},
+		{name: "invalid grant", status: http.StatusBadRequest, body: `{"error":"invalid_grant","error_description":"Refresh token has expired","message":"Access denied","request_id":"req-123","refresh_token":"must-not-leak"}`, permanent: true, code: "invalid_grant", message: "Refresh token has expired · Access denied", response: `"refresh_token":"[REDACTED]"`},
+		{name: "nested error", status: http.StatusBadRequest, body: `{"error":{"code":"invalid_client","message":"Client rejected","detail":"Application disabled"}}`, permanent: true, code: "invalid_client", message: "Client rejected · Application disabled", response: `"detail":"Application disabled"`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -108,8 +111,14 @@ func TestOAuthRefreshClassifiesPermanentAndTransientFailures(t *testing.T) {
 			client.tokenURL = "https://auth.x.ai/oauth2/token"
 			_, err := client.refresh(context.Background(), "refresh")
 			var refreshErr *provider.CredentialRefreshError
-			if !errors.As(err, &refreshErr) || refreshErr.Permanent != test.permanent || refreshErr.Code != test.code {
+			if !errors.As(err, &refreshErr) || refreshErr.Status != test.status || refreshErr.Permanent != test.permanent || refreshErr.Code != test.code || refreshErr.Message != test.message {
 				t.Fatalf("error = %#v", err)
+			}
+			if test.response != "" && !strings.Contains(refreshErr.Response, test.response) {
+				t.Fatalf("response = %q, want substring %q", refreshErr.Response, test.response)
+			}
+			if strings.Contains(refreshErr.Response, "must-not-leak") {
+				t.Fatalf("response leaked refresh token: %q", refreshErr.Response)
 			}
 			if test.retryAfter != "" && refreshErr.RetryAfter != 7*time.Second {
 				t.Fatalf("retry after = %s", refreshErr.RetryAfter)

--- a/backend/internal/infra/provider/provider.go
+++ b/backend/internal/infra/provider/provider.go
@@ -83,8 +83,12 @@ func IsMediaPostProcessingError(err error) bool {
 
 // CredentialRefreshError distinguishes permanent OAuth errors requiring reauthorization from temporary errors that can retry with backoff.
 type CredentialRefreshError struct {
-	Status     int
-	Code       string
+	Status  int
+	Code    string
+	Message string
+	// Response is a bounded, redacted representation of the upstream OAuth
+	// response. It is diagnostic only and must never contain credentials.
+	Response   string
 	Permanent  bool
 	RetryAfter time.Duration
 	Cause      error
@@ -95,7 +99,13 @@ func (e *CredentialRefreshError) Error() string {
 		return "credential refresh failed"
 	}
 	if e.Code != "" {
+		if e.Message != "" {
+			return "credential refresh failed: " + e.Code + ": " + e.Message
+		}
 		return "credential refresh failed: " + e.Code
+	}
+	if e.Message != "" {
+		return "credential refresh failed: " + e.Message
 	}
 	if e.Cause != nil {
 		return "credential refresh failed: " + e.Cause.Error()

--- a/backend/internal/repository/account.go
+++ b/backend/internal/repository/account.go
@@ -20,6 +20,19 @@ type AccountUpsertResult struct {
 	Created bool
 }
 
+// CredentialRefreshFailure is the bounded diagnostic state persisted for the
+// latest failed OAuth refresh. Response must already be redacted by the
+// provider adapter before it reaches persistence.
+type CredentialRefreshFailure struct {
+	Count     int
+	RetryAt   time.Time
+	Status    int
+	Code      string
+	Message   string
+	Response  string
+	Permanent bool
+}
+
 // LinkedDeleteResolution is the server-side expansion of root deletes with optional linked peers.
 type LinkedDeleteResolution struct {
 	RootIDs          []uint64
@@ -111,7 +124,7 @@ type AccountRepository interface {
 	ListCriticalCredentialRefreshIDs(ctx context.Context, now, expiresBefore time.Time, limit int) ([]uint64, error)
 	ListDueCredentialRefreshIDs(ctx context.Context, now time.Time, limit int) ([]uint64, error)
 	NextCredentialRefreshDueAt(ctx context.Context) (*time.Time, error)
-	UpdateCredentialRefreshFailure(ctx context.Context, id uint64, failureCount int, retryAt time.Time, errorCode string, permanent bool) error
+	UpdateCredentialRefreshFailure(ctx context.Context, id uint64, failure CredentialRefreshFailure) error
 	UpdateObservedModel(ctx context.Context, id uint64, model string, observedAt time.Time) error
 	UpdateHealth(ctx context.Context, id uint64, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error
 	// MarkBuildAPIFallback 幂等写入 Build 账号的 XAI 推理回退标记；非 Build 账号返回错误。

--- a/backend/internal/transport/http/account/handler.go
+++ b/backend/internal/transport/http/account/handler.go
@@ -278,7 +278,10 @@ type accountResponse struct {
 	RefreshDueAt               *time.Time              `json:"refreshDueAt,omitempty"`
 	LastRefreshAt              *time.Time              `json:"lastRefreshAt,omitempty"`
 	RefreshFailures            int                     `json:"refreshFailureCount"`
+	LastRefreshErrorStatus     int                     `json:"lastRefreshErrorStatus,omitempty"`
 	LastRefreshError           string                  `json:"lastRefreshErrorCode,omitempty"`
+	LastRefreshErrorMessage    string                  `json:"lastRefreshErrorMessage,omitempty"`
+	LastRefreshErrorResponse   string                  `json:"lastRefreshErrorResponse,omitempty"`
 	Priority                   int                     `json:"priority"`
 	MaxConcurrent              int                     `json:"maxConcurrent"`
 	MinimumRemaining           float64                 `json:"minimumRemaining"`
@@ -1415,7 +1418,7 @@ func newAccountResponse(value accountapp.View) accountResponse {
 		WebTierSyncedAt: c.WebTierSyncedAt, WebNSFWEnabledAt: c.WebNSFWEnabledAt, WebTermsAcceptedAt: c.WebTermsAcceptedAt, Name: c.Name, Email: c.Email, UserID: c.UserID, TeamID: c.TeamID,
 		Enabled: c.Enabled, AuthStatus: string(c.AuthStatus), Refreshable: c.EncryptedRefreshToken != "",
 		RefreshDueAt: c.RefreshDueAt, LastRefreshAt: c.LastRefreshAt,
-		RefreshFailures: c.RefreshFailureCount, LastRefreshError: c.LastRefreshErrorCode,
+		RefreshFailures: c.RefreshFailureCount, LastRefreshErrorStatus: c.LastRefreshErrorStatus, LastRefreshError: c.LastRefreshErrorCode, LastRefreshErrorMessage: c.LastRefreshErrorMessage, LastRefreshErrorResponse: c.LastRefreshErrorResponse,
 		Priority: c.Priority, MaxConcurrent: c.MaxConcurrent, MinimumRemaining: c.MinimumRemaining,
 		FailureCount: c.FailureCount, CooldownUntil: c.CooldownUntil, LastError: c.LastError,
 		LastUsedAt: c.LastUsedAt, LinkedAccountID: c.LinkedAccountID, LinkedName: c.LinkedAccountName, LinkedProvider: string(c.LinkedProvider),

--- a/backend/internal/transport/http/account/handler_test.go
+++ b/backend/internal/transport/http/account/handler_test.go
@@ -50,6 +50,15 @@ func TestNewAccountResponseExposesAllLinkedAccounts(t *testing.T) {
 	}
 }
 
+func TestNewAccountResponseExposesCredentialRefreshError(t *testing.T) {
+	response := newAccountResponse(accountapp.View{Credential: accountdomain.Credential{
+		Provider: accountdomain.ProviderBuild, LastRefreshErrorStatus: 400, LastRefreshErrorCode: "invalid_grant", LastRefreshErrorMessage: "Refresh token has expired", LastRefreshErrorResponse: `{"error":"invalid_grant"}`,
+	}})
+	if response.LastRefreshErrorStatus != 400 || response.LastRefreshError != "invalid_grant" || response.LastRefreshErrorMessage != "Refresh token has expired" || response.LastRefreshErrorResponse == "" {
+		t.Fatalf("refresh error = %#v", response)
+	}
+}
+
 type accountSynchronizerStub struct {
 	accountIDs []uint64
 }

--- a/frontend/src/features/accounts/accounts-api.ts
+++ b/frontend/src/features/accounts/accounts-api.ts
@@ -87,7 +87,10 @@ export type AccountDTO = {
   refreshDueAt?: string;
   lastRefreshAt?: string;
   refreshFailureCount: number;
+  lastRefreshErrorStatus?: number;
   lastRefreshErrorCode?: string;
+  lastRefreshErrorMessage?: string;
+  lastRefreshErrorResponse?: string;
   priority: number;
   maxConcurrent: number;
   minimumRemaining: number;
@@ -183,7 +186,7 @@ const accountValidator = hasShape({
   enabled: isBoolean, authStatus: isOneOf("active", "reauthRequired"), expiresAt: isOptional(isString), refreshable: isBoolean, cloudflareCookieConfigured: isBoolean,
   buildSuperEntitled: isBoolean, buildRouteMode: isOneOf("auto", "build", "xai"), buildBotFlagged: isBoolean, modelSyncFailed: isOptional(isBoolean), refreshDueAt: isOptional(isString), lastRefreshAt: isOptional(isString), refreshFailureCount: isNumber,
   egressNodeId: isOptional(isString), egressAssignmentMode: isOptional(isOneOf("manual", "auto")),
-  lastRefreshErrorCode: isOptional(isString), priority: isNumber, maxConcurrent: isNumber, minimumRemaining: isNumber,
+  lastRefreshErrorStatus: isOptional(isNumber), lastRefreshErrorCode: isOptional(isString), lastRefreshErrorMessage: isOptional(isString), lastRefreshErrorResponse: isOptional(isString), priority: isNumber, maxConcurrent: isNumber, minimumRemaining: isNumber,
   failureCount: isNumber, cooldownUntil: isOptional(isString), lastError: isOptional(isString), lastUsedAt: isOptional(isString),
   linkedAccountId: isOptional(isString), linkedAccountName: isOptional(isString), linkedProvider: isOptional(isOneOf("grok_build", "grok_web")), linkedAccounts: isOptional(isArrayOf(linkedAccountValidator)),
   createdAt: isString, billing: isOptional(billingValidator), quota: quotaValidator, quotaWindows: isOptional(isArrayOf(quotaWindowValidator)),

--- a/frontend/src/features/accounts/accounts-page.tsx
+++ b/frontend/src/features/accounts/accounts-page.tsx
@@ -2003,7 +2003,21 @@ function AccountStatus({ account }: { account: AccountDTO }) {
     return <Badge variant="outline" className="text-muted-foreground">{t("accounts.statusDisabled")}</Badge>;
   }
   if (account.authStatus === "reauthRequired") {
-    return <Badge variant="destructive">{t("accounts.statusReauthRequired")}</Badge>;
+    const refreshErrorDetails = formatAdditionalRefreshErrorDetails(account);
+    const hasRefreshError = Boolean(account.lastRefreshErrorStatus || account.lastRefreshErrorCode || account.lastRefreshErrorMessage || refreshErrorDetails);
+    if (!hasRefreshError) return <Badge variant="destructive">{t("accounts.statusReauthRequired")}</Badge>;
+    return (
+      <StatusTooltip content={(
+        <div className="grid w-72 max-w-[calc(100vw-2rem)] grid-cols-[4.5rem_minmax(0,1fr)] gap-x-3 gap-y-1 text-xs font-normal leading-5">
+          {account.lastRefreshErrorStatus ? <><span className="text-primary-foreground/60">{t("accounts.refreshErrorStatus")}</span><span>{account.lastRefreshErrorStatus}</span></> : null}
+          {account.lastRefreshErrorCode ? <><span className="text-primary-foreground/60">{t("accounts.refreshErrorCode")}</span><span className="break-all">{account.lastRefreshErrorCode}</span></> : null}
+          {account.lastRefreshErrorMessage ? <><span className="text-primary-foreground/60">{t("accounts.refreshErrorMessage")}</span><span className="break-words">{account.lastRefreshErrorMessage}</span></> : null}
+          {refreshErrorDetails ? <><span className="text-primary-foreground/60">{t("accounts.refreshErrorResponse")}</span><span className="max-h-40 overflow-auto whitespace-pre-wrap break-all">{refreshErrorDetails}</span></> : null}
+        </div>
+      )}>
+        <Badge variant="destructive">{t("accounts.statusReauthRequired")}</Badge>
+      </StatusTooltip>
+    );
   }
   const consoleWindow = account.provider === "grok_console"
     ? account.quotaWindows?.find((window) => window.mode === "console" && window.remaining <= 0)
@@ -2041,13 +2055,41 @@ function AccountStatus({ account }: { account: AccountDTO }) {
   return <Badge variant="secondary" className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-300">{t("accounts.statusActive")}</Badge>;
 }
 
-function StatusTooltip({ children, content }: { children: ReactNode; content: string }) {
+function formatAdditionalRefreshErrorDetails(account: AccountDTO): string | undefined {
+  const response = account.lastRefreshErrorResponse?.trim();
+  if (!response) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(response);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return response;
+    const details = { ...(parsed as Record<string, unknown>) };
+    const messages = new Set((account.lastRefreshErrorMessage ?? "").split(" · ").map((value) => value.trim()).filter(Boolean));
+    if (typeof details.error === "string" && details.error === account.lastRefreshErrorCode) delete details.error;
+    for (const key of ["error_description", "message", "detail", "description", "title"]) {
+      if (typeof details[key] === "string" && messages.has(details[key])) delete details[key];
+    }
+    if (details.error && typeof details.error === "object" && !Array.isArray(details.error)) {
+      const nested = { ...(details.error as Record<string, unknown>) };
+      if (typeof nested.code === "string" && nested.code === account.lastRefreshErrorCode) delete nested.code;
+      for (const key of ["error_description", "message", "detail", "description"]) {
+        if (typeof nested[key] === "string" && messages.has(nested[key])) delete nested[key];
+      }
+      if (Object.keys(nested).length === 0) delete details.error;
+      else details.error = nested;
+    }
+    if (Object.keys(details).length === 0) return undefined;
+    return JSON.stringify(details, null, 2);
+  } catch {
+    return response;
+  }
+}
+
+function StatusTooltip({ children, content }: { children: ReactNode; content: ReactNode }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span tabIndex={0} className="inline-flex cursor-help">{children}</span>
       </TooltipTrigger>
-      <TooltipContent className="max-w-72">{content}</TooltipContent>
+      <TooltipContent className="w-max max-w-sm">{content}</TooltipContent>
     </Tooltip>
   );
 }

--- a/frontend/src/shared/i18n/index.ts
+++ b/frontend/src/shared/i18n/index.ts
@@ -1784,12 +1784,14 @@ Object.assign(resources["zh-CN"].translation.settings.egress as unknown as Recor
 });
 
 Object.assign(resources["zh-CN"].translation.accounts as unknown as Record<string, string>, {
+  refreshErrorStatus: "HTTP 状态", refreshErrorCode: "错误码", refreshErrorMessage: "错误信息", refreshErrorResponse: "额外详情",
   egressConfiguration: "代理配置", egressConfigurationTitle: "配置 {{count}} 个账号的代理", egressConfigurationDescription: "选择绑定或解绑所选账号的固定出口代理。",
   bindEgress: "绑定代理", unbindEgress: "解绑代理", unbindEgressDescription: "移除所选账号的固定代理绑定；账号随后按当前出口策略重新参与调度。",
   bindEgressNode: "代理节点", bindEgressEmpty: "请选择代理节点", bindEgressNoNodes: "当前账号池没有可绑定的代理节点", egressBound: "代理已绑定", egressUnbound: "代理已解绑", egressFilter: "代理绑定",
 });
 
 Object.assign(resources.en.translation.accounts as unknown as Record<string, string>, {
+  refreshErrorStatus: "HTTP status", refreshErrorCode: "Code", refreshErrorMessage: "Message", refreshErrorResponse: "Details",
   egressConfiguration: "Proxy configuration", egressConfigurationTitle: "Configure proxy for {{count}} accounts", egressConfigurationDescription: "Choose whether to bind or unbind a fixed egress proxy for the selected accounts.",
   bindEgress: "Bind proxy", unbindEgress: "Unbind proxy", unbindEgressDescription: "Remove fixed proxy bindings from the selected accounts. They will return to the current egress routing policy.",
   bindEgressNode: "Proxy node", bindEgressEmpty: "Select a proxy node", bindEgressNoNodes: "No compatible proxy nodes are available for this account pool", egressBound: "Proxy bound", egressUnbound: "Proxy unbound", egressFilter: "Proxy binding",


### PR DESCRIPTION

## 概要

- 完整记录凭据刷新失败时的 HTTP 状态、错误码、错误信息及脱敏响应详情。
- 兼容 OAuth 错误的顶层、嵌套及非 JSON 响应格式。
- 优化账号失效状态 Tooltip，统一字体与排版并避免重复展示。
- 凭据刷新成功后自动清除历史错误信息。

## 问题

原实现只解析上游响应中的 `error` 和 `error_description`：

```json
{
  "error": "invalid_grant",
  "error_description": "Access denied"
}
```

如果上游同时返回 `message`、`detail`、嵌套 `error.message` 或其他诊断字段，这些内容会被丢弃，管理端无法确认完整失败原因。

同时，Tooltip 中不同字号、字重和等宽字体混用，响应正文还会重复展示已经提取的 Code 和 Message，影响可读性。

## 修改内容

### OAuth 错误解析

- 保存上游 HTTP 状态码。
- 支持以下错误字段：
  - `error`
  - `error_description`
  - `message`
  - `detail`
  - `description`
  - `title`
  - 嵌套的 `error.code`、`error.message` 等字段
- 非 JSON 错误响应也会保留有限长度的诊断内容。
- 多个不同的错误信息会去重后合并。
- 超长内容会明确使用 `…` 标记截断，不再静默省略。

### 安全处理

响应详情写入数据库前会进行脱敏：

- Access Token
- Refresh Token
- ID Token
- Authorization
- Cookie
- JWT
- Password、Secret、Credential 等敏感字段

敏感值统一替换为：

```text
[REDACTED]
```

### 数据与 API

账号凭据刷新状态新增：

- `lastRefreshErrorStatus`
- `lastRefreshErrorMessage`
- `lastRefreshErrorResponse`

刷新成功后会同时清空上述字段和原有错误码，避免继续展示过期错误。

历史数据保持兼容；旧记录无法还原此前未保存的完整响应，但不会影响账号列表和调用链路。

### 管理端 UI

失效状态 Tooltip 统一使用相同的字体、字号、字重和行高，以两列形式展示：

- HTTP 状态
- 错误码
- 错误信息
- 额外详情

如果响应正文只包含已经展示的 Code 和 Message，则自动隐藏重复内容；只有存在额外字段时才显示脱敏详情。

## 验证

后端：

```bash
go test ./...
go test -race ./internal/infra/provider/cli ./internal/application/account
```

前端：

```bash
pnpm lint
pnpm build
```

全部通过。