### PR TITLE
fix: harden Grok Build 0.2.119 protocol compatibility

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -26,7 +26,7 @@ const (
 	ClearanceModeFlareSolverr     = "flaresolverr"
 	DefaultStatsigSignerURL       = "https://grok.wodf.de/sign"
 	DefaultFlareSolverrURL        = "http://flaresolverr:8191"
-	RecommendedBuildClientVersion = "0.2.111"
+	RecommendedBuildClientVersion = "0.2.119"
 	RecommendedBuildUserAgent     = "grok-shell/" + RecommendedBuildClientVersion + " (linux; x86_64)"
 
 	maxServerBodyBytes     = 256 << 20

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -139,17 +139,39 @@ func TestBuildResponseHeaderTimeoutIsRuntimeOnly(t *testing.T) {
 
 func TestDefaultGrokBuildClientVersionMatchesLocalBaseline(t *testing.T) {
 	build := defaultConfig().Provider.Build
-	if RecommendedBuildClientVersion != "0.2.111" {
+	if RecommendedBuildClientVersion != "0.2.119" {
 		t.Fatalf("recommended clientVersion = %q", RecommendedBuildClientVersion)
 	}
 	if build.ClientVersion != RecommendedBuildClientVersion {
 		t.Fatalf("clientVersion = %q", build.ClientVersion)
 	}
-	if RecommendedBuildUserAgent != "grok-shell/0.2.111 (linux; x86_64)" {
+	if RecommendedBuildUserAgent != "grok-shell/0.2.119 (linux; x86_64)" {
 		t.Fatalf("recommended userAgent = %q", RecommendedBuildUserAgent)
 	}
 	if build.UserAgent != RecommendedBuildUserAgent {
 		t.Fatalf("userAgent = %q", build.UserAgent)
+	}
+}
+
+func TestLoadKeepsExplicitGrokBuildClientFingerprint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	data := []byte(`provider:
+  build:
+    clientVersion: "0.2.111"
+    userAgent: "grok-shell/0.2.111 (linux; x86_64)"
+secrets:
+  jwtSecret: "12345678901234567890123456789012"
+  credentialEncryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider.Build.ClientVersion != "0.2.111" || cfg.Provider.Build.UserAgent != "grok-shell/0.2.111 (linux; x86_64)" {
+		t.Fatalf("explicit Build fingerprint was overwritten: %#v", cfg.Provider.Build)
 	}
 }
 

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -200,7 +200,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			}
 			return invalidResponsesResponse(err), nil
 		}
-		body, err = normalizeBuildReasoningEffort(body)
+		body, err = normalizeBuildRequest(body, request.Model)
 		if err != nil {
 			if request.Operation == conversation.OperationChat || request.Operation == conversation.OperationMessages {
 				return invalidConversationResponse(request.Operation, err), nil
@@ -340,12 +340,12 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 		}
 	}
 	reasoningRecovery.appendWarnings(resp.Header)
-	if responsesOperation && toolCompatibility != nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	if responsesOperation && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if request.Streaming {
 			resp.Body = toolCompatibility.normalizeResponseStream(resp.Body)
 			resp.Header.Del("Content-Length")
 			resp.Header.Set("Content-Type", "text/event-stream")
-		} else {
+		} else if toolCompatibility != nil {
 			data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxCompatibleResponseBytes+1))
 			_ = resp.Body.Close()
 			if readErr != nil {

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -935,6 +935,10 @@ func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
 		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
 			t.Fatal(err)
 		}
+		includes, _ := payload["include"].([]any)
+		if payload["store"] != false || len(includes) != 1 || includes[0] != "reasoning.encrypted_content" {
+			t.Fatalf("Build defaults = %#v", payload)
+		}
 		expectedSessionID, err := grokSessionID("chat-cache-key")
 		if err != nil {
 			t.Fatal(err)

--- a/backend/internal/infra/provider/cli/normalize.go
+++ b/backend/internal/infra/provider/cli/normalize.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
 )
 
 // normalizeResponsesRequest 改写路由字段和兼容别名，并为上游不支持的新工具协议建立请求级映射。
@@ -14,7 +16,9 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 		return nil, nil, fmt.Errorf("解析 Responses 请求: %w", err)
 	}
 	payload["model"] = mustJSON(model)
-	normalizeBuildReasoningEffortPayload(payload)
+	if _, err := normalizeBuildRequestPayload(payload, model); err != nil {
+		return nil, nil, err
+	}
 	if responseFormat, exists := payload["response_format"]; exists {
 		var text map[string]json.RawMessage
 		if raw := payload["text"]; len(raw) > 0 && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
@@ -51,19 +55,71 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 	return normalized, compatibility, nil
 }
 
-// normalizeBuildReasoningEffort maps client aliases to levels accepted by Grok Build.
-func normalizeBuildReasoningEffort(body []byte) ([]byte, error) {
+// normalizeBuildRequest applies the stable compatibility boundary shared by Responses,
+// Chat Completions, and Anthropic Messages before the request reaches Grok Build.
+func normalizeBuildRequest(body []byte, model string) ([]byte, error) {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return nil, fmt.Errorf("解析 Build reasoning 请求: %w", err)
+		return nil, fmt.Errorf("解析 Build 请求: %w", err)
 	}
-	if !normalizeBuildReasoningEffortPayload(payload) {
+	changed, err := normalizeBuildRequestPayload(payload, model)
+	if err != nil {
+		return nil, err
+	}
+	if !changed {
 		return body, nil
 	}
 	return json.Marshal(payload)
 }
 
-func normalizeBuildReasoningEffortPayload(payload map[string]json.RawMessage) bool {
+func normalizeBuildRequestPayload(payload map[string]json.RawMessage, model string) (bool, error) {
+	changed := false
+	// client_metadata is a Codex transport envelope and may contain local paths,
+	// repository remotes, and installation/session identifiers. It is consumed by
+	// the HTTP boundary for cache affinity and must never cross into Grok Build.
+	if _, exists := payload["client_metadata"]; exists {
+		delete(payload, "client_metadata")
+		changed = true
+	}
+	if normalizeBuildReasoningEffortPayload(payload, model) {
+		changed = true
+	}
+	defaultsChanged, err := applyBuildResponseDefaults(payload)
+	if err != nil {
+		return false, err
+	}
+	return changed || defaultsChanged, nil
+}
+
+// applyBuildResponseDefaults mirrors the official Grok Build client boundary.
+// Explicit store=true remains a caller choice; only an absent/null value is made ZDR-safe.
+func applyBuildResponseDefaults(payload map[string]json.RawMessage) (bool, error) {
+	changed := false
+	if raw, exists := payload["store"]; !exists || isEmptyJSON(raw) {
+		payload["store"] = mustJSON(false)
+		changed = true
+	}
+
+	var includes []string
+	if raw, exists := payload["include"]; exists && !isEmptyJSON(raw) {
+		if err := json.Unmarshal(raw, &includes); err != nil {
+			return false, fmt.Errorf("解析 Build include: %w", err)
+		}
+	}
+	for _, value := range includes {
+		if value == "reasoning.encrypted_content" {
+			return changed, nil
+		}
+	}
+	includes = append(includes, "reasoning.encrypted_content")
+	payload["include"] = mustJSON(includes)
+	return true, nil
+}
+
+// normalizeBuildReasoningEffortPayload maps client aliases to levels accepted by
+// the selected Grok model. Grok 4.5 and unknown models retain the proven defensive
+// xhigh/max -> high behavior; explicitly supported xhigh models keep their value.
+func normalizeBuildReasoningEffortPayload(payload map[string]json.RawMessage, model string) bool {
 	raw, exists := payload["reasoning"]
 	if !exists || isEmptyJSON(raw) {
 		return false
@@ -78,8 +134,14 @@ func normalizeBuildReasoningEffortPayload(payload map[string]json.RawMessage) bo
 	}
 	var normalized string
 	switch strings.ToLower(strings.TrimSpace(effort)) {
-	case "max", "xhigh":
-		normalized = "high"
+	case "xhigh":
+		if modeldomain.SupportsReasoningEffort(model, modeldomain.ReasoningEffortXHigh) {
+			normalized = modeldomain.ReasoningEffortXHigh
+		} else {
+			normalized = modeldomain.ReasoningEffortHigh
+		}
+	case "max":
+		normalized = modeldomain.ReasoningEffortHigh
 	default:
 		return false
 	}

--- a/backend/internal/infra/provider/cli/normalize_test.go
+++ b/backend/internal/infra/provider/cli/normalize_test.go
@@ -41,19 +41,24 @@ func TestNormalizeResponsesRequest(t *testing.T) {
 func TestNormalizeBuildReasoningEffort(t *testing.T) {
 	tests := []struct {
 		name   string
+		model  string
 		effort string
 		want   string
 	}{
-		{name: "max", effort: "max", want: "high"},
-		{name: "xhigh", effort: "xhigh", want: "high"},
-		{name: "uppercase max", effort: "MAX", want: "high"},
-		{name: "high", effort: "high", want: "high"},
-		{name: "medium", effort: "medium", want: "medium"},
+		{name: "4.5 max", model: "grok-4.5", effort: "max", want: "high"},
+		{name: "4.5 xhigh", model: "grok-4.5", effort: "xhigh", want: "high"},
+		{name: "4.5 uppercase max", model: "grok-4.5", effort: "MAX", want: "high"},
+		{name: "multi-agent xhigh", model: "grok-4.20-multi-agent-0309", effort: "xhigh", want: "xhigh"},
+		{name: "multi-agent uppercase xhigh", model: "grok-4.20-multi-agent-0309", effort: "XHIGH", want: "xhigh"},
+		{name: "multi-agent max remains guarded", model: "grok-4.20-multi-agent-0309", effort: "max", want: "high"},
+		{name: "unknown xhigh remains guarded", model: "future-model", effort: "xhigh", want: "high"},
+		{name: "high", model: "grok-4.5", effort: "high", want: "high"},
+		{name: "medium", model: "grok-4.5", effort: "medium", want: "medium"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			body := []byte(`{"reasoning":{"effort":"` + test.effort + `"},"input":"hello"}`)
-			normalized, err := normalizeBuildReasoningEffort(body)
+			normalized, err := normalizeBuildRequest(body, test.model)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -66,6 +71,63 @@ func TestNormalizeBuildReasoningEffort(t *testing.T) {
 				t.Fatalf("reasoning = %#v, want %q", payload["reasoning"], test.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeBuildRequestAppliesSafeDefaultsAndStripsCodexEnvelope(t *testing.T) {
+	body := []byte(`{
+		"model":"public",
+		"input":"hello",
+		"metadata":{"tenant":"keep"},
+		"client_metadata":{"cwd":"/private/workspace","git_remote":"ssh://private/repo"},
+		"include":["web_search_call.action.sources"]
+	}`)
+	normalized, err := normalizeBuildRequest(body, "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["client_metadata"] != nil {
+		t.Fatalf("client_metadata crossed Build boundary: %#v", payload["client_metadata"])
+	}
+	if payload["metadata"].(map[string]any)["tenant"] != "keep" || payload["store"] != false {
+		t.Fatalf("standard metadata or store default changed incorrectly: %#v", payload)
+	}
+	includes := payload["include"].([]any)
+	if len(includes) != 2 || includes[0] != "web_search_call.action.sources" || includes[1] != "reasoning.encrypted_content" {
+		t.Fatalf("include = %#v", includes)
+	}
+}
+
+func TestNormalizeBuildRequestPreservesExplicitStoreAndEncryptedInclude(t *testing.T) {
+	body := []byte(`{"input":"hello","store":true,"include":["reasoning.encrypted_content"],"stream_tool_calls":true}`)
+	normalized, err := normalizeBuildRequest(body, "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["store"] != true || len(payload["include"].([]any)) != 1 || payload["stream_tool_calls"] != true {
+		t.Fatalf("explicit Build defaults were overwritten: %#v", payload)
+	}
+}
+
+func TestNormalizeBuildRequestDoesNotInventStreamToolCalls(t *testing.T) {
+	normalized, err := normalizeBuildRequest([]byte(`{"input":"hello"}`), "grok-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := payload["stream_tool_calls"]; exists {
+		t.Fatalf("stream_tool_calls must remain client/model controlled: %#v", payload)
 	}
 }
 

--- a/backend/internal/infra/provider/cli/responses_advanced_test.go
+++ b/backend/internal/infra/provider/cli/responses_advanced_test.go
@@ -349,7 +349,7 @@ func TestResponsesBuild02110NativeAndUnsupportedToolMatrix(t *testing.T) {
 			body := []byte(`{"model":"public","input":"hello","tools":[{"type":"` + kind + `"}]}`)
 			_, _, err := normalizeResponsesRequest(body, "grok-4.5")
 			requestErr, ok := err.(*responsesRequestError)
-			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "0.2.110") {
+			if !ok || requestErr.Code != "unsupported_parameter" || requestErr.Param != "tools[0].type" || !strings.Contains(requestErr.Message, "Grok Build") {
 				t.Fatalf("error = %#v", err)
 			}
 		})
@@ -534,6 +534,30 @@ func TestResponsesStreamFiltersPrivateEventsAndPreservesSSEFields(t *testing.T) 
 	}
 	if strings.Contains(text, "xai.internal") || strings.Contains(text, "private") {
 		t.Fatalf("私有事件泄露:\n%s", text)
+	}
+}
+
+func TestResponsesStreamAlwaysStripsBOMAndDoomLoopControlEvents(t *testing.T) {
+	source := "\uFEFFevent: response.created\n" +
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n" +
+		"event: response.doom_loop_check\n" +
+		"data: {\"type\":\"response.doom_loop_check\",\"detected\":false}\n\n" +
+		"data: {\"type\":\"response.doom_loop_check\",\"detected\":true}\n\n" +
+		"event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\"}}\n\n"
+	var compatibility *responsesToolCompatibility
+	converted, err := io.ReadAll(compatibility.normalizeResponseStream(io.NopCloser(strings.NewReader(source))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(converted)
+	if strings.Contains(text, "\uFEFF") || strings.Contains(text, "doom_loop_check") {
+		t.Fatalf("Build private framing leaked downstream:\n%s", text)
+	}
+	for _, expected := range []string{"event: response.created", "event: response.completed", `"id":"resp_1"`} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("SSE missing %q:\n%s", expected, text)
+		}
 	}
 }
 

--- a/backend/internal/infra/provider/cli/responses_codex_tools.go
+++ b/backend/internal/infra/provider/cli/responses_codex_tools.go
@@ -19,7 +19,7 @@ func (c *responsesToolCompatibility) normalizeShellTool(tool map[string]any, par
 	return c.normalizeNativeTool(tool, param)
 }
 
-// normalizeLegacyLocalShellTool upgrades the legacy Codex local_shell declaration to Build 0.2.110.
+// normalizeLegacyLocalShellTool upgrades the legacy Codex local_shell declaration to Build's native shell shape.
 func (c *responsesToolCompatibility) normalizeLegacyLocalShellTool(tool map[string]any, param string) ([]any, error) {
 	if c.nativeShell || c.legacyLocalShell {
 		return nil, &responsesRequestError{
@@ -368,7 +368,7 @@ func (c *responsesToolCompatibility) normalizeFunctionCallOutputBlocks(blocks []
 			}
 			normalized = append(normalized, converted)
 		default:
-			return nil, &responsesRequestError{Message: "Grok Build 0.2.110 不支持该 function_call_output.output 类型", Param: blockParam + ".type", Code: "unsupported_parameter"}
+			return nil, &responsesRequestError{Message: "Grok Build 不支持该 function_call_output.output 类型", Param: blockParam + ".type", Code: "unsupported_parameter"}
 		}
 	}
 	return normalized, nil

--- a/backend/internal/infra/provider/cli/responses_compaction.go
+++ b/backend/internal/infra/provider/cli/responses_compaction.go
@@ -20,7 +20,7 @@ const (
 
 // Generated from xai-org/grok-build's full_replace_summary_prompt.txt using
 // build_summary_prompt(None), so the optional {user_context_section} slot is
-// empty. The Grok Build 0.2.110 source confirms that this text is appended as
+// empty. The Grok Build source confirms that this text is appended as
 // the final user item for every compaction attempt.
 //
 //go:embed responses_compaction_prompt.txt
@@ -125,7 +125,7 @@ func expandGatewayCompactionHistory(body []byte, codec *gatewayCompactionCodec, 
 	return encoded, foreign, err
 }
 
-// prepareGatewayCompactionSample mirrors Grok Build 0.2.110 full-replace
+// prepareGatewayCompactionSample mirrors Grok Build full-replace
 // sampling: normal /responses SSE, instructions=null, tools retained with
 // tool_choice=auto, concise reasoning summary, and the canonical final user prompt.
 func prepareGatewayCompactionSample(body []byte) ([]byte, error) {

--- a/backend/internal/infra/provider/cli/responses_history.go
+++ b/backend/internal/infra/provider/cli/responses_history.go
@@ -53,7 +53,7 @@ func (c *responsesToolCompatibility) normalizeInputItems(items []any) ([]any, []
 			rewritten = append(rewritten, converted)
 		case "file_search_call", "web_search_call", "image_generation_call", "code_interpreter_call",
 			"shell_call", "mcp_list_tools", "mcp_approval_request", "mcp_approval_response", "mcp_call", "compaction":
-			// These types are part of the Grok Build 0.2.110 Responses InputItem contract.
+			// These types are part of the native Grok Build Responses InputItem contract.
 			// Remove only Codex-private fields and nulls; native calls must not degrade to text.
 			converted := sanitizeNativeHistoryInput(item, itemType)
 			c.changed = true
@@ -286,7 +286,7 @@ func hasPortableReasoningContent(item map[string]any) bool {
 	return false
 }
 
-// sanitizeNativeHistoryInput rebuilds history from Grok Build 0.2.110 native InputItem fields
+// sanitizeNativeHistoryInput rebuilds history from native Grok Build InputItem fields
 // so Codex extension metadata cannot interfere with Rust untagged enum deserialization.
 func sanitizeNativeHistoryInput(item map[string]any, itemType string) map[string]any {
 	var fields []string

--- a/backend/internal/infra/provider/cli/responses_input.go
+++ b/backend/internal/infra/provider/cli/responses_input.go
@@ -135,7 +135,7 @@ func (c *responsesToolCompatibility) normalizeMessageContent(value any, role, pa
 		case "input_file":
 			normalized = append(normalized, normalizeInputFilePart(item))
 		default:
-			return nil, &responsesRequestError{Message: "Grok Build 0.2.110 不支持该 message.content 类型", Param: fmt.Sprintf("%s[%d].type", param, index), Code: "unsupported_parameter"}
+			return nil, &responsesRequestError{Message: "Grok Build 不支持该 message.content 类型", Param: fmt.Sprintf("%s[%d].type", param, index), Code: "unsupported_parameter"}
 		}
 	}
 	return normalized, nil
@@ -156,7 +156,7 @@ func (c *responsesToolCompatibility) normalizeInputImagePart(item map[string]any
 	switch detail {
 	case "auto", "low", "high":
 	case "original":
-		// OpenAI accepts original, while Grok Build 0.2.110 supports up to high.
+		// OpenAI accepts original, while the verified Build wire contract supports up to high.
 		detail = "high"
 		c.addWarning("image_detail_original_downgraded")
 	default:

--- a/backend/internal/infra/provider/cli/responses_response.go
+++ b/backend/internal/infra/provider/cli/responses_response.go
@@ -36,15 +36,20 @@ func (c *responsesToolCompatibility) normalizeResponseJSON(body []byte) ([]byte,
 	return converted, nil
 }
 
-// normalizeResponseStream 逐事件恢复 SSE 中的 namespace，并隐藏内部 Tool Search 函数参数事件。
+// normalizeResponseStream applies the Build-to-OpenAI SSE boundary for every
+// Responses stream. Tool rewriting is optional, while BOM removal and private
+// Grok control-event filtering always apply.
 func (c *responsesToolCompatibility) normalizeResponseStream(source io.ReadCloser) io.ReadCloser {
-	if c == nil {
-		return source
-	}
 	reader, writer := io.Pipe()
 	go func() {
 		defer source.Close()
 		err := consumeCompatibleSSE(source, func(event compatibleSSEEvent) error {
+			if isPrivateBuildControlEvent(event) {
+				return nil
+			}
+			if c == nil {
+				return event.writeTo(writer)
+			}
 			if !event.HasData() {
 				return event.writeTo(writer)
 			}
@@ -82,6 +87,19 @@ func (c *responsesToolCompatibility) normalizeResponseStream(source io.ReadClose
 		_ = writer.CloseWithError(err)
 	}()
 	return reader
+}
+
+func isPrivateBuildControlEvent(event compatibleSSEEvent) bool {
+	if strings.TrimSpace(event.Event) == "response.doom_loop_check" {
+		return true
+	}
+	if !event.HasData() {
+		return false
+	}
+	var payload struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(event.Data(), &payload) == nil && payload.Type == "response.doom_loop_check"
 }
 
 type responsesStreamOutput struct {
@@ -514,6 +532,7 @@ func consumeCompatibleSSE(source io.Reader, handle func(compatibleSSEEvent) erro
 	scanner.Buffer(make([]byte, 64<<10), maxCompatibleSSEEventBytes)
 	event := compatibleSSEEvent{}
 	eventBytes := 0
+	firstLine := true
 	flush := func() error {
 		if len(event.data) == 0 && len(event.Comments) == 0 && len(event.Other) == 0 && event.Event == "" && event.ID == "" && event.Retry == "" {
 			return nil
@@ -525,6 +544,10 @@ func consumeCompatibleSSE(source io.Reader, handle func(compatibleSSEEvent) erro
 	}
 	for scanner.Scan() {
 		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if firstLine {
+			line = strings.TrimPrefix(line, "\uFEFF")
+			firstLine = false
+		}
 		if line == "" {
 			if err := flush(); err != nil {
 				return err

--- a/backend/internal/infra/provider/cli/responses_tool_types.go
+++ b/backend/internal/infra/provider/cli/responses_tool_types.go
@@ -22,7 +22,7 @@ var nativeHostedToolChoiceTypes = map[string]string{
 	"local_shell":                   "shell",
 }
 
-// webSearchCompatibilityFields lists newer Codex/OpenAI controls that Build 0.2.110 rejects.
+// webSearchCompatibilityFields lists newer Codex/OpenAI controls that the verified Build wire contract rejects.
 // The compatibility layer can only reduce them to Build's native minimal search tool.
 var webSearchCompatibilityFields = map[string]struct{}{
 	"external_web_access":  {},
@@ -34,7 +34,7 @@ var webSearchCompatibilityFields = map[string]struct{}{
 	"safe_search":          {},
 }
 
-// normalizeNativeTool preserves tools supported by Build 0.2.110 and removes Tool Search-only fields.
+// normalizeNativeTool preserves native Build tools and removes Tool Search-only fields.
 func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, _ string) ([]any, error) {
 	converted := cloneJSONObject(tool)
 	if _, exists := converted["defer_loading"]; exists {
@@ -84,7 +84,7 @@ func (c *responsesToolCompatibility) normalizeXSearchTool(tool map[string]any, p
 	return c.normalizeNativeTool(converted, param)
 }
 
-// normalizeWebSearchTool preserves Build 0.2.110's allowed_domains constraint and safely
+// normalizeWebSearchTool preserves Build's allowed_domains constraint and safely
 // reduces newer controls that cannot be represented with equivalent semantics.
 func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any, kind, param string) ([]any, error) {
 	if external, exists := tool["external_web_access"]; exists {
@@ -248,7 +248,7 @@ func (c *responsesToolCompatibility) normalizeMCPTool(tool map[string]any, clien
 
 func unsupportedBuildToolError(kind, param string) error {
 	return &responsesRequestError{
-		Message: fmt.Sprintf("Grok Build 0.2.110 不支持 tools.type=%q", kind),
+		Message: fmt.Sprintf("Grok Build 不支持 tools.type=%q", kind),
 		Param:   param + ".type", Code: "unsupported_parameter",
 	}
 }

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -705,7 +705,7 @@ func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (
 			}
 			converted["filters"] = map[string]any{"allowed_domains": value}
 		case "max_uses", "blocked_domains", "user_location", "search_context_size":
-			// Build 0.2.110 supports only allowed_domains. Do not forward other optional Anthropic controls,
+			// The Build web-search wire contract supports only allowed_domains. Do not forward other optional Anthropic controls,
 			// preventing unknown parameters from causing the upstream to reject the request.
 			continue
 		default:

--- a/backend/internal/transport/http/settings/security_test.go
+++ b/backend/internal/transport/http/settings/security_test.go
@@ -47,9 +47,9 @@ func TestSettingsResponseIncludesBuildTokenAuth(t *testing.T) {
 
 func TestSettingsResponseIncludesRecommendedBuildBaseline(t *testing.T) {
 	response := newSettingsResponse(settingsapp.Snapshot{RecommendedProviderBuild: settingsapp.ProviderBuildRecommendation{
-		ClientVersion: "0.2.111", UserAgent: "grok-shell/0.2.111 (linux; x86_64)",
+		ClientVersion: "0.2.119", UserAgent: "grok-shell/0.2.119 (linux; x86_64)",
 	}})
-	if response.RecommendedProviderBuild.ClientVersion != "0.2.111" || response.RecommendedProviderBuild.UserAgent == "" {
+	if response.RecommendedProviderBuild.ClientVersion != "0.2.119" || response.RecommendedProviderBuild.UserAgent == "" {
 		t.Fatalf("recommended build = %#v", response.RecommendedProviderBuild)
 	}
 }


### PR DESCRIPTION
## What changed

- 将推荐 Grok Build 客户端版本及 User-Agent 基线更新至 `0.2.119`，同时保留显式版本配置与回退能力。
- 统一 Codex、Claude Code、Chat Completions 和 Responses 转换后的 Build 请求规范化：
  - 缺失时补充 `store: false`
  - 合并 `reasoning.encrypted_content`
  - 保留显式 `store: true` 和客户端已有 `include`
- 在本地提取 Codex 会话信息后移除 `client_metadata`，避免工作目录、Git remote、commit 和安装标识被转发给上游。
- 将 reasoning effort 兼容改为模型感知：
  - Grok 4.5 和未知模型继续将 `xhigh/max` 安全降级为 `high`
  - `grok-4.20-multi-agent-0309` 保留其明确支持的 `xhigh`
  - 未经验证的 `max` 继续保守降级
- 对所有 Build Responses SSE 增加统一防御：
  - 移除流首 UTF-8 BOM
  - 过滤私有 `response.doom_loop_check` 控制事件
  - 不启用可能导致流输出后重试的 doom-loop 请求头
- 保留客户端显式传入的 `stream_tool_calls`，缺失时不自动注入。
- 清理绑定旧 `0.2.110` 的协议提示和注释，改为稳定的能力描述。

## Compatibility guarantees

- `/v1/models` 继续只负责模型信息与发现，不参与请求改写、路由或重试决策。
- 未修改账号选择、出口重建、质量守护、容量等待和故障转移流程。
- 未增加嵌套重试或改变现有请求级重试次数。
- 保留 Grok 4.5 已验证的 reasoning 降级保护。
- 旧 Build 客户端版本和 User-Agent 仍可通过配置显式回退。

## Validation

- `go test -count=1` 覆盖 Build、Codex、Claude Code、inference、gateway 和 config 关键链路
- `go test ./...`
- `go vet ./...`
- `git diff --check`

完整后端测试通过，未发现协议转换、路由或重试回归。