### PR TITLE
fix(test): 修复直传文件名净化测试的跨平台断言

### DIFF
--- a/backend/internal/infra/provider/web/protocol_test.go
+++ b/backend/internal/infra/provider/web/protocol_test.go
@@ -13,6 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -741,7 +742,10 @@ func TestBuildDirectFileUploadBodySanitizesUnsafeFilename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if part.FormName() != "file" || part.FileName() != "a\\b\"c_.png" {
+	// multipart 的 Part.FileName() 内部会过一层 filepath.Base(平台相关):
+	// Windows 把 \ 视作路径分隔符,会剥掉 a\ 前缀;Linux 则原样返回。
+	// 期望值同样用 filepath.Base 计算,双平台同时成立,断言强度不变。
+	if part.FormName() != "file" || part.FileName() != filepath.Base(`a\b"c_.png`) {
 		t.Fatalf("form name=%q filename=%q", part.FormName(), part.FileName())
 	}
 }


### PR DESCRIPTION
## 问题

Windows 上运行 `go test ./internal/infra/provider/web` 必挂：

```
--- FAIL: TestBuildDirectFileUploadBodySanitizesUnsafeFilename
    protocol_test.go:745: form name="file" filename="b\"c_.png"
```

期望是 `a\b"c_.png`，实际得到 `b"c_.png`（开头的 `a\` 消失了）。
Linux CI 不受影响，所以未被发现。

## 根因

测试把 multipart 读回的文件名断言为**平台相关**的常量。

Go 标准库 `mime/multipart.Part.FileName()`(`src/mime/multipart/multipart.go:91`)
在返回前会过一层 `filepath.Base()`——其文档明确标注 **platform dependent**,
且剥到 basename 是 RFC 7578 §4.2 的要求（接收方必须丢弃路径信息）:

- **Linux**:`\` 不是路径分隔符 → `filepath.Base("a\\b\"c_.png")` = `a\b"c_.png`
  （恰好等于硬编码期望，测试绿）
- **Windows**:`\` 是路径分隔符 → 剥到最后一个分隔符之后 = `b"c_.png`（挂）

生产代码没有问题：净化函数 `browserMultipartFilename` 由同文件内的表驱动测试
`TestBrowserMultipartFilename` 覆盖且在 Windows 上全绿；真实上传链路也不消费
`Part.FileName()`。只有这个"写出再读回"的测试把 Linux 行为写成了常量。

## 修复

测试层一行：期望值改用 `filepath.Base` 计算，双平台同时成立：

```go
if part.FormName() != "file" || part.FileName() != filepath.Base(`a\b"c_.png`) {
```

- **Linux 上零变化**:`filepath.Base` 对该输入退化为恒等（`\` 非分隔符）,
  断言与修改前逐字节相同
- **Windows** 精确复刻标准库行为
- `\r\n\x00` 净化、quoted-string 转义/反转义的端到端断言强度不变

被否决的替代：删除测试输入中的 `\`（丢失转义覆盖）、双候选值断言（掩盖平台语义）、
Windows 跳过该测试（丢失覆盖）。

## 测试

Windows 11,Go 1.26.4:

- 修复前：该测试在 Windows 必挂；修复后 `go test ./internal/infra/provider/web` 全绿
- `go vet ./internal/infra/provider/web` 无告警

Linux：断言与修改前逐字节等价（见上文分析）,fork 仓库 CI(push main 相同的提交）
Verify 已通过，上游 CI 将再次覆盖验证。