### PR TITLE
fix: harden large account pool queries and candidate caching

### DIFF
--- a/backend/internal/app/application.go
+++ b/backend/internal/app/application.go
@@ -328,6 +328,7 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*Applicat
 	auditService.SetDropObserver(clientKeyService.ReleaseBillingProtectionBatch)
 	dashboardService := dashboardapp.NewService(dashboardRepo)
 	selector := gateway.NewSelector(accountRepo, concurrency, sticky, providers, cfg.Routing.StickyTTL.Value(), cfg.Routing.CooldownBase.Value(), cfg.Routing.CooldownMax.Value(), cfg.Routing.CapacityWait.Value())
+	selector.SetLogger(logger)
 	selector.UpdatePreferFreeBuild(cfg.Routing.PreferFreeBuild)
 	selector.UpdateSegmentedSelector(cfg.Routing.SegmentedSelectorEnabled, cfg.Routing.SegmentedMinCandidates, cfg.Routing.SegmentedWindowSize)
 	egressManager.UpdateAccountIsolatedConnections(cfg.Routing.AccountIsolatedConnections)

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -3,9 +3,13 @@ package gateway
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -30,7 +34,20 @@ type accountLease struct {
 
 const quotaProbeLease = 5 * time.Minute
 const successPersistInterval = 30 * time.Second
-const candidateCacheTTL = time.Second
+
+// Routing writes publish precise invalidation events, so the TTL is only a
+// safety net for out-of-process database changes and missed notifications.
+// Keeping a one-second TTL made large pools rebuild continuously under load.
+const candidateCacheTTL = 30 * time.Second
+const candidateCacheStaleTTL = 5 * time.Minute
+const candidateCacheRetryTTL = 5 * time.Second
+const candidateCacheStaleLogInterval = time.Minute
+const maxCandidateCacheSnapshots = 64
+const maxCandidateCacheValues = 100_000
+const maxRoutingBaseSnapshots = 8
+const maxRoutingBaseValues = 150_000
+const maxRoutingOverlaySnapshots = 64
+const maxRoutingOverlayValues = 250_000
 const concurrencySnapshotTTL = 25 * time.Millisecond
 const maxConcurrencySnapshots = 256
 
@@ -47,10 +64,23 @@ type quotaRecoveryHints struct {
 	Billing *account.Billing
 }
 
+type quotaConsumptionKey struct {
+	provider  account.Provider
+	accountID uint64
+	mode      string
+}
+
+type accountQuotaConsumptionKey struct {
+	accountID uint64
+	mode      string
+}
+
 type candidateSnapshot struct {
-	values    []account.RoutingCandidate
-	byAccount map[uint64]int
-	expiresAt time.Time
+	values     []account.RoutingCandidate
+	byAccount  map[uint64]int
+	expiresAt  time.Time
+	staleUntil time.Time
+	lastAccess time.Time
 }
 
 func newCandidateSnapshot(values []account.RoutingCandidate, expiresAt time.Time) candidateSnapshot {
@@ -60,7 +90,8 @@ func newCandidateSnapshot(values []account.RoutingCandidate, expiresAt time.Time
 			byAccount[value.Credential.ID] = index
 		}
 	}
-	return candidateSnapshot{values: values, byAccount: byAccount, expiresAt: expiresAt}
+	now := time.Now().UTC()
+	return candidateSnapshot{values: values, byAccount: byAccount, expiresAt: expiresAt, staleUntil: expiresAt.Add(candidateCacheStaleTTL), lastAccess: now}
 }
 
 type candidateCacheKey struct {
@@ -87,15 +118,19 @@ type routingLayerVersion struct {
 }
 
 type routingBaseSnapshot struct {
-	values    []account.RoutingAccountBase
-	version   routingLayerVersion
-	expiresAt time.Time
+	values     []account.RoutingAccountBase
+	version    routingLayerVersion
+	expiresAt  time.Time
+	staleUntil time.Time
+	lastAccess time.Time
 }
 
 type routingOverlaySnapshot struct {
-	value     account.RoutingOverlaySnapshot
-	version   routingLayerVersion
-	expiresAt time.Time
+	value      account.RoutingOverlaySnapshot
+	version    routingLayerVersion
+	expiresAt  time.Time
+	staleUntil time.Time
+	lastAccess time.Time
 }
 
 type SelectionUnavailableReason string
@@ -232,10 +267,15 @@ type Selector struct {
 	configMu               sync.RWMutex
 	candidateMu            sync.Mutex
 	selectionMu            sync.RWMutex
+	quotaMu                sync.RWMutex
+	staleLogMu             sync.Mutex
+	logger                 *slog.Logger
 	leaseWakeMu            sync.Mutex
 	leaseWake              chan struct{}
 	lastSelectedAt         map[uint64]time.Time
 	lastSuccessAt          map[uint64]time.Time
+	quotaConsumed          map[quotaConsumptionKey]int
+	staleFallbackLoggedAt  map[string]time.Time
 	candidates             map[candidateCacheKey]candidateSnapshot
 	routingBases           map[routingBaseCacheKey]routingBaseSnapshot
 	routingOverlays        map[routingOverlayCacheKey]routingOverlaySnapshot
@@ -258,7 +298,15 @@ func NewSelector(accounts repository.AccountRepository, concurrency repository.C
 	if len(capacityWait) > 0 && capacityWait[0] > 0 {
 		wait = capacityWait[0]
 	}
-	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), routingAccountProvider: make(map[uint64]account.Provider), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
+	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), logger: slog.Default(), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), quotaConsumed: make(map[quotaConsumptionKey]int), staleFallbackLoggedAt: make(map[string]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), routingAccountProvider: make(map[uint64]account.Provider), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
+}
+
+// SetLogger wires the application logger into routing degradation diagnostics.
+// It is intended to be called during startup before the selector serves traffic.
+func (s *Selector) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		s.logger = logger
+	}
 }
 
 func (s *Selector) UpdateConfig(stickyTTL, cooldownBase, cooldownMax time.Duration, capacityWait ...time.Duration) {
@@ -340,6 +388,7 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 	if err != nil {
 		return nil, err
 	}
+	quotaConsumed := s.quotaConsumptionSnapshot(provider)
 	// 仅保留候选下标，避免每个请求复制包含凭据、计费和额度结构的完整账号切片。
 	normalCandidates := make([]int, 0, len(values))
 	probeCandidates := make([]int, 0, len(values))
@@ -391,7 +440,7 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 			quotaCandidates++
 			continue
 		}
-		if candidate.QuotaWindow != nil && candidate.QuotaWindow.Remaining <= 0 {
+		if quotaWindowExhausted(candidate, quotaConsumed) {
 			quotaCandidates++
 			if candidate.QuotaWindow.ResetAt != nil {
 				earliestRetry = earlierFuture(earliestRetry, *candidate.QuotaWindow.ResetAt, now)
@@ -640,6 +689,7 @@ func (s *Selector) acquirePinned(ctx context.Context, provider account.Provider,
 	if err != nil {
 		return nil, err
 	}
+	quotaConsumed := s.quotaConsumptionSnapshot(provider)
 	for _, candidate := range values {
 		value := candidate.Credential
 		if value.ID != accountID {
@@ -692,7 +742,7 @@ func (s *Selector) acquirePinned(ctx context.Context, provider account.Provider,
 			if candidate.Billing != nil && candidate.Billing.IsExhausted(value.MinimumRemaining) {
 				return nil, &SelectionUnavailableError{Reason: SelectionQuotaExhausted}
 			}
-			if candidate.QuotaWindow != nil && candidate.QuotaWindow.Remaining <= 0 {
+			if quotaWindowExhausted(candidate, quotaConsumed) {
 				var retryAfter time.Duration
 				if candidate.QuotaWindow.ResetAt != nil {
 					retryAfter = retryDelay(now, *candidate.QuotaWindow.ResetAt)
@@ -876,59 +926,73 @@ func (s *Selector) MarkQuotaStateChanged(provider account.Provider, accountIDs .
 		return
 	}
 	for _, accountID := range accountIDs {
+		s.clearQuotaConsumptionAccount(provider, accountID)
 		s.evictCandidate(provider, accountID)
 	}
 }
 
-// ConsumeQuota 将成功请求的本地额度变化应用到候选快照，避免为单账号变化清空整个 Provider 缓存。
+// ConsumeQuota records a small local delta instead of Copy-on-Write cloning
+// every cached candidate/base slice. Selection snapshots remain immutable for
+// concurrent requests, while the next request observes the consumed amount.
 func (s *Selector) ConsumeQuota(provider account.Provider, accountID uint64, mode string, amount int) {
 	if accountID == 0 || mode == "" || mode == "weekly" || amount <= 0 {
 		return
 	}
-	s.candidateMu.Lock()
-	defer s.candidateMu.Unlock()
-	for key, snapshot := range s.candidates {
-		if key.provider != provider {
-			continue
-		}
-		index, found := snapshot.byAccount[accountID]
-		if !found || index >= len(snapshot.values) {
-			continue
-		}
-		candidate := snapshot.values[index]
-		if candidate.QuotaWindow == nil || candidate.QuotaWindow.Mode != mode {
-			continue
-		}
-		next := append([]account.RoutingCandidate(nil), snapshot.values...)
-		window := *next[index].QuotaWindow
-		window.Remaining = max(0, window.Remaining-amount)
-		window.UpdatedAt = time.Now().UTC()
-		next[index].QuotaWindow = &window
-		snapshot.values = next
-		s.candidates[key] = snapshot
+	s.quotaMu.Lock()
+	if s.quotaConsumed == nil {
+		s.quotaConsumed = make(map[quotaConsumptionKey]int)
 	}
-	for key, snapshot := range s.routingBases {
-		if key.provider != provider {
-			continue
+	key := quotaConsumptionKey{provider: provider, accountID: accountID, mode: mode}
+	s.quotaConsumed[key] += amount
+	s.quotaMu.Unlock()
+}
+
+func (s *Selector) quotaConsumptionSnapshot(provider account.Provider) map[accountQuotaConsumptionKey]int {
+	s.quotaMu.RLock()
+	if len(s.quotaConsumed) == 0 {
+		s.quotaMu.RUnlock()
+		return nil
+	}
+	result := make(map[accountQuotaConsumptionKey]int)
+	for key, amount := range s.quotaConsumed {
+		if key.provider == provider {
+			result[accountQuotaConsumptionKey{accountID: key.accountID, mode: key.mode}] = amount
 		}
-		index := -1
-		for candidateIndex, base := range snapshot.values {
-			if base.Credential.ID == accountID {
-				index = candidateIndex
-				break
+	}
+	s.quotaMu.RUnlock()
+	return result
+}
+
+func quotaWindowExhausted(candidate account.RoutingCandidate, consumed map[accountQuotaConsumptionKey]int) bool {
+	if candidate.QuotaWindow == nil {
+		return false
+	}
+	remaining := candidate.QuotaWindow.Remaining - consumed[accountQuotaConsumptionKey{accountID: candidate.Credential.ID, mode: candidate.QuotaWindow.Mode}]
+	return remaining <= 0
+}
+
+func (s *Selector) clearQuotaConsumption(provider account.Provider) {
+	s.quotaMu.Lock()
+	if provider == "" {
+		clear(s.quotaConsumed)
+	} else {
+		for key := range s.quotaConsumed {
+			if key.provider == provider {
+				delete(s.quotaConsumed, key)
 			}
 		}
-		if index < 0 || snapshot.values[index].QuotaWindow == nil || snapshot.values[index].QuotaWindow.Mode != mode {
-			continue
-		}
-		next := append([]account.RoutingAccountBase(nil), snapshot.values...)
-		window := *next[index].QuotaWindow
-		window.Remaining = max(0, window.Remaining-amount)
-		window.UpdatedAt = time.Now().UTC()
-		next[index].QuotaWindow = &window
-		snapshot.values = next
-		s.routingBases[key] = snapshot
 	}
+	s.quotaMu.Unlock()
+}
+
+func (s *Selector) clearQuotaConsumptionAccount(provider account.Provider, accountID uint64) {
+	s.quotaMu.Lock()
+	for key := range s.quotaConsumed {
+		if key.provider == provider && key.accountID == accountID {
+			delete(s.quotaConsumed, key)
+		}
+	}
+	s.quotaMu.Unlock()
 }
 
 func (s *Selector) MarkFailure(ctx context.Context, credential account.Credential, status int, retryAfter time.Duration) {
@@ -986,6 +1050,8 @@ func (s *Selector) loadCombinedCandidates(ctx context.Context, provider account.
 	key := candidateCacheKey{provider: provider, modelRouteID: modelRouteID, upstreamModel: upstreamModel, quotaMode: quotaMode}
 	s.candidateMu.Lock()
 	if snapshot, ok := s.candidates[key]; ok && now.Before(snapshot.expiresAt) {
+		snapshot.lastAccess = now
+		s.candidates[key] = snapshot
 		s.candidateMu.Unlock()
 		return snapshot.values, nil
 	}
@@ -993,18 +1059,36 @@ func (s *Selector) loadCombinedCandidates(ctx context.Context, provider account.
 	loadKey := fmt.Sprintf("%s\x00%d\x00%s\x00%s", provider, modelRouteID, upstreamModel, quotaMode)
 	loaded, err, _ := s.candidateLoads.Do(loadKey, func() (any, error) {
 		checkTime := time.Now().UTC()
+		var stale candidateSnapshot
+		hasStale := false
 		s.candidateMu.Lock()
-		if snapshot, ok := s.candidates[key]; ok && checkTime.Before(snapshot.expiresAt) {
-			s.candidateMu.Unlock()
-			return snapshot.values, nil
+		if snapshot, ok := s.candidates[key]; ok {
+			if checkTime.Before(snapshot.expiresAt) {
+				snapshot.lastAccess = checkTime
+				s.candidates[key] = snapshot
+				s.candidateMu.Unlock()
+				return snapshot.values, nil
+			}
+			if checkTime.Before(snapshot.staleUntil) {
+				stale, hasStale = snapshot, true
+			}
 		}
 		s.candidateMu.Unlock()
 		values, err := s.accounts.ListRoutingCandidates(ctx, provider, modelRouteID, upstreamModel, quotaMode)
 		if err != nil {
+			if hasStale && canUseStaleRoutingSnapshot(ctx, err) {
+				s.candidateMu.Lock()
+				stale.lastAccess = checkTime
+				stale.expiresAt = staleRetryExpiry(checkTime, stale.staleUntil)
+				s.storeCandidateSnapshotLocked(key, stale, checkTime)
+				s.candidateMu.Unlock()
+				s.logStaleRoutingFallback("combined", provider, checkTime, stale.staleUntil, err)
+				return stale.values, nil
+			}
 			return nil, err
 		}
 		s.candidateMu.Lock()
-		s.candidates[key] = newCandidateSnapshot(values, checkTime.Add(candidateCacheTTL))
+		s.storeCandidateSnapshotLocked(key, newCandidateSnapshot(values, checkTime.Add(candidateCacheTTL)), checkTime)
 		s.candidateMu.Unlock()
 		return values, nil
 	})
@@ -1018,6 +1102,8 @@ func (s *Selector) loadLayeredCandidates(ctx context.Context, provider account.P
 	key := candidateCacheKey{provider: provider, modelRouteID: modelRouteID, upstreamModel: upstreamModel, quotaMode: quotaMode}
 	s.candidateMu.Lock()
 	if snapshot, ok := s.candidates[key]; ok && now.Before(snapshot.expiresAt) {
+		snapshot.lastAccess = now
+		s.candidates[key] = snapshot
 		s.candidateMu.Unlock()
 		return snapshot.values, nil
 	}
@@ -1027,6 +1113,8 @@ func (s *Selector) loadLayeredCandidates(ctx context.Context, provider account.P
 		checkTime := time.Now().UTC()
 		s.candidateMu.Lock()
 		if snapshot, ok := s.candidates[key]; ok && checkTime.Before(snapshot.expiresAt) {
+			snapshot.lastAccess = checkTime
+			s.candidates[key] = snapshot
 			s.candidateMu.Unlock()
 			return snapshot.values, nil
 		}
@@ -1049,7 +1137,7 @@ func (s *Selector) loadLayeredCandidates(ctx context.Context, provider account.P
 			s.candidateMu.Lock()
 			stable := baseVersion == s.routingBaseVersionLocked(provider) && overlayVersion == s.routingOverlayVersionLocked(provider)
 			if stable {
-				s.candidates[key] = newCandidateSnapshot(values, checkTime.Add(candidateCacheTTL))
+				s.storeCandidateSnapshotLocked(key, newCandidateSnapshot(values, checkTime.Add(candidateCacheTTL)), checkTime)
 			}
 			s.candidateMu.Unlock()
 			if stable {
@@ -1072,6 +1160,8 @@ func (s *Selector) loadRoutingBases(ctx context.Context, layered repository.Rout
 	version := s.routingBaseVersion(provider)
 	s.candidateMu.Lock()
 	if snapshot, ok := s.routingBases[key]; ok && now.Before(snapshot.expiresAt) && snapshot.version == version {
+		snapshot.lastAccess = now
+		s.routingBases[key] = snapshot
 		values := snapshot.values
 		s.candidateMu.Unlock()
 		return values, version, nil
@@ -1081,21 +1171,40 @@ func (s *Selector) loadRoutingBases(ctx context.Context, layered repository.Rout
 	loaded, err, _ := s.candidateLoads.Do(loadKey, func() (any, error) {
 		checkTime := time.Now().UTC()
 		checkVersion := s.routingBaseVersion(provider)
+		var stale routingBaseSnapshot
+		hasStale := false
 		s.candidateMu.Lock()
-		if snapshot, ok := s.routingBases[key]; ok && checkTime.Before(snapshot.expiresAt) && snapshot.version == checkVersion {
-			values := snapshot.values
-			s.candidateMu.Unlock()
-			return routingBaseLoadResult{values: values, version: checkVersion}, nil
+		if snapshot, ok := s.routingBases[key]; ok && snapshot.version == checkVersion {
+			if checkTime.Before(snapshot.expiresAt) {
+				snapshot.lastAccess = checkTime
+				s.routingBases[key] = snapshot
+				values := snapshot.values
+				s.candidateMu.Unlock()
+				return routingBaseLoadResult{values: values, version: checkVersion}, nil
+			}
+			if checkTime.Before(snapshot.staleUntil) {
+				stale, hasStale = snapshot, true
+			}
 		}
 		s.candidateMu.Unlock()
 		values, loadErr := layered.ListRoutingAccountBases(ctx, provider, quotaMode)
 		if loadErr != nil {
+			if hasStale && canUseStaleRoutingSnapshot(ctx, loadErr) {
+				s.candidateMu.Lock()
+				stale.lastAccess = checkTime
+				stale.expiresAt = staleRetryExpiry(checkTime, stale.staleUntil)
+				s.storeRoutingBaseSnapshotLocked(key, stale, checkTime)
+				s.candidateMu.Unlock()
+				s.logStaleRoutingFallback("base", provider, checkTime, stale.staleUntil, loadErr)
+				return routingBaseLoadResult{values: stale.values, version: checkVersion}, nil
+			}
 			return nil, loadErr
 		}
 		s.candidateMu.Lock()
 		currentVersion := s.routingBaseVersionLocked(provider)
 		if currentVersion == checkVersion {
-			s.routingBases[key] = routingBaseSnapshot{values: values, version: checkVersion, expiresAt: checkTime.Add(candidateCacheTTL)}
+			s.clearQuotaConsumption(provider)
+			s.storeRoutingBaseSnapshotLocked(key, routingBaseSnapshot{values: values, version: checkVersion, expiresAt: checkTime.Add(candidateCacheTTL)}, checkTime)
 			for accountID, cachedProvider := range s.routingAccountProvider {
 				if cachedProvider == provider {
 					delete(s.routingAccountProvider, accountID)
@@ -1120,6 +1229,8 @@ func (s *Selector) loadRoutingOverlay(ctx context.Context, layered repository.Ro
 	version := s.routingOverlayVersion(provider)
 	s.candidateMu.Lock()
 	if snapshot, ok := s.routingOverlays[key]; ok && now.Before(snapshot.expiresAt) && snapshot.version == version {
+		snapshot.lastAccess = now
+		s.routingOverlays[key] = snapshot
 		value := snapshot.value
 		s.candidateMu.Unlock()
 		return value, version, nil
@@ -1129,21 +1240,39 @@ func (s *Selector) loadRoutingOverlay(ctx context.Context, layered repository.Ro
 	loaded, err, _ := s.candidateLoads.Do(loadKey, func() (any, error) {
 		checkTime := time.Now().UTC()
 		checkVersion := s.routingOverlayVersion(provider)
+		var stale routingOverlaySnapshot
+		hasStale := false
 		s.candidateMu.Lock()
-		if snapshot, ok := s.routingOverlays[key]; ok && checkTime.Before(snapshot.expiresAt) && snapshot.version == checkVersion {
-			value := snapshot.value
-			s.candidateMu.Unlock()
-			return routingOverlayLoadResult{value: value, version: checkVersion}, nil
+		if snapshot, ok := s.routingOverlays[key]; ok && snapshot.version == checkVersion {
+			if checkTime.Before(snapshot.expiresAt) {
+				snapshot.lastAccess = checkTime
+				s.routingOverlays[key] = snapshot
+				value := snapshot.value
+				s.candidateMu.Unlock()
+				return routingOverlayLoadResult{value: value, version: checkVersion}, nil
+			}
+			if checkTime.Before(snapshot.staleUntil) {
+				stale, hasStale = snapshot, true
+			}
 		}
 		s.candidateMu.Unlock()
 		value, loadErr := layered.ListRoutingAccountOverlays(ctx, provider, modelRouteID, upstreamModel)
 		if loadErr != nil {
+			if hasStale && canUseStaleRoutingSnapshot(ctx, loadErr) {
+				s.candidateMu.Lock()
+				stale.lastAccess = checkTime
+				stale.expiresAt = staleRetryExpiry(checkTime, stale.staleUntil)
+				s.storeRoutingOverlaySnapshotLocked(key, stale, checkTime)
+				s.candidateMu.Unlock()
+				s.logStaleRoutingFallback("overlay", provider, checkTime, stale.staleUntil, loadErr)
+				return routingOverlayLoadResult{value: stale.value, version: checkVersion}, nil
+			}
 			return nil, loadErr
 		}
 		s.candidateMu.Lock()
 		currentVersion := s.routingOverlayVersionLocked(provider)
 		if currentVersion == checkVersion {
-			s.routingOverlays[key] = routingOverlaySnapshot{value: value, version: checkVersion, expiresAt: checkTime.Add(candidateCacheTTL)}
+			s.storeRoutingOverlaySnapshotLocked(key, routingOverlaySnapshot{value: value, version: checkVersion, expiresAt: checkTime.Add(candidateCacheTTL)}, checkTime)
 		}
 		s.candidateMu.Unlock()
 		return routingOverlayLoadResult{value: value, version: checkVersion}, nil
@@ -1206,6 +1335,7 @@ func (s *Selector) ApplyInvalidation(event repository.InvalidationEvent) {
 	base := layer == repository.InvalidationLayerBase
 	overlay := layer == repository.InvalidationLayerOverlay || layer == repository.InvalidationLayerRoute
 	if base {
+		s.clearQuotaConsumption(provider)
 		if provider == "" {
 			s.baseGlobalVersion++
 			clearRoutingBases(s.routingBases, "")
@@ -1245,6 +1375,169 @@ func clearRoutingOverlays(values map[routingOverlayCacheKey]routingOverlaySnapsh
 			delete(values, key)
 		}
 	}
+}
+
+func cacheSnapshotAccess(lastAccess, expiresAt time.Time) time.Time {
+	if !lastAccess.IsZero() {
+		return lastAccess
+	}
+	return expiresAt
+}
+
+func staleRetryExpiry(now, staleUntil time.Time) time.Time {
+	expiresAt := now.Add(candidateCacheRetryTTL)
+	if !staleUntil.IsZero() && expiresAt.After(staleUntil) {
+		return staleUntil
+	}
+	return expiresAt
+}
+
+// canUseStaleRoutingSnapshot deliberately accepts only errors that carry a
+// transient signal. Serving stale data for cancellations, schema/query bugs,
+// or repository validation failures would hide correctness problems.
+func canUseStaleRoutingSnapshot(ctx context.Context, err error) bool {
+	if err == nil || ctx != nil && ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, repository.ErrNotFound) || errors.Is(err, repository.ErrConflict) || errors.Is(err, repository.ErrLimitExceeded) || errors.Is(err, repository.ErrInvalidRecord) || errors.Is(err, repository.ErrAccountPoolMismatch) {
+		return false
+	}
+	if errors.Is(err, sql.ErrConnDone) || errors.Is(err, driver.ErrBadConn) {
+		return true
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && (networkError.Timeout() || networkError.Temporary()) {
+		return true
+	}
+	var temporary interface{ Temporary() bool }
+	if errors.As(err, &temporary) && temporary.Temporary() {
+		return true
+	}
+	// modernc SQLite exposes the primary/extended result through Code().
+	// SQLITE_BUSY (5) and SQLITE_LOCKED (6) are safe to retry.
+	var sqliteError interface{ Code() int }
+	if errors.As(err, &sqliteError) {
+		switch sqliteError.Code() & 0xff {
+		case 5, 6:
+			return true
+		}
+	}
+	// pgx exposes SQLSTATE without requiring the application layer to depend on
+	// a concrete PostgreSQL driver type.
+	var postgresError interface{ SQLState() string }
+	if errors.As(err, &postgresError) {
+		switch state := postgresError.SQLState(); {
+		case strings.HasPrefix(state, "08"), strings.HasPrefix(state, "40"), state == "55P03", state == "57P01", state == "57P02", state == "57P03":
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Selector) logStaleRoutingFallback(layer string, provider account.Provider, now, staleUntil time.Time, err error) {
+	key := layer + "\x00" + string(provider)
+	s.staleLogMu.Lock()
+	if s.staleFallbackLoggedAt == nil {
+		s.staleFallbackLoggedAt = make(map[string]time.Time)
+	}
+	last := s.staleFallbackLoggedAt[key]
+	if !last.IsZero() && now.Sub(last) < candidateCacheStaleLogInterval {
+		s.staleLogMu.Unlock()
+		return
+	}
+	s.staleFallbackLoggedAt[key] = now
+	s.staleLogMu.Unlock()
+
+	staleFor := now.Sub(staleUntil.Add(-candidateCacheStaleTTL))
+	if staleFor < 0 {
+		staleFor = 0
+	}
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Warn("routing_snapshot_stale_fallback",
+		"provider", provider,
+		"layer", layer,
+		"stale_for_ms", staleFor.Milliseconds(),
+		"retry_after_ms", candidateCacheRetryTTL.Milliseconds(),
+		"error_type", fmt.Sprintf("%T", err),
+	)
+}
+
+type snapshotCacheMetadata struct {
+	values     int
+	staleUntil time.Time
+	accessedAt time.Time
+}
+
+func pruneSnapshotCache[K comparable, V any](values map[K]V, protected K, now time.Time, maxSnapshots, maxValues int, metadata func(V) snapshotCacheMetadata) {
+	for key, value := range values {
+		entry := metadata(value)
+		if key != protected && !entry.staleUntil.IsZero() && !now.Before(entry.staleUntil) {
+			delete(values, key)
+		}
+	}
+	for {
+		total := 0
+		for _, value := range values {
+			total += metadata(value).values
+		}
+		// A single oversized provider pool must remain usable. The budget becomes
+		// a strict bound as soon as there is another evictable snapshot.
+		if len(values) <= maxSnapshots && (total <= maxValues || len(values) == 1) {
+			return
+		}
+		var oldestKey K
+		var oldestAt time.Time
+		found := false
+		for key, value := range values {
+			if key == protected {
+				continue
+			}
+			accessedAt := metadata(value).accessedAt
+			if !found || accessedAt.Before(oldestAt) {
+				oldestKey, oldestAt, found = key, accessedAt, true
+			}
+		}
+		if !found {
+			return
+		}
+		delete(values, oldestKey)
+	}
+}
+
+func (s *Selector) storeCandidateSnapshotLocked(key candidateCacheKey, snapshot candidateSnapshot, now time.Time) {
+	snapshot.lastAccess = now
+	if snapshot.staleUntil.IsZero() {
+		snapshot.staleUntil = snapshot.expiresAt.Add(candidateCacheStaleTTL)
+	}
+	s.candidates[key] = snapshot
+	pruneSnapshotCache(s.candidates, key, now, maxCandidateCacheSnapshots, maxCandidateCacheValues, func(value candidateSnapshot) snapshotCacheMetadata {
+		return snapshotCacheMetadata{values: len(value.values), staleUntil: value.staleUntil, accessedAt: cacheSnapshotAccess(value.lastAccess, value.expiresAt)}
+	})
+}
+
+func (s *Selector) storeRoutingBaseSnapshotLocked(key routingBaseCacheKey, snapshot routingBaseSnapshot, now time.Time) {
+	snapshot.lastAccess = now
+	if snapshot.staleUntil.IsZero() {
+		snapshot.staleUntil = snapshot.expiresAt.Add(candidateCacheStaleTTL)
+	}
+	s.routingBases[key] = snapshot
+	pruneSnapshotCache(s.routingBases, key, now, maxRoutingBaseSnapshots, maxRoutingBaseValues, func(value routingBaseSnapshot) snapshotCacheMetadata {
+		return snapshotCacheMetadata{values: len(value.values), staleUntil: value.staleUntil, accessedAt: cacheSnapshotAccess(value.lastAccess, value.expiresAt)}
+	})
+}
+
+func (s *Selector) storeRoutingOverlaySnapshotLocked(key routingOverlayCacheKey, snapshot routingOverlaySnapshot, now time.Time) {
+	snapshot.lastAccess = now
+	if snapshot.staleUntil.IsZero() {
+		snapshot.staleUntil = snapshot.expiresAt.Add(candidateCacheStaleTTL)
+	}
+	s.routingOverlays[key] = snapshot
+	pruneSnapshotCache(s.routingOverlays, key, now, maxRoutingOverlaySnapshots, maxRoutingOverlayValues, func(value routingOverlaySnapshot) snapshotCacheMetadata {
+		return snapshotCacheMetadata{values: len(value.value.Values), staleUntil: value.staleUntil, accessedAt: cacheSnapshotAccess(value.lastAccess, value.expiresAt)}
+	})
 }
 
 type routingBaseLoadResult struct {

--- a/backend/internal/application/gateway/selector_layered_test.go
+++ b/backend/internal/application/gateway/selector_layered_test.go
@@ -28,12 +28,29 @@ type layeredAccountRepository struct {
 	firstBaseStart chan struct{}
 	firstBaseReady chan struct{}
 	baseHook       func()
+	baseErr        error
+	overlayErr     error
 	combined       []account.RoutingCandidate
 	combinedCalls  int
 	materialErrors map[uint64]error
 	materials      map[uint64]account.CredentialMaterial
 	materialCalls  []uint64
 }
+
+type temporaryRoutingLoadError struct{ message string }
+
+func (e temporaryRoutingLoadError) Error() string { return e.message }
+func (temporaryRoutingLoadError) Temporary() bool { return true }
+
+type sqliteRoutingLoadError struct{ code int }
+
+func (e sqliteRoutingLoadError) Error() string { return "sqlite routing load failure" }
+func (e sqliteRoutingLoadError) Code() int     { return e.code }
+
+type postgresRoutingLoadError struct{ state string }
+
+func (e postgresRoutingLoadError) Error() string    { return "postgres routing load failure" }
+func (e postgresRoutingLoadError) SQLState() string { return e.state }
 
 func (r *layeredAccountRepository) ListRoutingAccountBases(context.Context, account.Provider, string) ([]account.RoutingAccountBase, error) {
 	r.mu.Lock()
@@ -45,6 +62,7 @@ func (r *layeredAccountRepository) ListRoutingAccountBases(context.Context, acco
 	}
 	start, ready := r.firstBaseStart, r.firstBaseReady
 	hook := r.baseHook
+	loadErr := r.baseErr
 	r.mu.Unlock()
 	if hook != nil {
 		hook()
@@ -53,7 +71,7 @@ func (r *layeredAccountRepository) ListRoutingAccountBases(context.Context, acco
 		close(start)
 		<-ready
 	}
-	return values, nil
+	return values, loadErr
 }
 
 func (r *layeredAccountRepository) ListRoutingCandidates(context.Context, account.Provider, uint64, string, string) ([]account.RoutingCandidate, error) {
@@ -83,6 +101,9 @@ func (r *layeredAccountRepository) ListRoutingAccountOverlays(_ context.Context,
 		r.overlayCalls = make(map[string]int)
 	}
 	r.overlayCalls[upstreamModel]++
+	if r.overlayErr != nil {
+		return account.RoutingOverlaySnapshot{}, r.overlayErr
+	}
 	if modelRouteID > 0 && r.routeOverlays != nil {
 		return r.routeOverlays[modelRouteID], nil
 	}
@@ -127,6 +148,233 @@ func TestSelectorLayeredCacheReusesBaseAcrossModels(t *testing.T) {
 	baseCalls, modelACalls = repo.callCounts("model-a")
 	if baseCalls != 2 || modelACalls != 2 {
 		t.Fatalf("overlay invalidation reloaded base=%d overlay=%d", baseCalls, modelACalls)
+	}
+}
+
+func TestSelectorLayeredCacheUsesLastGoodSnapshotOnTransientLoadFailure(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	now := time.Now().UTC()
+	initial, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", now)
+	if err != nil || len(initial) != 1 {
+		t.Fatalf("initial candidates = %#v, err = %v", initial, err)
+	}
+
+	selector.candidateMu.Lock()
+	for key, snapshot := range selector.candidates {
+		snapshot.expiresAt = now.Add(-time.Second)
+		snapshot.staleUntil = now.Add(time.Minute)
+		selector.candidates[key] = snapshot
+	}
+	for key, snapshot := range selector.routingBases {
+		snapshot.expiresAt = now.Add(-time.Second)
+		snapshot.staleUntil = now.Add(time.Minute)
+		selector.routingBases[key] = snapshot
+	}
+	for key, snapshot := range selector.routingOverlays {
+		snapshot.expiresAt = now.Add(-time.Second)
+		snapshot.staleUntil = now.Add(time.Minute)
+		selector.routingOverlays[key] = snapshot
+	}
+	selector.candidateMu.Unlock()
+
+	repo.mu.Lock()
+	repo.baseErr = temporaryRoutingLoadError{message: "temporary base failure"}
+	repo.overlayErr = temporaryRoutingLoadError{message: "temporary overlay failure"}
+	repo.mu.Unlock()
+	loaded, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", time.Now().UTC())
+	if err != nil || len(loaded) != 1 || loaded[0].Credential.ID != initial[0].Credential.ID {
+		t.Fatalf("stale candidates = %#v, err = %v", loaded, err)
+	}
+	baseCalls, overlayCalls := repo.callCounts("model-a")
+	if baseCalls != 2 || overlayCalls != 2 {
+		t.Fatalf("reload calls base=%d overlay=%d, want 2/2", baseCalls, overlayCalls)
+	}
+}
+
+func TestSelectorStaleSnapshotDoesNotMaskCancellationOrPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "deadline", err: context.DeadlineExceeded},
+		{name: "permanent", err: errors.New("invalid routing query")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newLayeredRepositoryFixture()
+			selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+			now := time.Now().UTC()
+			if _, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", now); err != nil {
+				t.Fatal(err)
+			}
+			selector.candidateMu.Lock()
+			for key, snapshot := range selector.candidates {
+				snapshot.expiresAt = now.Add(-time.Second)
+				snapshot.staleUntil = now.Add(time.Minute)
+				selector.candidates[key] = snapshot
+			}
+			for key, snapshot := range selector.routingBases {
+				snapshot.expiresAt = now.Add(-time.Second)
+				snapshot.staleUntil = now.Add(time.Minute)
+				selector.routingBases[key] = snapshot
+			}
+			selector.candidateMu.Unlock()
+
+			repo.mu.Lock()
+			repo.baseErr = test.err
+			repo.mu.Unlock()
+			_, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", time.Now().UTC())
+			if !errors.Is(err, test.err) {
+				t.Fatalf("load error = %v, want %v", err, test.err)
+			}
+		})
+	}
+}
+
+func TestCanUseStaleRoutingSnapshotClassifiesFailuresConservatively(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{name: "temporary marker", ctx: context.Background(), err: temporaryRoutingLoadError{message: "retry"}, want: true},
+		{name: "sqlite busy", ctx: context.Background(), err: sqliteRoutingLoadError{code: 5}, want: true},
+		{name: "sqlite extended locked", ctx: context.Background(), err: sqliteRoutingLoadError{code: 6 | 1<<8}, want: true},
+		{name: "sqlite constraint", ctx: context.Background(), err: sqliteRoutingLoadError{code: 19}, want: false},
+		{name: "postgres connection", ctx: context.Background(), err: postgresRoutingLoadError{state: "08006"}, want: true},
+		{name: "postgres serialization", ctx: context.Background(), err: postgresRoutingLoadError{state: "40001"}, want: true},
+		{name: "postgres query canceled", ctx: context.Background(), err: postgresRoutingLoadError{state: "57014"}, want: false},
+		{name: "request canceled", ctx: context.Background(), err: context.Canceled, want: false},
+		{name: "request deadline", ctx: context.Background(), err: context.DeadlineExceeded, want: false},
+		{name: "canceled context wins", ctx: canceledCtx, err: temporaryRoutingLoadError{message: "retry"}, want: false},
+		{name: "repository validation", ctx: context.Background(), err: repository.ErrInvalidRecord, want: false},
+		{name: "unclassified failure", ctx: context.Background(), err: errors.New("broken query"), want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canUseStaleRoutingSnapshot(test.ctx, test.err); got != test.want {
+				t.Fatalf("canUseStaleRoutingSnapshot(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSelectorInvalidationNeverFallsBackToStaleSnapshot(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	if _, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	selector.ApplyInvalidation(repository.InvalidationEvent{Kind: repository.InvalidationAccountStateChanged, Provider: account.ProviderBuild})
+	repo.mu.Lock()
+	repo.baseErr = errors.New("base unavailable after invalidation")
+	repo.mu.Unlock()
+	if _, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", time.Now().UTC()); err == nil {
+		t.Fatal("invalidated cache unexpectedly served its stale snapshot")
+	}
+}
+
+func TestSelectorCacheSnapshotCountsAreBoundedAndLRU(t *testing.T) {
+	selector := NewSelector(nil, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	now := time.Now().UTC()
+	selector.candidateMu.Lock()
+	for index := 0; index < maxCandidateCacheSnapshots+5; index++ {
+		key := candidateCacheKey{provider: account.ProviderBuild, modelRouteID: uint64(index + 1)}
+		snapshot := candidateSnapshot{values: []account.RoutingCandidate{{Credential: account.Credential{ID: uint64(index + 1)}}}, expiresAt: now.Add(time.Hour), staleUntil: now.Add(2 * time.Hour), lastAccess: now.Add(time.Duration(index) * time.Second)}
+		selector.storeCandidateSnapshotLocked(key, snapshot, snapshot.lastAccess)
+	}
+	if len(selector.candidates) != maxCandidateCacheSnapshots {
+		selector.candidateMu.Unlock()
+		t.Fatalf("candidate snapshots = %d, want %d", len(selector.candidates), maxCandidateCacheSnapshots)
+	}
+	if _, exists := selector.candidates[candidateCacheKey{provider: account.ProviderBuild, modelRouteID: 1}]; exists {
+		selector.candidateMu.Unlock()
+		t.Fatal("least-recently-used candidate snapshot was retained")
+	}
+	latestKey := candidateCacheKey{provider: account.ProviderBuild, modelRouteID: uint64(maxCandidateCacheSnapshots + 5)}
+	if _, exists := selector.candidates[latestKey]; !exists {
+		selector.candidateMu.Unlock()
+		t.Fatal("newest candidate snapshot was evicted")
+	}
+	selector.candidateMu.Unlock()
+}
+
+func TestSelectorLargePoolCacheUsesCandidateValueBudget(t *testing.T) {
+	const accountCount = 41571
+	repo := newLayeredRepositoryFixture()
+	repo.bases = make([]account.RoutingAccountBase, accountCount)
+	for index := range repo.bases {
+		repo.bases[index].Credential = account.Credential{
+			ID: uint64(index + 1), Provider: account.ProviderBuild, Enabled: true, AuthStatus: account.AuthStatusActive,
+		}
+	}
+	selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	now := time.Now().UTC()
+	for _, model := range []string{"model-a", "model-b", "model-c"} {
+		values, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, model, "", now)
+		if err != nil || len(values) != accountCount {
+			t.Fatalf("model %s candidates=%d, err=%v", model, len(values), err)
+		}
+	}
+	selector.candidateMu.Lock()
+	cachedValues := 0
+	for _, snapshot := range selector.candidates {
+		cachedValues += len(snapshot.values)
+	}
+	_, oldestRetained := selector.candidates[candidateCacheKey{provider: account.ProviderBuild, upstreamModel: "model-a"}]
+	selector.candidateMu.Unlock()
+	if cachedValues > maxCandidateCacheValues {
+		t.Fatalf("cached candidate values = %d, budget = %d", cachedValues, maxCandidateCacheValues)
+	}
+	if oldestRetained {
+		t.Fatal("oldest large-pool model snapshot was not evicted")
+	}
+
+	// Reopening an evicted model reuses the provider base and model overlay; it
+	// only reconstructs the bounded derived view and does not query the pool again.
+	if _, err := selector.loadCandidates(context.Background(), account.ProviderBuild, 0, "model-a", "", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	baseCalls, overlayCalls := repo.callCounts("model-a")
+	if baseCalls != 1 || overlayCalls != 1 {
+		t.Fatalf("reopened model queried repository: base=%d overlay=%d", baseCalls, overlayCalls)
+	}
+}
+
+func TestSelectorQuotaConsumptionUsesDeltaWithoutMutatingLargeSnapshots(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	repo.bases[0].QuotaWindow = &account.QuotaWindow{AccountID: 1, Mode: "fast", Remaining: 1}
+	selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	if _, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "fast", "", nil, false); err != nil {
+		t.Fatal(err)
+	}
+	selector.candidateMu.Lock()
+	originalCandidate := selector.candidates[candidateCacheKey{provider: account.ProviderBuild, upstreamModel: "model-a", quotaMode: "fast"}].values[0].QuotaWindow.Remaining
+	originalBase := selector.routingBases[routingBaseCacheKey{provider: account.ProviderBuild, quotaMode: "fast"}].values[0].QuotaWindow.Remaining
+	selector.candidateMu.Unlock()
+
+	selector.ConsumeQuota(account.ProviderBuild, 1, "fast", 1)
+	_, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "fast", "", nil, false)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionQuotaExhausted {
+		t.Fatalf("selection error = %v, want quota exhausted", err)
+	}
+	selector.candidateMu.Lock()
+	currentCandidate := selector.candidates[candidateCacheKey{provider: account.ProviderBuild, upstreamModel: "model-a", quotaMode: "fast"}].values[0].QuotaWindow.Remaining
+	currentBase := selector.routingBases[routingBaseCacheKey{provider: account.ProviderBuild, quotaMode: "fast"}].values[0].QuotaWindow.Remaining
+	selector.candidateMu.Unlock()
+	if currentCandidate != originalCandidate || currentBase != originalBase {
+		t.Fatalf("immutable snapshots changed: candidate %d->%d base %d->%d", originalCandidate, currentCandidate, originalBase, currentBase)
+	}
+
+	selector.ApplyInvalidation(repository.InvalidationEvent{Kind: repository.InvalidationAccountQuotaChanged, Provider: account.ProviderBuild})
+	if _, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "fast", "", nil, false); err != nil {
+		t.Fatalf("authoritative quota invalidation did not clear local delta: %v", err)
 	}
 }
 

--- a/backend/internal/application/gateway/selector_session.go
+++ b/backend/internal/application/gateway/selector_session.go
@@ -20,6 +20,7 @@ type selectionSession struct {
 	quotaMode        string
 	stickyKey        string
 	values           []account.RoutingCandidate
+	quotaConsumed    map[accountQuotaConsumptionKey]int
 	normalCandidates []int
 	probeCandidates  []int
 	normalPlan       *candidatePlan
@@ -44,6 +45,7 @@ func (s *Selector) beginSelectionSessionForKey(ctx context.Context, provider acc
 	if err != nil {
 		return nil, err
 	}
+	quotaConsumed := s.quotaConsumptionSnapshot(provider)
 
 	session = &selectionSession{
 		selector:        s,
@@ -53,6 +55,7 @@ func (s *Selector) beginSelectionSessionForKey(ctx context.Context, provider acc
 		quotaMode:       quotaMode,
 		stickyKey:       stickySessionKey(affinityKey),
 		values:          values,
+		quotaConsumed:   quotaConsumed,
 		staleCandidates: make(map[uint64]bool),
 	}
 	consideredCandidates := 0
@@ -100,7 +103,7 @@ func (s *Selector) beginSelectionSessionForKey(ctx context.Context, provider acc
 			quotaCandidates++
 			continue
 		}
-		if candidate.QuotaWindow != nil && candidate.QuotaWindow.Remaining <= 0 {
+		if quotaWindowExhausted(candidate, quotaConsumed) {
 			quotaCandidates++
 			if candidate.QuotaWindow.ResetAt != nil {
 				earliestRetry = earlierFuture(earliestRetry, *candidate.QuotaWindow.ResetAt, now)

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -983,12 +983,20 @@ func TestSelectorConsumesOnlyMatchingQuotaSnapshot(t *testing.T) {
 	selector := &Selector{candidates: map[candidateCacheKey]candidateSnapshot{key: newCandidateSnapshot(values, time.Now().UTC().Add(time.Minute))}}
 	original := selector.candidates[key].values
 	selector.ConsumeQuota(account.ProviderWeb, 7, "fast", 3)
-	window := selector.candidates[key].values[0].QuotaWindow
-	if window == nil || window.Remaining != 7 {
-		t.Fatalf("quota window = %#v", window)
-	}
 	if original[0].QuotaWindow == nil || original[0].QuotaWindow.Remaining != 10 {
 		t.Fatalf("published snapshot was mutated: %#v", original[0].QuotaWindow)
+	}
+	consumed := selector.quotaConsumptionSnapshot(account.ProviderWeb)
+	if quotaWindowExhausted(values[0], consumed) {
+		t.Fatal("partially consumed quota was treated as exhausted")
+	}
+	selector.ConsumeQuota(account.ProviderWeb, 7, "other", 100)
+	if quotaWindowExhausted(values[0], selector.quotaConsumptionSnapshot(account.ProviderWeb)) {
+		t.Fatal("a different quota mode affected the candidate")
+	}
+	selector.ConsumeQuota(account.ProviderWeb, 7, "fast", 7)
+	if !quotaWindowExhausted(values[0], selector.quotaConsumptionSnapshot(account.ProviderWeb)) {
+		t.Fatal("fully consumed quota remained schedulable")
 	}
 }
 

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -226,42 +226,53 @@ func (r *AccountRepository) ListRoutingCandidates(ctx context.Context, provider 
 			values = filtered
 		}
 	}
-	ids := make([]uint64, 0, len(values))
-	for _, value := range values {
-		ids = append(ids, value.ID)
-	}
-	billings, err := r.getRoutingBillings(ctx, ids)
+	billings, err := r.getRoutingBillings(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
-	recoveries, err := r.GetQuotaRecoveries(ctx, ids)
+	recoveries, err := r.getRoutingQuotaRecoveries(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
-	quotaWindows, err := r.getRoutingQuotaWindows(ctx, ids, provider, quotaMode)
+	quotaWindows, err := r.getRoutingQuotaWindows(ctx, provider, quotaMode)
 	if err != nil {
 		return nil, err
 	}
-	known := make(map[uint64]bool, len(ids))
-	supported := make(map[uint64]bool, len(ids))
-	modelQuotaBlocks := make(map[uint64]account.ModelQuotaBlock, len(ids))
-	if strings.TrimSpace(upstreamModel) != "" && len(ids) > 0 {
+	known := make(map[uint64]bool, len(values))
+	supported := make(map[uint64]bool, len(values))
+	modelQuotaBlocks := make(map[uint64]account.ModelQuotaBlock, len(values))
+	if strings.TrimSpace(upstreamModel) != "" && len(values) > 0 {
 		var states []accountModelSyncStateModel
-		if err := r.db.db.WithContext(ctx).Where("account_id IN ? AND last_success_at IS NOT NULL", ids).Find(&states).Error; err != nil {
+		if err := r.db.db.WithContext(ctx).
+			Table("account_model_sync_states AS state").
+			Select("state.*").
+			Joins("JOIN provider_accounts AS account ON account.id = state.account_id").
+			Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ? AND state.last_success_at IS NOT NULL", provider, true, account.AuthStatusActive).
+			Find(&states).Error; err != nil {
 			return nil, err
 		}
 		for _, state := range states {
 			known[state.AccountID] = true
 		}
 		var capabilities []accountModelCapabilityModel
-		if err := r.db.db.WithContext(ctx).Where("account_id IN ? AND upstream_model = ?", ids, upstreamModel).Find(&capabilities).Error; err != nil {
+		if err := r.db.db.WithContext(ctx).
+			Table("account_model_capabilities AS capability").
+			Select("capability.*").
+			Joins("JOIN provider_accounts AS account ON account.id = capability.account_id").
+			Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ? AND capability.upstream_model = ?", provider, true, account.AuthStatusActive, upstreamModel).
+			Find(&capabilities).Error; err != nil {
 			return nil, err
 		}
 		for _, capability := range capabilities {
 			supported[capability.AccountID] = true
 		}
 		var blockRows []accountModelQuotaBlockModel
-		if err := r.db.db.WithContext(ctx).Where("account_id IN ? AND upstream_model = ? AND cooldown_until > ?", ids, upstreamModel, time.Now().UTC()).Find(&blockRows).Error; err != nil {
+		if err := r.db.db.WithContext(ctx).
+			Table("account_model_quota_blocks AS block").
+			Select("block.*").
+			Joins("JOIN provider_accounts AS account ON account.id = block.account_id").
+			Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ? AND block.upstream_model = ? AND block.cooldown_until > ?", provider, true, account.AuthStatusActive, upstreamModel, time.Now().UTC()).
+			Find(&blockRows).Error; err != nil {
 			return nil, err
 		}
 		for _, row := range blockRows {
@@ -321,19 +332,15 @@ func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provide
 	if err != nil {
 		return nil, err
 	}
-	ids := make([]uint64, 0, len(values))
-	for _, value := range values {
-		ids = append(ids, value.ID)
-	}
-	billings, err := r.getRoutingBillings(ctx, ids)
+	billings, err := r.getRoutingBillings(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
-	recoveries, err := r.GetQuotaRecoveries(ctx, ids)
+	recoveries, err := r.getRoutingQuotaRecoveries(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
-	quotaWindows, err := r.getRoutingQuotaWindows(ctx, ids, provider, quotaMode)
+	quotaWindows, err := r.getRoutingQuotaWindows(ctx, provider, quotaMode)
 	if err != nil {
 		return nil, err
 	}
@@ -358,15 +365,7 @@ func (r *AccountRepository) ListRoutingAccountBases(ctx context.Context, provide
 // account to use. Provider secrets deliberately stay in account_credentials
 // until a selected account is hydrated for the upstream call.
 func (r *AccountRepository) listRoutingCredentials(ctx context.Context, provider account.Provider) ([]account.Credential, error) {
-	var rows []accountModel
-	err := r.db.db.WithContext(ctx).
-		Preload("Credential", func(query *gorm.DB) *gorm.DB {
-			return query.Select(routingCredentialMetadataColumns)
-		}).
-		Preload("WebProfile").
-		Where("provider = ? AND enabled = ? AND auth_status = ?", provider, true, account.AuthStatusActive).
-		Order("priority DESC, id ASC").
-		Find(&rows).Error
+	rows, err := r.listActiveProviderAccountRows(ctx, provider, routingCredentialMetadataColumns)
 	if err != nil {
 		return nil, err
 	}
@@ -378,6 +377,72 @@ func (r *AccountRepository) listRoutingCredentials(ctx context.Context, provider
 		return nil, err
 	}
 	return values, nil
+}
+
+// listActiveProviderAccountRows avoids GORM association preloads for complete
+// provider pools. Preload expands every parent key into an IN list and exceeds
+// SQLite's variable limit for large pools. The fixed-shape JOIN queries below
+// remain valid for both SQLite and PostgreSQL regardless of pool size.
+func (r *AccountRepository) listActiveProviderAccountRows(ctx context.Context, provider account.Provider, credentialColumns []string) ([]accountModel, error) {
+	var rows []accountModel
+	if err := r.db.db.WithContext(ctx).
+		Where("provider = ? AND enabled = ? AND auth_status = ?", provider, true, account.AuthStatusActive).
+		Order("priority DESC, id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return rows, nil
+	}
+	positions := make(map[uint64]int, len(rows))
+	for index := range rows {
+		positions[rows[index].ID] = index
+	}
+
+	credentialSelect := "credential.*"
+	if len(credentialColumns) > 0 {
+		credentialSelect = qualifiedColumnList("credential", credentialColumns)
+	}
+	var credentials []accountCredentialModel
+	if err := r.db.db.WithContext(ctx).
+		Table("account_credentials AS credential").
+		Select(credentialSelect).
+		Joins("JOIN provider_accounts AS account ON account.id = credential.account_id").
+		Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ?", provider, true, account.AuthStatusActive).
+		Find(&credentials).Error; err != nil {
+		return nil, err
+	}
+	for index := range credentials {
+		if position, ok := positions[credentials[index].AccountID]; ok {
+			rows[position].Credential = &credentials[index]
+		}
+	}
+
+	if provider == account.ProviderWeb {
+		var profiles []webAccountProfileModel
+		if err := r.db.db.WithContext(ctx).
+			Table("web_account_profiles AS profile").
+			Select("profile.*").
+			Joins("JOIN provider_accounts AS account ON account.id = profile.account_id").
+			Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ?", provider, true, account.AuthStatusActive).
+			Find(&profiles).Error; err != nil {
+			return nil, err
+		}
+		for index := range profiles {
+			if position, ok := positions[profiles[index].AccountID]; ok {
+				rows[position].WebProfile = &profiles[index]
+			}
+		}
+	}
+	return rows, nil
+}
+
+func qualifiedColumnList(alias string, columns []string) string {
+	qualified := make([]string, 0, len(columns))
+	for _, column := range columns {
+		qualified = append(qualified, alias+"."+column)
+	}
+	return strings.Join(qualified, ", ")
 }
 
 // routingCredentialMetadataColumns contains all credential fields used for
@@ -394,13 +459,15 @@ var routingBillingColumns = []string{
 	"usage_period_start", "usage_period_end", "billing_period_start", "billing_period_end", "synced_at",
 }
 
-func (r *AccountRepository) getRoutingBillings(ctx context.Context, accountIDs []uint64) (map[uint64]account.Billing, error) {
-	result := make(map[uint64]account.Billing, len(accountIDs))
-	if len(accountIDs) == 0 {
-		return result, nil
-	}
+func (r *AccountRepository) getRoutingBillings(ctx context.Context, provider account.Provider) (map[uint64]account.Billing, error) {
+	result := make(map[uint64]account.Billing)
 	var rows []billingModel
-	if err := r.db.db.WithContext(ctx).Select(routingBillingColumns).Where("account_id IN ?", accountIDs).Find(&rows).Error; err != nil {
+	if err := r.db.db.WithContext(ctx).
+		Table("account_billing_snapshots AS billing").
+		Select(qualifiedColumnList("billing", routingBillingColumns)).
+		Joins("JOIN provider_accounts AS account ON account.id = billing.account_id").
+		Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ?", provider, true, account.AuthStatusActive).
+		Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	for _, row := range rows {
@@ -409,13 +476,34 @@ func (r *AccountRepository) getRoutingBillings(ctx context.Context, accountIDs [
 	return result, nil
 }
 
+func (r *AccountRepository) getRoutingQuotaRecoveries(ctx context.Context, provider account.Provider) (map[uint64]account.QuotaRecovery, error) {
+	result := make(map[uint64]account.QuotaRecovery)
+	var rows []quotaRecoveryModel
+	if err := r.db.db.WithContext(ctx).
+		Table("account_quota_recovery AS recovery").
+		Select("recovery.*").
+		Joins("JOIN provider_accounts AS account ON account.id = recovery.account_id").
+		Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ?", provider, true, account.AuthStatusActive).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.AccountID] = account.QuotaRecovery{
+			AccountID: row.AccountID, Kind: account.QuotaRecoveryKind(row.Kind), Status: account.QuotaRecoveryStatus(row.Status), ConfirmedUsed: row.ConfirmedUsed,
+			ConfirmedLimit: row.ConfirmedLimit, ExhaustedAt: row.ExhaustedAt, NextProbeAt: row.NextProbeAt,
+			LastConfirmedAt: row.LastConfirmedAt, UpdatedAt: row.UpdatedAt,
+		}
+	}
+	return result, nil
+}
+
 var routingQuotaWindowColumns = []string{
 	"account_id", "mode", "remaining", "total", "usage_percent", "window_seconds", "reset_at", "synced_at", "source", "updated_at",
 }
 
-func (r *AccountRepository) getRoutingQuotaWindows(ctx context.Context, accountIDs []uint64, provider account.Provider, quotaMode string) (map[uint64]account.QuotaWindow, error) {
-	result := make(map[uint64]account.QuotaWindow, len(accountIDs))
-	if len(accountIDs) == 0 || (provider != account.ProviderWeb && quotaMode == "") {
+func (r *AccountRepository) getRoutingQuotaWindows(ctx context.Context, provider account.Provider, quotaMode string) (map[uint64]account.QuotaWindow, error) {
+	result := make(map[uint64]account.QuotaWindow)
+	if provider != account.ProviderWeb && quotaMode == "" {
 		return result, nil
 	}
 	modes := make([]string, 0, 2)
@@ -427,9 +515,11 @@ func (r *AccountRepository) getRoutingQuotaWindows(ctx context.Context, accountI
 	}
 	var rows []quotaWindowModel
 	if err := r.db.db.WithContext(ctx).
-		Select(routingQuotaWindowColumns).
-		Where("account_id IN ? AND mode IN ?", accountIDs, modes).
-		Order("CASE WHEN mode = 'weekly' THEN 0 ELSE 1 END").
+		Table("account_quota_windows AS quota").
+		Select(qualifiedColumnList("quota", routingQuotaWindowColumns)).
+		Joins("JOIN provider_accounts AS account ON account.id = quota.account_id").
+		Where("account.provider = ? AND account.enabled = ? AND account.auth_status = ? AND quota.mode IN ?", provider, true, account.AuthStatusActive, modes).
+		Order("CASE WHEN quota.mode = 'weekly' THEN 0 ELSE 1 END").
 		Find(&rows).Error; err != nil {
 		return nil, err
 	}
@@ -524,8 +614,7 @@ func (r *AccountRepository) listRoutingBoundAccountIDs(ctx context.Context, prov
 }
 
 func (r *AccountRepository) ListEnabled(ctx context.Context, provider account.Provider) ([]account.Credential, error) {
-	var rows []accountModel
-	err := r.db.db.WithContext(ctx).Preload("Credential").Preload("WebProfile").Where("provider = ? AND enabled = ? AND auth_status = ?", provider, true, account.AuthStatusActive).Order("priority DESC, id ASC").Find(&rows).Error
+	rows, err := r.listActiveProviderAccountRows(ctx, provider, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -872,10 +961,8 @@ func (r *AccountRepository) attachRoutingEgressIdentities(ctx context.Context, p
 	if len(values) == 0 || provider == account.ProviderWeb {
 		return nil
 	}
-	ids := make([]uint64, 0, len(values))
 	positions := make(map[uint64]int, len(values))
 	for index := range values {
-		ids = append(ids, values[index].ID)
 		positions[values[index].ID] = index
 	}
 	type identityRow struct {
@@ -889,15 +976,17 @@ func (r *AccountRepository) attachRoutingEgressIdentities(ctx context.Context, p
 	case account.ProviderBuild:
 		query = query.Table("account_provider_links AS link").
 			Select("link.build_account_id AS account_id, web.source_key AS web_source_key, profile.egress_identity").
+			Joins("JOIN provider_accounts AS target ON target.id = link.build_account_id").
 			Joins("JOIN provider_accounts AS web ON web.id = link.web_account_id").
 			Joins("LEFT JOIN web_account_profiles AS profile ON profile.account_id = web.id").
-			Where("link.build_account_id IN ?", ids)
+			Where("target.provider = ? AND target.enabled = ? AND target.auth_status = ?", provider, true, account.AuthStatusActive)
 	case account.ProviderConsole:
 		query = query.Table("web_console_account_links AS link").
 			Select("link.console_account_id AS account_id, web.source_key AS web_source_key, profile.egress_identity").
+			Joins("JOIN provider_accounts AS target ON target.id = link.console_account_id").
 			Joins("JOIN provider_accounts AS web ON web.id = link.web_account_id").
 			Joins("LEFT JOIN web_account_profiles AS profile ON profile.account_id = web.id").
-			Where("link.console_account_id IN ?", ids)
+			Where("target.provider = ? AND target.enabled = ? AND target.auth_status = ?", provider, true, account.AuthStatusActive)
 	default:
 		return nil
 	}

--- a/backend/internal/infra/persistence/relational/routing_large_pool_test.go
+++ b/backend/internal/infra/persistence/relational/routing_large_pool_test.go
@@ -1,0 +1,103 @@
+package relational
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+)
+
+func TestRoutingLargeSQLiteAccountPoolDoesNotExceedVariableLimit(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDatabase(t)
+	const accountCount = 32767
+
+	if err := database.db.WithContext(ctx).Exec(`
+		WITH RECURSIVE seq(id) AS (
+			SELECT 1 UNION ALL SELECT id + 1 FROM seq WHERE id < ?
+		)
+		INSERT INTO provider_accounts (
+			id, identity_key, provider, name, email, user_id, team_id, source_key,
+			enabled, auth_status, priority, max_concurrent, minimum_remaining,
+			failure_count, last_error, observed_model, build_api_fallback,
+			build_route_mode, build_super_entitled, egress_assignment_mode,
+			created_at, updated_at
+		)
+		SELECT id, printf('%064x', id), 'grok_console', 'account-' || id, '', '', '',
+			'source-' || id, 1, 'active', 1, 8, 0, 0, '', '', 0, 'auto', 0, '',
+			CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+		FROM seq`, accountCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.db.WithContext(ctx).Exec(`
+		INSERT INTO account_credentials (
+			account_id, auth_type, client_id, encrypted_primary, encrypted_refresh,
+			encrypted_cloudflare_cookie, refresh_failures, last_refresh_error_status,
+			last_refresh_error, last_refresh_error_message, last_refresh_error_response,
+			refresh_permanent, updated_at
+		)
+		SELECT id, 'oauth', '', 'token', '', '', 0, 0, '', '', '', 0, CURRENT_TIMESTAMP
+		FROM provider_accounts`).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := database.db.WithContext(ctx).Create(&billingModel{
+		AccountID: accountCount, PlanCode: "paid", MonthlyLimit: 100, Used: 12, HistoryJSON: "[]", SyncedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.db.WithContext(ctx).Create(&quotaRecoveryModel{
+		AccountID: accountCount, Kind: string(account.QuotaRecoveryKindPaid), Status: string(account.QuotaRecoveryStatusExhausted), UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.db.WithContext(ctx).Create(&quotaWindowModel{
+		AccountID: accountCount, Mode: "monthly", Remaining: 7, Total: 10, UsagePercent: 30,
+		BreakdownJSON: "[]", WindowSeconds: 3600, Source: string(account.QuotaSourceUpstream), UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	repository := NewAccountRepository(database)
+	enabled, err := repository.ListEnabled(ctx, account.ProviderConsole)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(enabled) != accountCount || enabled[len(enabled)-1].EncryptedAccessToken != "token" {
+		t.Fatalf("enabled account load = %d rows, last credential hydrated = %t", len(enabled), len(enabled) > 0 && enabled[len(enabled)-1].EncryptedAccessToken == "token")
+	}
+
+	bases, err := repository.ListRoutingAccountBases(ctx, account.ProviderConsole, "monthly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bases) != accountCount {
+		t.Fatalf("routing bases = %d, want %d", len(bases), accountCount)
+	}
+	last := bases[len(bases)-1]
+	if last.Credential.ID != accountCount || last.Credential.AuthType != account.AuthTypeOAuth {
+		t.Fatalf("last routing credential = %#v", last.Credential)
+	}
+	if last.Credential.EncryptedAccessToken != "" {
+		t.Fatal("routing projection unexpectedly loaded credential secret")
+	}
+	if last.Billing == nil || last.Billing.PlanCode != "paid" {
+		t.Fatalf("last routing billing = %#v", last.Billing)
+	}
+	if last.QuotaRecovery == nil || last.QuotaRecovery.Status != account.QuotaRecoveryStatusExhausted {
+		t.Fatalf("last routing recovery = %#v", last.QuotaRecovery)
+	}
+	if last.QuotaWindow == nil || last.QuotaWindow.Remaining != 7 {
+		t.Fatalf("last routing quota window = %#v", last.QuotaWindow)
+	}
+
+	candidates, err := repository.ListRoutingCandidates(ctx, account.ProviderConsole, 0, "grok-test", "monthly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != accountCount {
+		t.Fatalf("routing candidates = %d, want %d", len(candidates), accountCount)
+	}
+}


### PR DESCRIPTION
## What changed

- replaces large account ID `IN (...)` queries and GORM association preloads with fixed-shape provider-scoped JOIN queries
- prevents SQLite variable-limit failures when routing pools contain more than 32,766 accounts
- applies the same query strategy to SQLite and PostgreSQL without database-specific `json_each`, `carray`, batching, or temporary tables
- introduces bounded LRU caching for routing bases, model overlays, and materialized candidates
- increases the routing cache TTL while retaining precise event-driven invalidation
- replaces full-snapshot copy-on-write quota updates with O(1) process-local quota deltas
- permits last-good routing snapshots only for explicitly transient database failures
- prevents canceled requests, deadlines, validation failures, and permanent query errors from being hidden by stale-cache fallback
- adds rate-limited structured logs for stale routing snapshot fallback

## Root cause

Large routing pools were loaded by first collecting every account ID and then passing the complete list into unbatched `IN (...)` queries and GORM preloads.

SQLite accepts at most 32,766 bound variables in the current driver build. Pools containing 32,767 or more accounts therefore failed before account selection, lease allocation, or upstream dispatch. The underlying database error was later exposed as `upstream_unavailable`.

The account summary page remained healthy because it used aggregate SQL rather than the failing routing query path.

## Reliability and performance

- routing queries now have a stable parameter count regardless of account-pool size
- candidate snapshot counts and total cached candidate values are bounded
- one oversized active pool remains usable while older model snapshots are evicted
- successful quota consumption no longer clones complete 40k-account snapshots
- stale snapshots are never restored after an account or route invalidation
- transient fallback retries authoritative loading every 5 seconds and expires after 5 minutes
- degradation logs are limited to one event per provider and cache layer per minute

## Compatibility

This change does not alter:

- public APIs or configuration format
- account eligibility and priority rules
- sticky-account behavior
- retry counts or routing failover
- model bindings or account capabilities
- credential, billing, or quota persistence semantics

## Validation

- `go test ./...` in `backend`
- `go test -race ./internal/application/gateway`
- `go vet ./internal/application/gateway ./internal/infra/persistence/relational ./internal/app`
- SQLite regression coverage with 32,767 accounts
- cache-capacity coverage with 41,571 candidates
- cancellation, deadline, permanent-error, transient-error, invalidation, and stale-snapshot regression tests
- `git diff --check`