### PR TITLE
fix(test): skip POSIX permission assertions on Windows

### DIFF
--- a/backend/internal/infra/qualityguard/bootstrap_test.go
+++ b/backend/internal/infra/qualityguard/bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -31,7 +32,9 @@ func TestPrepareWritesPrivateScopedBootstrap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	// Windows has no POSIX permission bits: the os.WriteFile mode argument
+	// is ignored and files always report 0666-style permissions.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %o", info.Mode().Perm())
 	}
 	var payload bootstrapFile

--- a/backend/internal/transport/http/egress/handler_test.go
+++ b/backend/internal/transport/http/egress/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -120,7 +121,9 @@ func TestUpdateQualityGuardConfigWritesPrivateAtomicFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	// Windows has no POSIX permission bits: the os.WriteFile mode argument
+	// is ignored and files always report 0666-style permissions.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("runtime config mode = %o", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## 概述

v3.1.0 新增的 qualityguard 相关测试在 Windows 上必挂：`bootstrap.json` 与 `runtime-config.json` 写入后断言文件权限为 `0600`，但 **Windows 没有 POSIX 权限位**，`os.WriteFile` 的 mode 参数被忽略，文件恒为 `0666` 样式（Go 官方文档：Windows 仅使用 0200 位控制只读属性）。

## 改动

- `qualityguard/bootstrap_test.go` 与 `transport/http/egress/handler_test.go` 的权限断言加 `runtime.GOOS != "windows"` 分支
- Windows 上跳过该断言（属性不存在，无可断言对象；实际安全由 ACL 继承保证）
- Linux / 容器部署环境断言**完整保留**

## 兼容性

- 仅测试代码改动，零生产代码影响
- Linux 行为不变（`0600` 断言照常执行）
- Windows 本地开发从「测试必挂」变为「测试通过」

`go test ./...` 全绿。
