### PR TITLE
fix: preserve thinking token usage in Anthropic responses

### DIFF
--- a/backend/internal/infra/provider/conversation/conversation_test.go
+++ b/backend/internal/infra/provider/conversation/conversation_test.go
@@ -1,6 +1,7 @@
 package conversation
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"strings"
@@ -559,6 +560,10 @@ func TestConvertResponsesJSONToChatAndMessages(t *testing.T) {
 	if messagesUsage["input_tokens"] != float64(8) || messagesUsage["cache_read_input_tokens"] != float64(2) {
 		t.Fatalf("messages cache usage = %#v", messagesUsage)
 	}
+	outputDetails, ok := messagesUsage["output_tokens_details"].(map[string]any)
+	if !ok || outputDetails["thinking_tokens"] != float64(1) {
+		t.Fatalf("messages thinking usage = %#v", messagesUsage)
+	}
 }
 
 func TestAnthropicUsageClampsCacheReadToTotalInput(t *testing.T) {
@@ -568,6 +573,20 @@ func TestAnthropicUsageClampsCacheReadToTotalInput(t *testing.T) {
 	converted := anthropicUsage(usage, 0)
 	if converted["input_tokens"] != int64(0) || converted["cache_read_input_tokens"] != int64(10) {
 		t.Fatalf("clamped messages usage = %#v", converted)
+	}
+	outputDetails, ok := converted["output_tokens_details"].(map[string]any)
+	if !ok || outputDetails["thinking_tokens"] != int64(0) {
+		t.Fatalf("non-reasoning messages usage = %#v", converted)
+	}
+}
+
+func TestAnthropicUsageClampsThinkingTokensToOutputTokens(t *testing.T) {
+	usage := responseUsage{OutputTokens: 5}
+	usage.OutputTokensDetails.ReasoningTokens = 8
+	converted := anthropicUsage(usage, 0)
+	outputDetails := converted["output_tokens_details"].(map[string]any)
+	if outputDetails["thinking_tokens"] != int64(5) {
+		t.Fatalf("clamped thinking usage = %#v", converted)
 	}
 }
 
@@ -921,7 +940,7 @@ func TestConvertResponsesStreamMergesPartialUsageFrames(t *testing.T) {
 		want      []string
 	}{
 		{operation: OperationChat, want: []string{`"prompt_tokens":120`, `"completion_tokens":30`, `"cached_tokens":80`, `"reasoning_tokens":12`, `"cost_in_usd_ticks":9000`}},
-		{operation: OperationMessages, want: []string{`"input_tokens":40`, `"output_tokens":30`, `"cache_read_input_tokens":80`, `"cost_in_usd_ticks":9000`}},
+		{operation: OperationMessages, want: []string{`"input_tokens":40`, `"output_tokens":30`, `"cache_read_input_tokens":80`, `"thinking_tokens":12`, `"cost_in_usd_ticks":9000`}},
 	}
 	for _, test := range tests {
 		converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), test.operation))
@@ -934,5 +953,52 @@ func TestConvertResponsesStreamMergesPartialUsageFrames(t *testing.T) {
 				t.Fatalf("%s partial usage lost %s:\n%s", test.operation, want, text)
 			}
 		}
+		if test.operation == OperationMessages {
+			assertAnthropicThinkingUsageEventPlacement(t, converted, 12)
+		}
+	}
+}
+
+func assertAnthropicThinkingUsageEventPlacement(t *testing.T, stream []byte, want int64) {
+	t.Helper()
+	seenStart := false
+	seenDelta := false
+	err := consumeSSE(bytes.NewReader(stream), func(event string, data []byte) error {
+		if event != "message_start" && event != "message_delta" {
+			return nil
+		}
+		var payload struct {
+			Message struct {
+				Usage map[string]json.RawMessage `json:"usage"`
+			} `json:"message"`
+			Usage map[string]json.RawMessage `json:"usage"`
+		}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			t.Fatalf("decode %s event: %v", event, err)
+		}
+		if event == "message_start" {
+			seenStart = true
+			if _, exists := payload.Message.Usage["output_tokens_details"]; exists {
+				t.Fatalf("message_start unexpectedly contains output token details: %s", data)
+			}
+			return nil
+		}
+		seenDelta = true
+		var details struct {
+			ThinkingTokens int64 `json:"thinking_tokens"`
+		}
+		if err := json.Unmarshal(payload.Usage["output_tokens_details"], &details); err != nil {
+			t.Fatalf("decode message_delta output token details: %v", err)
+		}
+		if details.ThinkingTokens != want {
+			t.Fatalf("message_delta thinking_tokens = %d, want %d", details.ThinkingTokens, want)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !seenStart || !seenDelta {
+		t.Fatalf("missing Anthropic usage events: message_start=%t message_delta=%t", seenStart, seenDelta)
 	}
 }

--- a/backend/internal/infra/provider/conversation/messages_response.go
+++ b/backend/internal/infra/provider/conversation/messages_response.go
@@ -107,9 +107,15 @@ func nullableAnthropicString(value string) any {
 func anthropicUsage(value responseUsage, webSearchRequests int) map[string]any {
 	inputTokens := max(int64(0), value.InputTokens)
 	cacheReadInputTokens := min(inputTokens, max(int64(0), value.InputTokensDetails.CachedTokens))
+	outputTokens := max(int64(0), value.OutputTokens)
+	thinkingTokens := min(outputTokens, max(int64(0), value.OutputTokensDetails.ReasoningTokens))
 	usage := map[string]any{
-		"input_tokens": inputTokens - cacheReadInputTokens, "output_tokens": value.OutputTokens,
+		"input_tokens": inputTokens - cacheReadInputTokens, "output_tokens": outputTokens,
 		"cache_creation_input_tokens": 0, "cache_read_input_tokens": cacheReadInputTokens,
+		// Anthropic Messages names the internal-reasoning breakdown
+		// output_tokens_details.thinking_tokens. Grok Build Responses supplies the
+		// same quantity as output_tokens_details.reasoning_tokens.
+		"output_tokens_details":      map[string]any{"thinking_tokens": thinkingTokens},
 		"cost_in_usd_ticks":          value.CostInUSDTicks,
 		"num_sources_used":           value.NumSourcesUsed,
 		"num_server_side_tools_used": value.NumServerSideToolsUsed,

--- a/backend/internal/infra/provider/conversation/messages_stream.go
+++ b/backend/internal/infra/provider/conversation/messages_stream.go
@@ -6,11 +6,15 @@ import (
 )
 
 func (c *streamConverter) startMessages() error {
+	usage := anthropicUsage(c.usage, 0)
+	// Anthropic emits output-token breakdowns only on the terminal
+	// message_delta. Keep message_start limited to the initial usage shape.
+	delete(usage, "output_tokens_details")
 	return c.writeEvent("message_start", map[string]any{
 		"type": "message_start", "message": map[string]any{
 			"id": anthropicMessageID(c.id), "type": "message", "role": "assistant",
 			"model": c.model, "content": []any{}, "stop_reason": nil, "stop_sequence": nil,
-			"usage": anthropicUsage(c.usage, 0),
+			"usage": usage,
 		},
 	})
 }

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1504,6 +1504,7 @@ type responseInputDetailsDTO struct {
 
 type responseOutputDetailsDTO struct {
 	ReasoningTokens int64 `json:"reasoning_tokens"`
+	ThinkingTokens  int64 `json:"thinking_tokens"`
 }
 
 type responseContextDetailsDTO struct {
@@ -1544,6 +1545,9 @@ func (value responseUsageDTO) toGatewayUsage(responseModel string) gateway.Usage
 	reasoning := value.OutputTokensDetails.ReasoningTokens
 	if reasoning == 0 {
 		reasoning = value.CompletionTokensDetails.ReasoningTokens
+	}
+	if reasoning == 0 {
+		reasoning = value.OutputTokensDetails.ThinkingTokens
 	}
 	return gateway.Usage{
 		InputTokens: input, CachedInputTokens: cached,

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -594,8 +594,8 @@ func TestExtractUsageFromCompletedEvent(t *testing.T) {
 }
 
 func TestExtractUsageFromAnthropicMessagesCaches(t *testing.T) {
-	metadata := normalizeMetadataUsage(extractMetadata([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"grok-4.5","usage":{"input_tokens":20,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":80,"cost_in_usd_ticks":1000}}`)), streamProtocolAnthropic)
-	if metadata.Usage.CachedInputTokens != 80 || metadata.Usage.InputTokens != 100 || metadata.Usage.OutputTokens != 20 {
+	metadata := normalizeMetadataUsage(extractMetadata([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"grok-4.5","usage":{"input_tokens":20,"output_tokens":20,"cache_creation_input_tokens":0,"cache_read_input_tokens":80,"output_tokens_details":{"thinking_tokens":12},"cost_in_usd_ticks":1000}}`)), streamProtocolAnthropic)
+	if metadata.Usage.CachedInputTokens != 80 || metadata.Usage.InputTokens != 100 || metadata.Usage.OutputTokens != 20 || metadata.Usage.ReasoningTokens != 12 {
 		t.Fatalf("anthropic usage = %#v", metadata.Usage)
 	}
 	if metadata.Usage.TotalTokens != 120 {
@@ -622,11 +622,11 @@ func TestExtractUsagePrefersResponsesCachedTokensOverAnthropicField(t *testing.T
 func TestStreamInspectorMergesCachedTokensAcrossFrames(t *testing.T) {
 	inspector := &responseInspector{protocol: streamProtocolAnthropic}
 	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":20,\"output_tokens\":20}}\n\n"))
-	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"cache_read_input_tokens\":80}}\n\n"))
+	inspector.Inspect([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"cache_read_input_tokens\":80,\"output_tokens_details\":{\"thinking_tokens\":12}}}\n\n"))
 	inspector.Inspect([]byte("data: {\"type\":\"message_stop\"}\n\n"))
 	inspector.Finish()
 	usage := inspector.Metadata().Usage
-	if usage.InputTokens != 100 || usage.OutputTokens != 20 || usage.CachedInputTokens != 80 || usage.TotalTokens != 120 {
+	if usage.InputTokens != 100 || usage.OutputTokens != 20 || usage.CachedInputTokens != 80 || usage.ReasoningTokens != 12 || usage.TotalTokens != 120 {
 		t.Fatalf("merged stream usage = %#v", usage)
 	}
 }


### PR DESCRIPTION
## What changed

- preserves Grok Build reasoning-token usage when converting Responses output to Anthropic Messages
- maps `output_tokens_details.reasoning_tokens` from the upstream Responses protocol to the Anthropic-standard `output_tokens_details.thinking_tokens`
- supports the mapping for both streaming and non-streaming Messages responses
- teaches the unified audit parser to recognize both `reasoning_tokens` and `thinking_tokens`
- records Anthropic thinking usage in the existing internal `ReasoningTokens` field
- clamps malformed thinking-token values to the valid `0...output_tokens` range

## Streaming compatibility

- keeps `message_start.message.usage` free of output-token breakdowns
- emits `output_tokens_details.thinking_tokens` only in the terminal `message_delta.usage`
- preserves the existing `output_tokens` value as the inclusive authoritative total
- does not change thinking blocks, signatures, stop reasons, or SSE event ordering

## Root cause

The Grok Build Responses payload correctly returned:

```json
{
  "output_tokens_details": {
    "reasoning_tokens": 12
  }
}
```

The Chat Completions converter preserved this value, but the Anthropic Messages usage converter dropped the entire output-token breakdown. Request auditing parses the converted downstream response, so Messages requests were recorded with zero reasoning tokens even though upstream reasoning had executed successfully.

## Compatibility

- no database migration is required
- Responses and Chat Completions behavior is unchanged
- Anthropic Messages uses the standard `thinking_tokens` field rather than exposing the OpenAI-style `reasoning_tokens` name
- requests without reasoning continue to report zero thinking tokens
- historical audit records are unchanged; new requests are recorded correctly

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/infra/provider/conversation ./internal/transport/http/inference -count=1`
- `go vet ./...`
- `git diff --check`
