### PR TITLE
fix(media): 修复 Windows 下视频上传提交因只读句柄 fsync 失败

### DIFF
--- a/backend/internal/infra/media/local_store.go
+++ b/backend/internal/infra/media/local_store.go
@@ -88,7 +88,11 @@ func (s *LocalStore) CommitVideoUpload(ctx context.Context, tempPath, storageKey
 		return err
 	}
 	// 确保临时文件已落盘。
-	file, err := os.Open(tempPath)
+	// 必须以 O_RDWR 打开：Windows 的 FlushFileBuffers 要求句柄具有写访问权限，
+	// 对 O_RDONLY 句柄调用 Sync 会返回 Access is denied；
+	// Linux 的 fsync 对只读/读写 fd 行为一致，此举不改变 POSIX 平台语义。
+	// O_RDWR 不含 O_TRUNC，不会改动文件内容。
+	file, err := os.OpenFile(tempPath, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("打开视频临时文件: %w", err)
 	}


### PR DESCRIPTION
## 问题

在 Windows 上，`LocalStore.CommitVideoUpload` 的每次视频上传提交都会失败：

```
同步视频文件: sync ...\.video-XXXXXX: Access is denied.
```

Windows 开发机上有 6 个测试失败：

- `TestAdminDeleteVideoJobsJobsRemovesTerminalJobAssetAndTicket`
- `TestIssueAndReceiveVideoUploadOnce`
- `TestSaveVideoArchivesProviderResultWithoutUploadTicket`
- `TestReceiveVideoUploadConcurrentOnlyOnceSucceeds`
- `TestReceiveVideoUploadCommitFailureReleasesTicketForRetry`
- `TestPublicVideoAssetSupportsGetHeadAndRange`

Linux CI 不受影响，所以问题一直没被发现。

## 根因

`CommitVideoUpload` 以只读方式打开临时文件，随后在硬链接前执行 `Sync`：

```go
file, err := os.Open(tempPath)   // O_RDONLY
...
if err := file.Sync(); err != nil { ... }
```

- **POSIX**:`fsync` 作用于已打开的文件描述（file description），不校验描述符的
  访问模式，因此对 `O_RDONLY` 的 fd 调用是合法的。Go 侧 `os/file_posix.go` 中
  `(*File).Sync` 只是 `Fsync` 的直接透传。
- **Windows**:`Sync` 映射到 `FlushFileBuffers`，该 API **要求句柄必须有写访问权限**。
  `syscall_windows.go` 将 `O_RDONLY` 映射为 `GENERIC_READ`，对这种句柄调用会返回
  `ERROR_ACCESS_DENIED`。

这是典型的 POSIX/Windows 语义差异。直存路径（`saveObject`，即 `SaveImage`/`SaveVideo`
用到的）不受影响，因为它 sync 的是 `CreateTemp` 句柄，本来就是 `O_RDWR`。

## 修复

一行改动——以读写方式打开临时文件替代只读：

```go
file, err := os.OpenFile(tempPath, os.O_RDWR, 0)
```

- 不带 `O_TRUNC`，不会改动文件内容；该句柄仅用于 `Sync`/`Close`。
- **Linux 行为不变**:`fsync` 语义与 fd 以只读还是读写打开无关。唯一的理论差异是
  `open(2)` 现在要求写权限，但这条路径下不可能失败——临时文件由同一进程以 `0600`
  创建于 `0700` 属主私有目录内。即便该前提真被破坏，提前在 open 处失败也比硬链接
  一个未完全落盘的文件更安全。
- 曾考虑过的替代方案（已否决）:`GOOS == "windows"` 时跳过 `Sync`——这会在 Windows 上
  悄悄丢掉落盘保证，不如保留语义。

## 测试

Windows 11,Go 1.26.4:

- `go test ./internal/infra/media/... ./internal/application/media/... ./internal/transport/http/media/...` —— 全部通过（上述失败测试全部转绿）
- `go test ./...` —— 全量测试通过
- `go vet ./...` —— 无告警

Linux：按上述分析无行为变化，由 CI 覆盖验证。