### PR TITLE
fix: allow manual retry of invalid Build credentials

### DIFF
--- a/backend/internal/application/account/credential_refresh_test.go
+++ b/backend/internal/application/account/credential_refresh_test.go
@@ -56,7 +56,7 @@ func TestEnsureCredentialReusesRotatedTokenAndThrottlesForcedRefresh(t *testing.
 		t.Fatalf("refresh after cooldown = %#v, count = %d", afterCooldown, adapter.refreshCount.Load())
 	}
 
-	manual, err := service.ensureCredential(ctx, afterCooldown, true, true, false)
+	manual, err := service.ensureCredential(ctx, afterCooldown, ensureCredentialOptions{force: true, bypassCooldown: true, retryPermanentOnce: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,6 +405,26 @@ func TestCredentialRefreshFailureDistinguishesTransientAndPermanent(t *testing.T
 	if finalState.AuthStatus != accountdomain.AuthStatusReauthRequired {
 		t.Fatalf("permanent with expired token should be reauthRequired: %#v", finalState)
 	}
+	manualCount := adapter.refreshCount.Load()
+	manualOptions := ensureCredentialOptions{force: true, bypassCooldown: true, retryPermanentOnce: true}
+	if _, err := service.ensureCredential(ctx, finalState, manualOptions); err == nil {
+		t.Fatal("manual retry should surface the repeated invalid_grant")
+	}
+	if adapter.refreshCount.Load() != manualCount+1 {
+		t.Fatalf("manual retry did not issue exactly one oauth request: before=%d after=%d", manualCount, adapter.refreshCount.Load())
+	}
+	adapter.refreshErr = nil
+	latest, err := service.accounts.Get(ctx, finalState.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := service.ensureCredential(ctx, latest, manualOptions)
+	if err != nil {
+		t.Fatalf("manual retry did not recover credential: %v", err)
+	}
+	if recovered.AuthStatus != accountdomain.AuthStatusActive || recovered.RefreshPermanent || recovered.LastRefreshErrorCode != "" {
+		t.Fatalf("manual recovery state = %#v", recovered)
+	}
 }
 
 func TestCredentialDecryptFailedAllowsRetryAfterKeyRecovery(t *testing.T) {
@@ -466,8 +486,19 @@ func TestRefreshAllTokensSkipsUnrefreshableAccounts(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	invalid, _, err := service.accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderBuild, Name: "invalid-refreshable", SourceKey: "invalid-refreshable",
+		EncryptedAccessToken: "access-invalid", EncryptedRefreshToken: "refresh-invalid", ExpiresAt: now.Add(time.Hour), Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid.AuthStatus = accountdomain.AuthStatusReauthRequired
+	if _, err := service.accounts.Update(ctx, invalid); err != nil {
+		t.Fatal(err)
+	}
 
-	progress := make([][2]int, 0, 3)
+	progress := make([][2]int, 0, 4)
 	succeeded, failed, skipped, err := service.RefreshAllTokensWithProgress(ctx, func(completed, total int) error {
 		progress = append(progress, [2]int{completed, total})
 		return nil
@@ -475,11 +506,15 @@ func TestRefreshAllTokensSkipsUnrefreshableAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if succeeded != 2 || failed != 0 || skipped != 1 || adapter.refreshCount.Load() != 2 {
+	if succeeded != 3 || failed != 0 || skipped != 1 || adapter.refreshCount.Load() != 3 {
 		t.Fatalf("result = %d/%d/%d, refresh count = %d", succeeded, failed, skipped, adapter.refreshCount.Load())
 	}
-	if len(progress) != 3 || progress[0] != [2]int{0, 2} || progress[1] != [2]int{1, 2} || progress[2] != [2]int{2, 2} {
+	if len(progress) != 4 || progress[0] != [2]int{0, 3} || progress[1] != [2]int{1, 3} || progress[2] != [2]int{2, 3} || progress[3] != [2]int{3, 3} {
 		t.Fatalf("progress = %#v", progress)
+	}
+	recovered, err := service.accounts.Get(ctx, invalid.ID)
+	if err != nil || recovered.AuthStatus != accountdomain.AuthStatusActive {
+		t.Fatalf("invalid account was not recovered: %#v err=%v", recovered, err)
 	}
 }
 
@@ -489,6 +524,7 @@ func TestBatchRefreshTokensRefreshesOnlySelectedEligibleAccounts(t *testing.T) {
 	service, refreshable, adapter := newCredentialRefreshTestService(t, now)
 	service.now = func() time.Time { return now }
 	selected := []uint64{refreshable.ID}
+	var invalidID uint64
 	for _, value := range []accountdomain.Credential{
 		{Provider: accountdomain.ProviderBuild, Name: "missing-refresh", SourceKey: "missing-refresh", EncryptedAccessToken: "access", Enabled: true, AuthStatus: accountdomain.AuthStatusActive},
 		{Provider: accountdomain.ProviderBuild, Name: "disabled", SourceKey: "disabled", EncryptedAccessToken: "access", EncryptedRefreshToken: "refresh", Enabled: true, AuthStatus: accountdomain.AuthStatusActive},
@@ -505,6 +541,7 @@ func TestBatchRefreshTokensRefreshesOnlySelectedEligibleAccounts(t *testing.T) {
 		}
 		if value.Name == "invalid" {
 			created.AuthStatus = accountdomain.AuthStatusReauthRequired
+			invalidID = created.ID
 			needsUpdate = true
 		}
 		if needsUpdate {
@@ -520,15 +557,19 @@ func TestBatchRefreshTokensRefreshesOnlySelectedEligibleAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if succeeded != 1 || failed != 0 || skipped != 3 || adapter.refreshCount.Load() != 1 {
+	if succeeded != 2 || failed != 0 || skipped != 2 || adapter.refreshCount.Load() != 2 {
 		t.Fatalf("result = %d/%d/%d, refresh count = %d", succeeded, failed, skipped, adapter.refreshCount.Load())
 	}
 	updated, err := service.accounts.Get(ctx, refreshable.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updated.EncryptedAccessToken != "access-1" {
+	if updated.EncryptedAccessToken == "" || updated.EncryptedAccessToken == "access-0" {
 		t.Fatalf("refreshed access token = %q", updated.EncryptedAccessToken)
+	}
+	recovered, err := service.accounts.Get(ctx, invalidID)
+	if err != nil || recovered.AuthStatus != accountdomain.AuthStatusActive {
+		t.Fatalf("selected invalid account was not recovered: %#v err=%v", recovered, err)
 	}
 }
 

--- a/backend/internal/application/account/credential_scheduler.go
+++ b/backend/internal/application/account/credential_scheduler.go
@@ -63,7 +63,7 @@ func (s *Service) RecoverCriticalCredentials(ctx context.Context, expiresWithin 
 			return s.MarkReauthRequired(taskCtx, id, permanentRefreshExpiredReason)
 		}
 		// 临界凭据不受进程内强制刷新节流影响；分布式账号锁和旋转 Token 比对仍避免重复 OAuth。
-		_, refreshErr := s.ensureCredential(taskCtx, credential, true, true, false)
+		_, refreshErr := s.ensureCredential(taskCtx, credential, ensureCredentialOptions{force: true, bypassCooldown: true})
 		return refreshErr
 	})
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
@@ -139,7 +139,7 @@ func (s *Service) refreshDueCredentials(ctx context.Context) error {
 			if credential.RefreshDueAt != nil && credential.RefreshDueAt.After(s.now()) {
 				return nil
 			}
-			_, err = s.ensureCredential(taskCtx, credential, true, false, true)
+			_, err = s.ensureCredential(taskCtx, credential, ensureCredentialOptions{force: true, respectSchedule: true})
 			return err
 		})
 		if batchErr != nil {

--- a/backend/internal/application/account/service.go
+++ b/backend/internal/application/account/service.go
@@ -2006,29 +2006,39 @@ func (s *Service) markSSOCredentialRejected(ctx context.Context, value accountdo
 
 // EnsureCredential 在即将过期时刷新 token，同一账号并发请求只执行一次刷新。
 func (s *Service) EnsureCredential(ctx context.Context, value accountdomain.Credential, force bool) (accountdomain.Credential, error) {
-	return s.ensureCredential(ctx, value, force, false, false)
+	return s.ensureCredential(ctx, value, ensureCredentialOptions{force: force})
 }
 
-func (s *Service) ensureCredential(ctx context.Context, value accountdomain.Credential, force, bypassCooldown, respectSchedule bool) (accountdomain.Credential, error) {
+type ensureCredentialOptions struct {
+	force              bool
+	bypassCooldown     bool
+	respectSchedule    bool
+	retryPermanentOnce bool
+}
+
+func (s *Service) ensureCredential(ctx context.Context, value accountdomain.Credential, options ensureCredentialOptions) (accountdomain.Credential, error) {
 	if s.providers == nil || !s.providers.SupportsCredentialRefresh(value.Provider) {
-		if force {
+		if options.force {
 			return accountdomain.Credential{}, ErrUnsupported
 		}
 		return value, nil
 	}
 	now := s.now()
-	if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, value, now, force); handled {
+	if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, value, now, options.force, options.retryPermanentOnce); handled {
 		return credential, err
 	}
-	if !force && value.ExpiresAt.IsZero() && value.EncryptedAccessToken != "" {
+	if !options.force && value.ExpiresAt.IsZero() && value.EncryptedAccessToken != "" {
 		return value, nil
 	}
-	if !force && value.EncryptedAccessToken != "" && !value.ExpiresAt.IsZero() && now.Add(credentialRefreshAdvance).Before(value.ExpiresAt) {
+	if !options.force && value.EncryptedAccessToken != "" && !value.ExpiresAt.IsZero() && now.Add(credentialRefreshAdvance).Before(value.ExpiresAt) {
 		return value, nil
 	}
 	refreshKey := strconv.FormatUint(value.ID, 10)
-	if respectSchedule {
+	if options.respectSchedule {
 		refreshKey += ":scheduled"
+	}
+	if options.retryPermanentOnce {
+		refreshKey += ":manual-retry"
 	}
 	result, err, _ := s.refreshes.Do(refreshKey, func() (any, error) {
 		latest, err := s.accounts.Get(ctx, value.ID)
@@ -2036,22 +2046,22 @@ func (s *Service) ensureCredential(ctx context.Context, value accountdomain.Cred
 			return nil, err
 		}
 		currentTime := s.now()
-		if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, latest, currentTime, force); handled {
+		if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, latest, currentTime, options.force, options.retryPermanentOnce); handled {
 			if err != nil {
 				return nil, err
 			}
 			return credential, nil
 		}
-		if respectSchedule && latest.RefreshDueAt != nil && latest.RefreshDueAt.After(currentTime) {
+		if options.respectSchedule && latest.RefreshDueAt != nil && latest.RefreshDueAt.After(currentTime) {
 			return latest, nil
 		}
-		if force && latest.EncryptedAccessToken != "" && latest.EncryptedAccessToken != value.EncryptedAccessToken {
+		if options.force && latest.EncryptedAccessToken != "" && latest.EncryptedAccessToken != value.EncryptedAccessToken {
 			return latest, nil
 		}
-		if !force && latest.EncryptedAccessToken != "" && !latest.ExpiresAt.IsZero() && currentTime.Add(credentialRefreshAdvance).Before(latest.ExpiresAt) {
+		if !options.force && latest.EncryptedAccessToken != "" && !latest.ExpiresAt.IsZero() && currentTime.Add(credentialRefreshAdvance).Before(latest.ExpiresAt) {
 			return latest, nil
 		}
-		if force && !bypassCooldown && s.credentialRefreshCoolingDown(latest, currentTime) {
+		if options.force && !options.bypassCooldown && s.credentialRefreshCoolingDown(latest, currentTime) {
 			return latest, nil
 		}
 		release, err := s.acquireRefreshLock(ctx, latest.ID)
@@ -2065,22 +2075,22 @@ func (s *Service) ensureCredential(ctx context.Context, value accountdomain.Cred
 				return nil, err
 			}
 			currentTime = s.now()
-			if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, latest, currentTime, force); handled {
+			if credential, err, handled := s.resolvePermanentRefreshFailure(ctx, latest, currentTime, options.force, options.retryPermanentOnce); handled {
 				if err != nil {
 					return nil, err
 				}
 				return credential, nil
 			}
-			if respectSchedule && latest.RefreshDueAt != nil && latest.RefreshDueAt.After(currentTime) {
+			if options.respectSchedule && latest.RefreshDueAt != nil && latest.RefreshDueAt.After(currentTime) {
 				return latest, nil
 			}
-			if force && !bypassCooldown && s.credentialRefreshCoolingDown(latest, currentTime) {
+			if options.force && !options.bypassCooldown && s.credentialRefreshCoolingDown(latest, currentTime) {
 				return latest, nil
 			}
 			if latest.EncryptedAccessToken != "" && latest.EncryptedAccessToken != value.EncryptedAccessToken {
 				return latest, nil
 			}
-			if !force && latest.EncryptedAccessToken != "" && !latest.ExpiresAt.IsZero() && currentTime.Add(credentialRefreshAdvance).Before(latest.ExpiresAt) {
+			if !options.force && latest.EncryptedAccessToken != "" && !latest.ExpiresAt.IsZero() && currentTime.Add(credentialRefreshAdvance).Before(latest.ExpiresAt) {
 				return latest, nil
 			}
 		}
@@ -2091,7 +2101,7 @@ func (s *Service) ensureCredential(ctx context.Context, value accountdomain.Cred
 		refreshed, err := adapter.RefreshCredential(ctx, latest)
 		if err != nil {
 			persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), credentialRefreshStateTTL)
-			s.recordCredentialRefreshFailure(persistCtx, latest, err)
+			s.recordCredentialRefreshFailure(persistCtx, latest, err, !options.retryPermanentOnce)
 			cancel()
 			return nil, err
 		}
@@ -2143,7 +2153,7 @@ func (s *Service) RefreshToken(ctx context.Context, id uint64) (View, error) {
 	if err != nil {
 		return View{}, mapRepositoryError(err)
 	}
-	if _, err := s.ensureCredential(ctx, value, true, true, false); err != nil {
+	if _, err := s.ensureCredential(ctx, value, ensureCredentialOptions{force: true, bypassCooldown: true, retryPermanentOnce: true}); err != nil {
 		return View{}, err
 	}
 	return s.Get(ctx, id)
@@ -2178,7 +2188,7 @@ func (s *Service) clearRefreshState(accountID uint64) {
 	s.refreshMu.Unlock()
 }
 
-func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential accountdomain.Credential, refreshErr error) {
+func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential accountdomain.Credential, refreshErr error, preservePermanent bool) {
 	if errors.Is(refreshErr, context.Canceled) || errors.Is(refreshErr, context.DeadlineExceeded) && errors.Is(ctx.Err(), context.Canceled) {
 		return
 	}
@@ -2211,7 +2221,7 @@ func (s *Service) recordCredentialRefreshFailure(ctx context.Context, credential
 	if permanent && isRecoverableRefreshErrorCode(errorCode) {
 		permanent = false
 	}
-	if credential.RefreshPermanent && !isRecoverableRefreshErrorCode(credential.LastRefreshErrorCode) && !isRecoverableRefreshErrorCode(errorCode) {
+	if preservePermanent && credential.RefreshPermanent && !isRecoverableRefreshErrorCode(credential.LastRefreshErrorCode) && !isRecoverableRefreshErrorCode(errorCode) {
 		permanent = true
 	}
 	now := s.now()
@@ -2277,15 +2287,18 @@ func normalizeCredentialRefreshErrorResponse(value string) string {
 	return value
 }
 
-// resolvePermanentRefreshFailure 阻止再次请求已确认失效的 refresh token，并在 access token 到期后收敛账号状态。
-// credential_decrypt_failed 属于本地密钥问题，允许手动 force / 调度重试（密钥恢复后可自愈）；
-// invalid_grant 等真正 OAuth 永久失败仍保持阻断。
-func (s *Service) resolvePermanentRefreshFailure(ctx context.Context, credential accountdomain.Credential, now time.Time, force bool) (accountdomain.Credential, error, bool) {
+// resolvePermanentRefreshFailure 阻止自动链路再次请求已确认失效的 refresh token，
+// 并在 access token 到期后收敛账号状态。管理员显式刷新可通过
+// retryPermanentOnce 绕过一次；credential_decrypt_failed 等可恢复本地错误不受阻断。
+func (s *Service) resolvePermanentRefreshFailure(ctx context.Context, credential accountdomain.Credential, now time.Time, force, retryPermanentOnce bool) (accountdomain.Credential, error, bool) {
 	if !credential.RefreshPermanent {
 		return accountdomain.Credential{}, nil, false
 	}
 	if isRecoverableRefreshErrorCode(credential.LastRefreshErrorCode) {
 		// 允许 force 或到期调度再次尝试解密/刷新；成功后会 clear permanent 标记。
+		return accountdomain.Credential{}, nil, false
+	}
+	if retryPermanentOnce {
 		return accountdomain.Credential{}, nil, false
 	}
 	accessTokenAlive := credential.EncryptedAccessToken != "" && !credential.ExpiresAt.IsZero() && credential.ExpiresAt.After(now)
@@ -3073,11 +3086,11 @@ func (s *Service) RefreshAllTokensWithProgress(ctx context.Context, progress Bat
 		if !s.providers.SupportsCredentialRefresh(providerValue) {
 			continue
 		}
-		providerIDs, err := s.accounts.ListEnabledAccountIDs(ctx, providerValue, false)
+		providerIDs, err := s.accounts.ListEnabledCredentialRefreshAccountIDs(ctx, providerValue, false)
 		if err != nil {
 			return 0, 0, 0, err
 		}
-		refreshableIDs, err := s.accounts.ListEnabledAccountIDs(ctx, providerValue, true)
+		refreshableIDs, err := s.accounts.ListEnabledCredentialRefreshAccountIDs(ctx, providerValue, true)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -3093,13 +3106,14 @@ func (s *Service) refreshTokens(ctx context.Context, ids []uint64, progress Batc
 	return s.runAccountBatch(ctx, "credential_refresh", ids, s.refreshPool, progress, func(workCtx context.Context, id uint64) error {
 		value, err := s.accounts.Get(workCtx, id)
 		if err == nil {
-			_, err = s.ensureCredential(workCtx, value, true, true, false)
+			_, err = s.ensureCredential(workCtx, value, ensureCredentialOptions{force: true, bypassCooldown: true, retryPermanentOnce: true})
 		}
 		return err
 	})
 }
 
-// BatchRefreshTokens 续期指定账号的凭据；停用、失效或缺少刷新凭据的账号会被跳过。
+// BatchRefreshTokens 续期指定账号的凭据；失效账号会强制向上游重试一次，
+// 停用、Provider 不支持或缺少刷新凭据的账号会被跳过。
 func (s *Service) BatchRefreshTokens(ctx context.Context, ids []uint64) (int, int, int, error) {
 	values, err := normalizeBatchIDs(ids)
 	if err != nil {
@@ -3114,7 +3128,7 @@ func (s *Service) BatchRefreshTokens(ctx context.Context, ids []uint64) (int, in
 		if getErr != nil {
 			return 0, 0, 0, getErr
 		}
-		if !s.providers.SupportsCredentialRefresh(value.Provider) || !value.Enabled || value.AuthStatus != accountdomain.AuthStatusActive || value.EncryptedRefreshToken == "" {
+		if !s.providers.SupportsCredentialRefresh(value.Provider) || !value.Enabled || value.EncryptedRefreshToken == "" {
 			continue
 		}
 		refreshableIDs = append(refreshableIDs, id)

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -548,6 +548,21 @@ func (r *AccountRepository) ListEnabledAccountIDs(ctx context.Context, provider 
 	return ids, err
 }
 
+func (r *AccountRepository) ListEnabledCredentialRefreshAccountIDs(ctx context.Context, provider account.Provider, refreshableOnly bool) ([]uint64, error) {
+	query := r.db.db.WithContext(ctx).
+		Table("provider_accounts AS account").
+		Select("account.id").
+		Where("account.provider = ? AND account.enabled = ? AND account.auth_status IN ?", provider, true, []account.AuthStatus{account.AuthStatusActive, account.AuthStatusReauthRequired})
+	if refreshableOnly {
+		query = query.
+			Joins("JOIN account_credentials AS credential ON credential.account_id = account.id").
+			Where("credential.encrypted_refresh <> ''")
+	}
+	var ids []uint64
+	err := query.Order("account.id ASC").Scan(&ids).Error
+	return ids, err
+}
+
 func (r *AccountRepository) FilterMissingBuildConversionIDs(ctx context.Context, ids []uint64) ([]uint64, error) {
 	if len(ids) == 0 {
 		return []uint64{}, nil

--- a/backend/internal/repository/account.go
+++ b/backend/internal/repository/account.go
@@ -82,6 +82,10 @@ type AccountRepository interface {
 	Summarize(ctx context.Context, now time.Time) ([]AccountSummary, error)
 	ListEnabled(ctx context.Context, provider account.Provider) ([]account.Credential, error)
 	ListEnabledAccountIDs(ctx context.Context, provider account.Provider, refreshableOnly bool) ([]uint64, error)
+	// ListEnabledCredentialRefreshAccountIDs includes enabled active and
+	// reauthRequired accounts so an explicit administrator refresh can retry a
+	// previously rejected refresh token once.
+	ListEnabledCredentialRefreshAccountIDs(ctx context.Context, provider account.Provider, refreshableOnly bool) ([]uint64, error)
 	CountProviderAccountsByIDs(ctx context.Context, provider account.Provider, ids []uint64) (int64, error)
 	// FilterMissingBuildConversionIDs 从指定账号中排除已经关联 Build 的 Web 账号。
 	FilterMissingBuildConversionIDs(ctx context.Context, ids []uint64) ([]uint64, error)

--- a/frontend/src/shared/i18n/index.ts
+++ b/frontend/src/shared/i18n/index.ts
@@ -446,7 +446,7 @@ const resources = {
         syncAllDescription: "将重新获取所有已启用 Grok Build 账号的额度数据。",
         syncAllWebDescription: "将重新获取所有已启用 Grok Web 账号的真实额度数据。",
         renewAllTitle: "续期所有账号？",
-        renewAllDescription: "将刷新所有支持自动续期的 Grok Build 凭据，不可自动续期的账号会被跳过。",
+        renewAllDescription: "将刷新所有具备刷新凭据的启用 Grok Build 账号；失效账号也会强制请求上游一次，缺少刷新凭据的账号会被跳过。",
         search: "搜索账号",
         deviceLogin: "Device OAuth",
         importAuth: "导入账号文件",
@@ -1792,6 +1792,7 @@ Object.assign(resources["zh-CN"].translation.accounts as unknown as Record<strin
 
 Object.assign(resources.en.translation.accounts as unknown as Record<string, string>, {
   refreshErrorStatus: "HTTP status", refreshErrorCode: "Code", refreshErrorMessage: "Message", refreshErrorResponse: "Details",
+  renewAllDescription: "Refresh every enabled Grok Build account with a refresh credential. Invalid accounts are forced to contact the upstream once; accounts without refresh credentials are skipped.",
   egressConfiguration: "Proxy configuration", egressConfigurationTitle: "Configure proxy for {{count}} accounts", egressConfigurationDescription: "Choose whether to bind or unbind a fixed egress proxy for the selected accounts.",
   bindEgress: "Bind proxy", unbindEgress: "Unbind proxy", unbindEgressDescription: "Remove fixed proxy bindings from the selected accounts. They will return to the current egress routing policy.",
   bindEgressNode: "Proxy node", bindEgressEmpty: "Select a proxy node", bindEgressNoNodes: "No compatible proxy nodes are available for this account pool", egressBound: "Proxy bound", egressUnbound: "Proxy unbound", egressFilter: "Proxy binding",


### PR DESCRIPTION

## 概要

- 允许管理员手动刷新已失效的 Grok Build 凭据，并强制向 OAuth 上游请求一次。
- 单账号刷新、批量刷新和“刷新全部”均支持失效账号重试。
- 自动调度、网关 401 恢复和正常选号仍会拦截永久失效凭据，避免无效请求循环。
- 保留完整的凭据刷新错误诊断，包括 HTTP 状态、错误码、错误信息和额外详情。

## 背景

Grok Build 账号一旦因 `invalid_grant` 等错误被标记为永久失效，原逻辑会直接阻止后续刷新。

这对自动任务是合理的，但也导致管理员点击手动刷新时无法真正请求上游。即使 Refresh Token 已在上游恢复，或此前状态判断已经过时，也只能继续看到旧错误。

## 修改内容

### 手动强制重试

以下管理员操作会绕过永久失败状态一次：

- 单账号刷新凭据
- 选中账号批量刷新
- 刷新全部凭据

具备 Refresh Token 的启用账号都会参与刷新，包括状态为“失效”的账号；缺少 Refresh Token、已停用或 Provider 不支持刷新的账号仍会跳过。

### 自动链路保持保护

以下链路不会绕过永久失败状态：

- 后台凭据刷新调度
- 临界凭据恢复
- Gateway 请求过程中的凭据续期
- 正常账号选号与调用

因此不会因为本次修改持续请求已经确认失效的 Refresh Token。

### 并发隔离

手动重试使用独立的 singleflight 标识，与自动刷新任务隔离，同时继续复用账号级分布式锁，避免多实例重复刷新。

### 状态处理

- 刷新成功：更新 Token，恢复账号为可用状态，并清除历史刷新错误。
- 刷新失败：保存本次上游返回的最新状态和错误信息。
- 手动重试产生的临时错误不会继承旧的永久失败标记。
- 自动链路仍保留既有永久失败状态，防止错误降级。

## 用户影响

管理员可以通过手动刷新验证失效凭据是否已经恢复，无需重新导入账号。

自动任务的保护行为保持不变，不会增加永久失效凭据的后台请求压力。

## 验证

```bash
go test ./... -count=1
go test -race ./internal/application/account ./internal/application/gateway -count=1
pnpm lint
pnpm build
git diff --cached --check
```

以上检查全部通过。