### PR TITLE
refactor: remove SearchTools from ModelSpec and update related logic in console provider

### DIFF
--- a/backend/internal/infra/provider/console/catalog.go
+++ b/backend/internal/infra/provider/console/catalog.go
@@ -19,16 +19,15 @@ type ModelSpec struct {
 	SupportsReasoningEffort bool
 	DefaultReasoningEffort  string
 	MaxOutputTokens         int
-	SearchTools             bool
 }
 
 var catalog = []ModelSpec{
-	{PublicID: "grok-4.3", UpstreamModel: "grok-4.3", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000, SearchTools: true},
-	{PublicID: "grok-4.20-0309-reasoning", UpstreamModel: "grok-4.20-0309-reasoning", SupportsReasoning: true, MaxOutputTokens: 1_000_000, SearchTools: true},
-	{PublicID: "grok-4.20-0309-non-reasoning", UpstreamModel: "grok-4.20-0309-non-reasoning", MaxOutputTokens: 1_000_000, SearchTools: true},
-	{PublicID: "grok-4.20-multi-agent-0309", UpstreamModel: "grok-4.20-multi-agent-0309", SupportsReasoning: true, SupportsReasoningEffort: true, MaxOutputTokens: 1_000_000, SearchTools: true},
-	{PublicID: "grok-4.5", UpstreamModel: "grok-4.5", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000, SearchTools: true},
-	{PublicID: "grok-build-0.1", UpstreamModel: "grok-build-0.1", MaxOutputTokens: 256_000, SearchTools: true},
+	{PublicID: "grok-4.3", UpstreamModel: "grok-4.3", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-4.20-0309-reasoning", UpstreamModel: "grok-4.20-0309-reasoning", SupportsReasoning: true, MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-4.20-0309-non-reasoning", UpstreamModel: "grok-4.20-0309-non-reasoning", MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-4.20-multi-agent-0309", UpstreamModel: "grok-4.20-multi-agent-0309", SupportsReasoning: true, SupportsReasoningEffort: true, MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-4.5", UpstreamModel: "grok-4.5", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-build-0.1", UpstreamModel: "grok-build-0.1", MaxOutputTokens: 256_000},
 }
 
 var mediaCatalog = []struct {

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -166,24 +166,42 @@ func TestNormalizeRequestAppliesConsoleContract(t *testing.T) {
 		t.Fatalf("include = %#v", include)
 	}
 	tools, _ := payload["tools"].([]any)
-	if len(tools) != 3 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "x_search" || toolIdentity(tools[2]) != "function:lookup" {
+	if len(tools) != 2 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "function:lookup" {
 		t.Fatalf("tools = %#v", tools)
 	}
 	webSearch, _ := tools[0].(map[string]any)
 	if webSearch["custom"] != nil || webSearch["enable_image_understanding"] != true {
 		t.Fatalf("web_search = %#v", webSearch)
 	}
-	stateless, err := normalizeRequest([]byte(`{"model":"grok-4.3","store":true,"previous_response_id":"resp_1","service_tier":"priority","input":"hello"}`), spec)
+	stateless, err := normalizeRequest([]byte(`{"model":"grok-4.3","store":true,"previous_response_id":"resp_1","service_tier":"priority","prompt_cache_key":"cache_1","input":"hello"}`), spec)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var statelessPayload map[string]any
-	if json.Unmarshal(stateless, &statelessPayload) != nil || statelessPayload["store"] != false || statelessPayload["previous_response_id"] != nil || statelessPayload["service_tier"] != nil {
+	if json.Unmarshal(stateless, &statelessPayload) != nil || statelessPayload["store"] != false || statelessPayload["previous_response_id"] != nil || statelessPayload["service_tier"] != nil || statelessPayload["prompt_cache_key"] != nil {
 		t.Fatalf("stateless payload = %#v", statelessPayload)
 	}
 }
 
-func TestNormalizeRequestMatchesCapturedMultiAgentDefaults(t *testing.T) {
+func TestNormalizeRequestDoesNotInjectToolsForConsoleCatalog(t *testing.T) {
+	for _, spec := range catalog {
+		t.Run(spec.PublicID, func(t *testing.T) {
+			body, err := normalizeRequest([]byte(`{"model":"public","input":"hello","tool_choice":"required"}`), spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["tools"] != nil || payload["tool_choice"] != nil {
+				t.Fatalf("Console must not inject tools: %#v", payload)
+			}
+		})
+	}
+}
+
+func TestNormalizeRequestPreservesMultiAgentDefaultsWithoutInjectingTools(t *testing.T) {
 	spec, ok := Resolve("grok-4.20-multi-agent-0309")
 	if !ok {
 		t.Fatal("grok-4.20-multi-agent-0309 missing")
@@ -204,8 +222,7 @@ func TestNormalizeRequestMatchesCapturedMultiAgentDefaults(t *testing.T) {
 		t.Fatalf("multi-agent defaults = %#v", payload)
 	}
 	include, _ := payload["include"].([]any)
-	tools, _ := payload["tools"].([]any)
-	if len(include) != 1 || include[0] != "reasoning.encrypted_content" || len(tools) != 2 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "x_search" {
+	if len(include) != 1 || include[0] != "reasoning.encrypted_content" || payload["tools"] != nil || payload["tool_choice"] != nil {
 		t.Fatalf("multi-agent compatibility = %#v", payload)
 	}
 	explicit, err := normalizeRequest([]byte(`{"model":"grok-4.20-multi-agent-0309","input":"hello","reasoning":{"effort":"xhigh"}}`), spec)
@@ -268,7 +285,7 @@ func TestNormalizeRequestAppliesConsoleCompatibilityBoundary(t *testing.T) {
 		t.Fatalf("message parts = %#v", parts)
 	}
 	tools, _ := payload["tools"].([]any)
-	if len(tools) != 2 || toolIdentity(tools[0]) != "web_search" || toolIdentity(tools[1]) != "x_search" {
+	if len(tools) != 1 || toolIdentity(tools[0]) != "web_search" {
 		t.Fatalf("sanitized tools = %#v", tools)
 	}
 	if tools[0].(map[string]any)["external_web_access"] != nil {

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -39,9 +39,6 @@ func normalizeRequest(body []byte, spec ModelSpec) ([]byte, error) {
 	normalizeReasoning(payload, spec)
 	ensureReasoningInclude(payload)
 	retainedClientTools := normalizeConsoleTools(payload)
-	if spec.SearchTools {
-		mergeSearchTools(payload)
-	}
 	normalizeConsoleToolChoice(payload, retainedClientTools)
 	return json.Marshal(payload)
 }
@@ -208,6 +205,8 @@ func ensureReasoningInclude(payload map[string]any) {
 func normalizeConsoleTools(payload map[string]any) bool {
 	value, exists := payload["tools"]
 	if !exists || value == nil {
+		delete(payload, "tools")
+		delete(payload, "tool_choice")
 		return false
 	}
 	tools, ok := value.([]any)
@@ -260,40 +259,18 @@ func normalizeConsoleTools(payload map[string]any) bool {
 	}
 	if len(result) == 0 {
 		delete(payload, "tools")
+		delete(payload, "tool_choice")
 		return false
 	}
 	payload["tools"] = result
 	return retainedClientTools
 }
 
-func mergeSearchTools(payload map[string]any) {
-	defaults := []any{
-		map[string]any{"type": "web_search", "enable_image_understanding": true},
-		map[string]any{"type": "x_search", "enable_video_understanding": true},
-	}
-	positions := map[string]int{"web_search": 0, "x_search": 1}
-	result := append([]any(nil), defaults...)
-	if value, exists := payload["tools"]; exists && value != nil {
-		tools, _ := value.([]any)
-		for _, tool := range tools {
-			identity := toolIdentity(tool)
-			if index, exists := positions[identity]; identity != "" && exists {
-				result[index] = tool
-				continue
-			}
-			if identity != "" {
-				positions[identity] = len(result)
-			}
-			result = append(result, tool)
-		}
-	}
-	payload["tools"] = result
-	if _, exists := payload["tool_choice"]; !exists {
-		payload["tool_choice"] = "auto"
-	}
-}
-
 func normalizeConsoleToolChoice(payload map[string]any, retainedClientTools bool) {
+	if _, exists := payload["tools"]; !exists {
+		delete(payload, "tool_choice")
+		return
+	}
 	choice, exists := payload["tool_choice"]
 	if !exists {
 		payload["tool_choice"] = "auto"


### PR DESCRIPTION
## 概述

修正 Grok Console 对话请求的工具处理逻辑。此前所有 Console 对话模型都会默认注入 `web_search` 和 `x_search`，即使客户端未声明任何工具，也会向上游发送 `tools` 和 `tool_choice: auto`。

本次调整为严格遵循客户端请求：只有客户端主动提供工具时，才向 Console 上游发送相关字段。

## 改动内容

- 移除所有 Console 对话模型的默认搜索工具开关。
- 删除 `web_search`、`x_search` 自动注入逻辑。
- 客户端未传入 `tools` 时：
  - 不发送 `tools`
  - 不发送 `tool_choice`
- 客户端主动传入工具时：
  - 保留并规范化 Console 支持的工具
  - 过滤不兼容或无效的工具
  - 所有工具均被过滤后，同时移除 `tools` 和 `tool_choice`
- Responses、Chat Completions、Anthropic Messages 三种协议保持一致。
- 保持 Console 无状态语义：
  - 强制 `store: false`
  - 移除 `previous_response_id`
  - 移除 `prompt_cache_key`
  - 不接入 Grok Build 的 Prompt Cache 与账号亲和逻辑

## 兼容性

- 不影响客户端主动声明的 Function、Web Search、X Search、MCP、Shell、File Search、Code Interpreter 等受支持工具。
- 不影响图像、图像编辑和视频接口。
- 不涉及数据库、配置或 API Schema 变更。
- 未声明工具的普通对话请求不再产生非预期搜索、额外延迟或工具调用成本。

## 测试

- 新增全部 Console 对话模型“不自动注入工具”的回归测试。
- 新增 `prompt_cache_key` 不进入 Console 上游的断言。
- 更新现有工具清洗和多智能体默认行为测试。
- `go test ./...` 通过。
- `go vet ./...` 通过。