### PR TITLE
feat: support PostgreSQL connection URL from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ When a fixed proxy enters cooldown after a transport failure, grok2api starts an
 
 Multi-instance deployments require a unique `deployment.instanceID` per replica, one shared `clusterID`, and `sharedMedia: true` only after the media directory is shared correctly.
 
+PostgreSQL credentials can be injected without storing them in `config.yaml`:
+
+```bash
+GROK2API_DATABASE_URL='postgresql://user:password@host:5432/grok2api?sslmode=require' docker compose up -d
+```
+
+A non-empty `GROK2API_DATABASE_URL` overrides `database.postgres.dsn` and automatically selects the `postgres` driver. An empty value is ignored. Supported URL schemes are `postgres://` and `postgresql://`; SQLAlchemy's `postgresql+asyncpg://` form is rejected with a migration hint. The application does not implicitly read the generic `DATABASE_URL`; platforms that provide it can map it explicitly with `GROK2API_DATABASE_URL: "${DATABASE_URL}"`. Database configuration precedence is built-in defaults, `config.yaml`, then `GROK2API_DATABASE_URL`. The current CLI has no database override.
+
 Important optional settings:
 
 - `audit.ledgerMode`: `observe` reports ledger faults; `enforce` can pause new inference to protect billing integrity.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,6 +335,14 @@ docker compose --profile flaresolverr up -d
 
 多实例需要为每个副本设置唯一的 `deployment.instanceID`，统一使用同一个 `clusterID`；只有媒体目录已正确共享时才设置 `sharedMedia: true`。
 
+PostgreSQL 凭据可以通过环境变量注入，无需写入 `config.yaml`：
+
+```bash
+GROK2API_DATABASE_URL='postgresql://user:password@host:5432/grok2api?sslmode=require' docker compose up -d
+```
+
+非空的 `GROK2API_DATABASE_URL` 会覆盖 `database.postgres.dsn` 并自动选择 `postgres`；空值不会覆盖 YAML。支持 `postgres://` 和 `postgresql://`，SQLAlchemy 的 `postgresql+asyncpg://` 会返回格式迁移提示。程序不会隐式读取通用的 `DATABASE_URL`；平台只提供该变量时，可在部署清单中显式映射为 `GROK2API_DATABASE_URL: "${DATABASE_URL}"`。数据库配置优先级为：内置默认值 < `config.yaml` < `GROK2API_DATABASE_URL`。当前 CLI 没有数据库覆盖参数。
+
 重要的可选设置：
 
 - `audit.ledgerMode`：`observe` 仅报告账本故障；`enforce` 可暂停新推理以保护计费准确性。

--- a/backend/README.md
+++ b/backend/README.md
@@ -36,6 +36,8 @@ go run ./cmd/grok2api --config /path/to/config.yaml --listen 0.0.0.0:8000
 
 启动配置统一由根目录 `config.yaml` 管理，启动阶段字段见 [`config.example.yaml`](../config.example.yaml)。Provider、服务容量、批量任务、路由、媒体、审计和客户端密钥默认限制由管理端设置页持久化；除页面明确标记“重启生效”的字段外均会热加载。
 
+PostgreSQL DSN 也可通过非空的 `GROK2API_DATABASE_URL` 注入；它的优先级高于 YAML，并会自动将数据库驱动切换为 `postgres`。空值不覆盖 YAML，程序不会隐式读取通用的 `DATABASE_URL`。
+
 | 场景 | 数据库 | 运行态存储 |
 | --- | --- | --- |
 | 本地开发 / 单实例 | SQLite | Memory |

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	DatabaseURLEnv                = "GROK2API_DATABASE_URL"
 	StatsigModeManual             = "manual"
 	StatsigModeURL                = "url"
 	ClearanceModeManual           = "manual"
@@ -345,10 +346,45 @@ func Load(path string) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if err := applyEnvironmentOverrides(&cfg); err != nil {
+		return Config{}, err
+	}
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+// applyEnvironmentOverrides applies typed, application-owned environment
+// overrides after YAML and before CLI overrides. Empty values are ignored so
+// Compose can pass an optional variable without changing existing deployments.
+func applyEnvironmentOverrides(cfg *Config) error {
+	value := strings.TrimSpace(os.Getenv(DatabaseURLEnv))
+	if value == "" {
+		return nil
+	}
+	dsn, err := validatePostgresEnvironmentURL(value)
+	if err != nil {
+		return err
+	}
+	cfg.Database.Driver = "postgres"
+	cfg.Database.Postgres.DSN = dsn
+	return nil
+}
+
+func validatePostgresEnvironmentURL(value string) (string, error) {
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "postgresql+asyncpg://") {
+		return "", fmt.Errorf("%s 不支持 SQLAlchemy asyncpg URL；请将 postgresql+asyncpg:// 改为 postgresql://", DatabaseURLEnv)
+	}
+	if !strings.HasPrefix(lower, "postgres://") && !strings.HasPrefix(lower, "postgresql://") {
+		return "", fmt.Errorf("%s 必须使用 postgres:// 或 postgresql:// URL（连接信息已隐藏）", DatabaseURLEnv)
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || parsed.Scheme == "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("%s 不是有效的 PostgreSQL URL（连接信息已隐藏）", DatabaseURLEnv)
+	}
+	return value, nil
 }
 
 func resolveRelativePaths(cfg *Config, configPath string) error {

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -4,11 +4,111 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	clientkeydomain "github.com/chenyme/grok2api/backend/internal/domain/clientkey"
 )
+
+func TestLoadDatabaseURLOverridesYAMLAndSelectsPostgres(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`secrets:
+  jwtSecret: "12345678901234567890123456789012"
+  credentialEncryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+bootstrapAdmin:
+  password: "password123"
+database:
+  driver: sqlite
+  sqlite:
+    path: "./yaml.db"
+  postgres:
+    dsn: "postgres://yaml:yaml@yaml.invalid/yaml"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const environmentDSN = "postgresql://env:secret@postgres.internal:5432/grok2api?sslmode=require"
+	t.Setenv(DatabaseURLEnv, environmentDSN)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Database.Driver != "postgres" || cfg.Database.Postgres.DSN != environmentDSN {
+		t.Fatalf("database config = %#v", cfg.Database)
+	}
+}
+
+func TestLoadEmptyDatabaseURLKeepsYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	const yamlDSN = "postgres://yaml:secret@postgres.internal:5432/grok2api"
+	if err := os.WriteFile(path, []byte(`secrets:
+  jwtSecret: "12345678901234567890123456789012"
+  credentialEncryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+bootstrapAdmin:
+  password: "password123"
+database:
+  driver: postgres
+  postgres:
+    dsn: "`+yamlDSN+`"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(DatabaseURLEnv, "   ")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Database.Driver != "postgres" || cfg.Database.Postgres.DSN != yamlDSN {
+		t.Fatalf("database config = %#v", cfg.Database)
+	}
+}
+
+func TestLoadDoesNotImplicitlyReadGenericDatabaseURL(t *testing.T) {
+	t.Setenv(DatabaseURLEnv, "")
+	t.Setenv("DATABASE_URL", "postgres://generic:secret@postgres.internal/grok2api")
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`secrets:
+  jwtSecret: "12345678901234567890123456789012"
+  credentialEncryptionKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+bootstrapAdmin:
+  password: "password123"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Database.Driver != "sqlite" {
+		t.Fatalf("generic DATABASE_URL unexpectedly selected %q", cfg.Database.Driver)
+	}
+}
+
+func TestLoadRejectsInvalidDatabaseEnvironmentURLWithoutLeakingCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		message string
+	}{
+		{name: "asyncpg", value: "postgresql+asyncpg://user:highly-secret@postgres.internal/grok2api", message: "改为 postgresql://"},
+		{name: "unsupported scheme", value: "mysql://user:highly-secret@mysql.internal/grok2api", message: "postgres:// 或 postgresql://"},
+		{name: "malformed URL", value: "postgres://user:highly-secret%zz@postgres.internal/grok2api", message: "不是有效的 PostgreSQL URL"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(DatabaseURLEnv, test.value)
+			_, err := Load("")
+			if err == nil || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("Load error = %v, want message containing %q", err, test.message)
+			}
+			if strings.Contains(err.Error(), "highly-secret") || strings.Contains(err.Error(), test.value) {
+				t.Fatalf("Load error leaked database credentials: %v", err)
+			}
+		})
+	}
+}
 
 func TestLoadDurationAndSecretsFromYAML(t *testing.T) {
 	dir := t.TempDir()

--- a/backend/internal/infra/persistence/relational/database.go
+++ b/backend/internal/infra/persistence/relational/database.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	glebarezsqlite "github.com/glebarez/sqlite"
@@ -56,9 +58,42 @@ func OpenSQLite(ctx context.Context, path string) (*Database, error) {
 func OpenPostgres(ctx context.Context, dsn string, maxOpenConns, maxIdleConns int) (*Database, error) {
 	db, err := gorm.Open(postgres.Open(dsn), gormConfig())
 	if err != nil {
-		return nil, fmt.Errorf("打开 PostgreSQL: %w", err)
+		return nil, &postgresConnectionError{operation: "打开 PostgreSQL", err: err, dsn: dsn}
 	}
-	return configureDatabase(ctx, db, "postgres", maxOpenConns, maxIdleConns)
+	database, err := configureDatabase(ctx, db, "postgres", maxOpenConns, maxIdleConns)
+	if err != nil {
+		return nil, &postgresConnectionError{operation: "配置 PostgreSQL", err: err, dsn: dsn}
+	}
+	return database, nil
+}
+
+type postgresConnectionError struct {
+	operation string
+	err       error
+	dsn       string
+}
+
+func (e *postgresConnectionError) Error() string {
+	return e.operation + ": " + redactPostgresErrorMessage(e.err, e.dsn)
+}
+
+func (e *postgresConnectionError) Unwrap() error { return e.err }
+
+var (
+	postgresURLPasswordPattern = regexp.MustCompile(`(?i)(postgres(?:ql)?://[^:/\s]+:)[^@\s]+(@)`)
+	postgresDSNPasswordPattern = regexp.MustCompile(`(?i)(password\s*=\s*)(?:'[^']*'|"[^"]*"|[^\s]+)`)
+)
+
+func redactPostgresErrorMessage(err error, dsn string) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	if value := strings.TrimSpace(dsn); value != "" {
+		message = strings.ReplaceAll(message, value, "<redacted PostgreSQL DSN>")
+	}
+	message = postgresURLPasswordPattern.ReplaceAllString(message, `${1}<redacted>${2}`)
+	return postgresDSNPasswordPattern.ReplaceAllString(message, `${1}<redacted>`)
 }
 
 func gormConfig() *gorm.Config {

--- a/backend/internal/infra/persistence/relational/database_redaction_test.go
+++ b/backend/internal/infra/persistence/relational/database_redaction_test.go
@@ -1,0 +1,56 @@
+package relational
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestOpenPostgresInvalidDSNDoesNotLeakCredentials(t *testing.T) {
+	const dsn = "postgres://database-user:highly-secret%zz@postgres.internal/grok2api"
+	_, err := OpenPostgres(context.Background(), dsn, 1, 1)
+	if err == nil {
+		t.Fatal("invalid PostgreSQL DSN was accepted")
+	}
+	if strings.Contains(err.Error(), "highly-secret") || strings.Contains(err.Error(), dsn) {
+		t.Fatalf("OpenPostgres error leaked PostgreSQL credentials: %v", err)
+	}
+}
+
+func TestRedactPostgresErrorMessageRemovesURLCredentials(t *testing.T) {
+	const dsn = "postgres://database-user:highly-secret@postgres.internal:5432/grok2api?sslmode=require"
+	message := redactPostgresErrorMessage(errors.New("cannot parse or connect to "+dsn), dsn)
+	if strings.Contains(message, "highly-secret") || strings.Contains(message, dsn) {
+		t.Fatalf("redacted error leaked PostgreSQL credentials: %s", message)
+	}
+}
+
+func TestRedactPostgresErrorMessageRemovesDriverRenderedPasswords(t *testing.T) {
+	tests := []string{
+		"connect postgres://database-user:rendered-secret@postgres.internal/grok2api failed",
+		"connect failed host=postgres.internal user=database-user password=rendered-secret dbname=grok2api",
+		"connect failed host=postgres.internal password='rendered secret' dbname=grok2api",
+	}
+	for _, input := range tests {
+		message := redactPostgresErrorMessage(errors.New(input), "postgres://different:redacted@other.internal/db")
+		if strings.Contains(message, "rendered-secret") || strings.Contains(message, "rendered secret") {
+			t.Fatalf("redacted error leaked PostgreSQL password: %s", message)
+		}
+	}
+}
+
+func TestPostgresConnectionErrorPreservesErrorChainWithoutLeakingDSN(t *testing.T) {
+	sentinel := errors.New("connection sentinel")
+	wrapped := &postgresConnectionError{
+		operation: "打开 PostgreSQL",
+		err:       sentinel,
+		dsn:       "postgres://database-user:highly-secret@postgres.internal/grok2api",
+	}
+	if !errors.Is(wrapped, sentinel) {
+		t.Fatal("redacted PostgreSQL error did not preserve its error chain")
+	}
+	if strings.Contains(wrapped.Error(), "highly-secret") {
+		t.Fatalf("wrapped error leaked PostgreSQL password: %s", wrapped)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,7 @@ database:
     path: "./data/backend.db"
   postgres:
     # [必须修改：仅 driver=postgres] 填写真实 DSN，并按需启用 sslmode。
+    # 也可通过 GROK2API_DATABASE_URL 注入；非空环境变量会覆盖本字段并自动启用 postgres。
     dsn: "postgres://user:password@127.0.0.1:5432/grok2api?sslmode=disable"
     # [按需修改] 根据数据库连接容量调整。
     maxOpenConns: 50

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - "${GROK2API_PORT:-8000}:8000"
     environment:
       TZ: "${TZ:-Asia/Shanghai}"
+      # 非空时覆盖 config.yaml 的 PostgreSQL DSN，并自动启用 postgres。
+      GROK2API_DATABASE_URL: "${GROK2API_DATABASE_URL:-}"
       GROK2API_QUALITY_GUARD_DIR: /var/lib/grok2api-quality-guard
     volumes:
       - "${GROK2API_CONFIG:-./config.yaml}:/run/grok2api/config.yaml:ro"


### PR DESCRIPTION

## What changed

- adds support for injecting the PostgreSQL connection URL through `GROK2API_DATABASE_URL`
- automatically selects the PostgreSQL driver when the environment variable is non-empty
- preserves existing SQLite and PostgreSQL YAML behavior when the variable is unset or empty
- accepts `postgres://` and `postgresql://` URLs
- rejects SQLAlchemy `postgresql+asyncpg://` URLs with an actionable migration message
- redacts PostgreSQL credentials from configuration, connection, and health-check errors
- preserves the original Go error chain through `Unwrap`, allowing existing `errors.Is` and `errors.As` checks to continue working
- exposes the optional variable through the built-in Docker Compose configuration
- documents environment-based PostgreSQL configuration in the English, Chinese, backend, and example configuration documentation

## Configuration priority

The startup configuration priority is:

```text
built-in defaults
    < config.yaml
    < GROK2API_DATABASE_URL
    < CLI overrides
```

The current CLI does not provide a database override, so `GROK2API_DATABASE_URL` is currently the highest-priority database setting.

A non-empty environment value overrides `database.postgres.dsn` and automatically sets:

```yaml
database:
  driver: postgres
```

An unset, empty, or whitespace-only value does not override YAML.

## Usage

Docker Compose:

```bash
GROK2API_DATABASE_URL='postgresql://user:password@host:5432/grok2api?sslmode=require' \
docker compose up -d
```

Kubernetes and PaaS deployments can inject the same variable through their Secret management facilities.

Platforms that only provide `DATABASE_URL` can map it explicitly:

```yaml
environment:
  GROK2API_DATABASE_URL: "${DATABASE_URL}"
```

The application intentionally does not read the generic `DATABASE_URL` implicitly, avoiding collisions with unrelated services or sidecars.

## Compatibility

- no API changes
- no database schema or migration changes
- existing SQLite deployments are unchanged
- existing YAML-based PostgreSQL deployments are unchanged
- PostgreSQL keyword/value DSNs remain supported in YAML
- URL-only validation applies only to `GROK2API_DATABASE_URL`
- connection-pool settings continue to come from YAML or built-in defaults
- the environment variable is read at startup and requires a restart to change

## Security

- invalid environment URLs never include the original URL or password in returned errors
- PostgreSQL driver parse, connection, and ping errors are sanitized
- URL and keyword/value password forms are redacted
- sanitized errors retain their underlying error chain for programmatic classification

## Validation

- `go test ./...` in `backend`
- targeted `go test -race` for configuration and relational persistence
- `go vet ./...`
- `docker compose config --quiet`
- repeated environment-priority regression tests
- malformed URL, unsupported scheme, asyncpg migration, empty override, generic `DATABASE_URL`, and credential-redaction tests
- `git diff --check`