### PR TITLE
fix(web): Web 上游搜索引用对齐（mgw render_citation → 客户端 citations）

### DIFF
--- a/backend/internal/infra/provider/conversation/response.go
+++ b/backend/internal/infra/provider/conversation/response.go
@@ -13,7 +13,30 @@ type ResponseOptions struct {
 	AnthropicWebSearchRequired bool
 	AnthropicWebSearchQuery    string
 	StopSequences              []string
+	// Include mirrors xAI Responses `include` (e.g. "no_inline_citations", "inline_citations").
+	Include []string
+	// InlineCitations overrides Include when non-nil.
+	InlineCitations *bool
 }
+
+// InlineCitationsEnabled reports whether [[N]](url) markers should be embedded.
+// Default is true (xAI Responses API default for HTTP clients).
+func (o ResponseOptions) InlineCitationsEnabled() bool {
+	if o.InlineCitations != nil {
+		return *o.InlineCitations
+	}
+	enabled := true
+	for _, item := range o.Include {
+		switch item {
+		case "no_inline_citations":
+			enabled = false
+		case "inline_citations":
+			enabled = true
+		}
+	}
+	return enabled
+}
+
 
 type responseEnvelope struct {
 	ID        string         `json:"id"`

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -83,6 +83,15 @@ type chatAttachmentInput struct {
 	Image    bool
 }
 
+// hostedSearchCall tracks one mgw web_search / x_search invocation for xAI Responses output items.
+type hostedSearchCall struct {
+	ID      string
+	Kind    string // web_search | x_search
+	Query   string
+	Status  string // in_progress | completed
+	Sources []map[string]any
+}
+
 type parsedChat struct {
 	ResponseID      string
 	ConversationID  string
@@ -93,6 +102,9 @@ type parsedChat struct {
 	Images          []string
 	SearchSources   []map[string]any
 	Annotations     []map[string]any
+	// HostedSearchCalls are ordered web_search_call / x_search_call items (xAI Responses).
+	HostedSearchCalls []hostedSearchCall
+	hostedSearchByID  map[string]int
 	// InlineCitations mirrors xAI default-on [[N]](url) embedding.
 	DisableInlineCitations bool
 	sourceKeys      map[string]struct{}
@@ -104,6 +116,7 @@ type parsedChat struct {
 	lastCitation    int
 	ServerTools     int64
 	WebSearchTools  int64
+	XSearchTools    int64
 	InputTokens     int64
 	ToolCalls       []parsedToolCall
 	Tools           []any
@@ -383,6 +396,7 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 		messagesStream := newWebMessagesStream(writer, responseID, model, parsed.InputTokens, options)
 		visiblePhase := webVisibleStreamPhase{}
 		annotationCursor := 0
+		hostedSearchCursor := 0
 		writeDelta := func(kind, delta string) error {
 			if !visiblePhase.Allow(kind, delta) {
 				return nil
@@ -397,12 +411,58 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 			annotationCursor = len(parsed.Annotations)
 			return writeStreamAnnotations(writer, operation, responseID, model, newOnes, annotationCursor-len(newOnes))
 		}
+		flushHostedSearch := func() error {
+			if operation != conversation.OperationResponses {
+				return nil
+			}
+			for hostedSearchCursor < len(parsed.HostedSearchCalls) {
+				call := parsed.HostedSearchCalls[hostedSearchCursor]
+				// Wait until the tool_result arrives (completed / has sources).
+				if call.Status != "completed" && len(call.Sources) == 0 {
+					break
+				}
+				items := xaiHostedSearchOutputItems(parsedChat{HostedSearchCalls: []hostedSearchCall{call}})
+				if len(items) == 0 {
+					hostedSearchCursor++
+					continue
+				}
+				item := items[0]
+				idx := hostedSearchCursor
+				hostedSearchCursor++
+				if err := writeSSE(writer, "response.output_item.added", map[string]any{
+					"type": "response.output_item.added", "response_id": responseID, "output_index": idx, "item": item,
+				}); err != nil {
+					return err
+				}
+				eventType := "response.web_search_call.completed"
+				if call.Kind == "x_search" {
+					eventType = "response.x_search_call.completed"
+				}
+				if err := writeSSE(writer, eventType, map[string]any{
+					"type": eventType, "response_id": responseID, "output_index": idx, "item_id": call.ID,
+				}); err != nil {
+					return err
+				}
+				if err := writeSSE(writer, "response.output_item.done", map[string]any{
+					"type": "response.output_item.done", "response_id": responseID, "output_index": idx, "item": item,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		flushSideChannel := func() error {
+			if err := flushHostedSearch(); err != nil {
+				return err
+			}
+			return flushAnnotations()
+		}
 		if operation != conversation.OperationMessages {
 			writeStreamStart(writer, operation, responseID, model, parsed.InputTokens)
 		}
 		err := consumeUpstreamInto(source, parsed, func(kind, delta string) error {
 			if len(parsed.ToolCalls) > 0 && kind != "reasoning" {
-				return nil
+				return flushSideChannel()
 			}
 			if kind == "image" {
 				rawURL := delta
@@ -432,20 +492,24 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 						if err := writeDelta(kind, result.Raw); err != nil {
 							return err
 						}
-						return flushAnnotations()
+						return flushSideChannel()
 					}
 					parsed.ToolCalls = result.Calls
 					return writeWebStreamToolCalls(writer, messagesStream, operation, responseID, model, result.Calls)
 				}
-				return flushAnnotations()
+				return flushSideChannel()
 			}
 			if kind == "text" {
-				clientText.WriteString(delta)
+				if delta != "" {
+					clientText.WriteString(delta)
+				}
 			}
-			if err := writeDelta(kind, delta); err != nil {
-				return err
+			if delta != "" {
+				if err := writeDelta(kind, delta); err != nil {
+					return err
+				}
 			}
-			return flushAnnotations()
+			return flushSideChannel()
 		})
 		if err != nil {
 			a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, 0, err)
@@ -731,10 +795,12 @@ func consumeUpstreamInto(source io.Reader, parsed *parsedChat, emit func(string,
 		if err != nil {
 			return err
 		}
-		if delta != "" && emit != nil {
-			return emit(kind, delta)
+		if emit == nil {
+			return nil
 		}
-		return nil
+		// Always invoke emit so streaming can flush tool/citation side-channels
+		// even when the frame produced no visible text delta.
+		return emit(kind, delta)
 	})
 }
 
@@ -1360,6 +1426,131 @@ func searchSourceTitle(sources []map[string]any, rawURL string) string {
 	return rawURL
 }
 
+func upsertHostedSearchCall(parsed *parsedChat, id, kind, query, status string) *hostedSearchCall {
+	if parsed == nil {
+		return nil
+	}
+	if id == "" {
+		id = fmt.Sprintf("%s_%d", kind, len(parsed.HostedSearchCalls)+1)
+	}
+	if parsed.hostedSearchByID == nil {
+		parsed.hostedSearchByID = make(map[string]int)
+	}
+	if idx, ok := parsed.hostedSearchByID[id]; ok {
+		call := &parsed.HostedSearchCalls[idx]
+		if query != "" {
+			call.Query = query
+		}
+		if status != "" {
+			call.Status = status
+		}
+		if kind != "" && call.Kind == "" {
+			call.Kind = kind
+		}
+		return call
+	}
+	if len(parsed.HostedSearchCalls) >= maxTrackedServerTools {
+		return nil
+	}
+	if status == "" {
+		status = "in_progress"
+	}
+	parsed.HostedSearchCalls = append(parsed.HostedSearchCalls, hostedSearchCall{
+		ID: id, Kind: kind, Query: query, Status: status,
+	})
+	parsed.hostedSearchByID[id] = len(parsed.HostedSearchCalls) - 1
+	return &parsed.HostedSearchCalls[len(parsed.HostedSearchCalls)-1]
+}
+
+func appendHostedSearchSources(call *hostedSearchCall, sources []map[string]any) {
+	if call == nil || len(sources) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(call.Sources)+len(sources))
+	for _, existing := range call.Sources {
+		if u, _ := existing["url"].(string); u != "" {
+			seen[u] = struct{}{}
+		}
+	}
+	for _, source := range sources {
+		u, _ := source["url"].(string)
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		if len(call.Sources) >= searchresult.MaxResults {
+			break
+		}
+		seen[u] = struct{}{}
+		call.Sources = append(call.Sources, source)
+	}
+}
+
+// xaiHostedSearchOutputItems builds Responses output items: web_search_call / x_search_call.
+func xaiHostedSearchOutputItems(parsed parsedChat) []any {
+	if len(parsed.HostedSearchCalls) == 0 {
+		return nil
+	}
+	items := make([]any, 0, len(parsed.HostedSearchCalls))
+	for _, call := range parsed.HostedSearchCalls {
+		typeName := "web_search_call"
+		if call.Kind == "x_search" {
+			typeName = "x_search_call"
+		}
+		status := call.Status
+		if status == "" {
+			status = "completed"
+		}
+		action := map[string]any{"type": "search"}
+		if call.Query != "" {
+			action["query"] = call.Query
+		}
+		if len(call.Sources) > 0 {
+			// xAI/OpenAI-compatible optional sources on the search action.
+			action["sources"] = call.Sources
+		}
+		items = append(items, map[string]any{
+			"id": call.ID, "type": typeName, "status": status, "action": action,
+		})
+	}
+	return items
+}
+
+func xaiServerSideToolUsage(parsed parsedChat) map[string]any {
+	var web, x int64
+	for _, call := range parsed.HostedSearchCalls {
+		// Billable/successful executions: completed or with returned sources.
+		if call.Status != "completed" && len(call.Sources) == 0 {
+			continue
+		}
+		switch call.Kind {
+		case "web_search":
+			web++
+		case "x_search":
+			x++
+		}
+	}
+	if web == 0 {
+		web = parsed.WebSearchTools
+	}
+	if x == 0 {
+		x = parsed.XSearchTools
+	}
+	usage := map[string]any{}
+	if web > 0 {
+		usage["SERVER_SIDE_TOOL_WEB_SEARCH"] = web
+	}
+	if x > 0 {
+		usage["SERVER_SIDE_TOOL_X_SEARCH"] = x
+	}
+	if len(usage) == 0 {
+		return nil
+	}
+	return usage
+}
+
 func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, streaming bool, responseOptions ...conversation.ResponseOptions) map[string]any {
 	created := time.Now().Unix()
 	options := conversation.ResponseOptions{}
@@ -1390,6 +1581,9 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 		// xAI: top-level citations = all source URLs encountered (always when present).
 		if citations := xaiCitationURLs(parsed); len(citations) > 0 {
 			value["citations"] = citations
+		}
+		if usage := xaiServerSideToolUsage(parsed); usage != nil {
+			value["server_side_tool_usage"] = usage
 		}
 		return value
 	}
@@ -1435,6 +1629,8 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 		output = append(output, map[string]any{"id": newWebID("rs"), "type": "reasoning", "status": "completed", "summary": []any{map[string]any{"type": "summary_text", "text": parsed.Reasoning.String()}}})
 	}
 	finalizeXAIAnnotations(&parsed)
+	// xAI Tool Usage Details: web_search_call / x_search_call precede the assistant message.
+	output = append(output, xaiHostedSearchOutputItems(parsed)...)
 	if parsed.Text.Len() > 0 || len(parsed.ToolCalls) == 0 {
 		annotations := responsesAnnotations(parsed.Annotations)
 		if annotations == nil {
@@ -1470,6 +1666,9 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	// xAI Citations docs: response.citations is the full URL list from tool research.
 	if citations := xaiCitationURLs(parsed); len(citations) > 0 {
 		value["citations"] = citations
+	}
+	if usage := xaiServerSideToolUsage(parsed); usage != nil {
+		value["server_side_tool_usage"] = usage
 	}
 	return value
 }

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -1400,37 +1400,39 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 			return "", nil
 		}
 		parsed.lastCitation = index
-		title := citationPageTitle(parsed, value)
+		title := citationPageTitle(parsed, value, index)
 		annotation := map[string]any{"type": "url_citation", "url": value, "title": title}
 		if parsed.DisableInlineCitations {
 			return "", annotation
 		}
-		// Inline marker keeps numeric label; annotation title is page name.
+		// Inline marker keeps numeric label; annotation title is page name (or N if unknown).
 		return fmt.Sprintf("[[%d]](%s)", index, value), annotation
 	default:
 		return "", nil
 	}
 }
 
-// citationPageTitle resolves a human page/source title for url_citation annotations.
-// Prefers tool_result / search pool titles; falls back to the URL.
-func citationPageTitle(parsed *parsedChat, rawURL string) string {
-	if parsed == nil {
-		return searchresult.NormalizeTitle("", rawURL)
-	}
-	if title := searchSourceTitle(parsed.SearchSources, rawURL); title != "" {
-		// searchSourceTitle returns the URL when no title is known — still usable.
-		return title
-	}
-	for _, call := range parsed.HostedSearchCalls {
-		if title := searchSourceTitle(call.Sources, rawURL); title != "" {
+// citationPageTitle resolves url_citation title: page/source title when known, else citation number.
+func citationPageTitle(parsed *parsedChat, rawURL string, index int) string {
+	if parsed != nil {
+		if title := lookupSourcePageTitle(parsed.SearchSources, rawURL); title != "" {
 			return title
 		}
+		for _, call := range parsed.HostedSearchCalls {
+			if title := lookupSourcePageTitle(call.Sources, rawURL); title != "" {
+				return title
+			}
+		}
 	}
-	return searchresult.NormalizeTitle("", rawURL)
+	if index < 1 {
+		index = 1
+	}
+	return fmt.Sprintf("%d", index)
 }
 
-func searchSourceTitle(sources []map[string]any, rawURL string) string {
+// lookupSourcePageTitle returns a non-empty page title for rawURL, or "" if unknown.
+// Unlike searchSourceTitle, it does not fall back to the URL itself.
+func lookupSourcePageTitle(sources []map[string]any, rawURL string) string {
 	if normalized, valid := searchresult.NormalizeURL(rawURL); valid {
 		rawURL = normalized
 	}
@@ -1439,7 +1441,18 @@ func searchSourceTitle(sources []map[string]any, rawURL string) string {
 			if title, _ := source["title"].(string); title != "" {
 				return title
 			}
+			return ""
 		}
+	}
+	return ""
+}
+
+func searchSourceTitle(sources []map[string]any, rawURL string) string {
+	if title := lookupSourcePageTitle(sources, rawURL); title != "" {
+		return title
+	}
+	if normalized, valid := searchresult.NormalizeURL(rawURL); valid {
+		return normalized
 	}
 	return rawURL
 }
@@ -1901,14 +1914,16 @@ func finalizeXAIAnnotations(parsed *parsedChat) {
 	if len(parsed.SearchSources) == 0 {
 		return
 	}
+	n := 0
 	for _, source := range parsed.SearchSources {
 		u, _ := source["url"].(string)
 		if u == "" {
 			continue
 		}
+		n++
 		title, _ := source["title"].(string)
 		if title == "" {
-			title = u
+			title = fmt.Sprintf("%d", n)
 		}
 		parsed.Annotations = append(parsed.Annotations, map[string]any{
 			"type":  "url_citation",

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -1484,8 +1484,37 @@ func appendHostedSearchSources(call *hostedSearchCall, sources []map[string]any)
 			break
 		}
 		seen[u] = struct{}{}
-		call.Sources = append(call.Sources, source)
+		// Normalize early so in-memory shape matches wire (type url + optional title).
+		item := map[string]any{"type": "url", "url": u}
+		if title, _ := source["title"].(string); title != "" {
+			item["title"] = title
+		}
+		call.Sources = append(call.Sources, item)
 	}
+}
+
+// hostedSearchActionSources copies sources for web_search_call/x_search_call action.
+// Always sets type:"url" (OpenAPI required); preserves title when present.
+func hostedSearchActionSources(sources []map[string]any) []map[string]any {
+	if len(sources) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(sources))
+	for _, source := range sources {
+		u, _ := source["url"].(string)
+		if u == "" {
+			continue
+		}
+		item := map[string]any{"type": "url", "url": u}
+		if title, _ := source["title"].(string); title != "" {
+			item["title"] = title
+		}
+		out = append(out, item)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // xaiHostedSearchOutputItems builds Responses output items: web_search_call / x_search_call.
@@ -1508,8 +1537,8 @@ func xaiHostedSearchOutputItems(parsed parsedChat) []any {
 			action["query"] = call.Query
 		}
 		if len(call.Sources) > 0 {
-			// xAI/OpenAI-compatible optional sources on the search action.
-			action["sources"] = call.Sources
+			// OpenAPI: sources[] requires type:"url"+url; title kept as optional extension.
+			action["sources"] = hostedSearchActionSources(call.Sources)
 		}
 		items = append(items, map[string]any{
 			"id": call.ID, "type": typeName, "status": status, "action": action,

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -1400,16 +1400,34 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 			return "", nil
 		}
 		parsed.lastCitation = index
-		label := fmt.Sprintf("%d", index)
-		annotation := map[string]any{"type": "url_citation", "url": value, "title": label}
+		title := citationPageTitle(parsed, value)
+		annotation := map[string]any{"type": "url_citation", "url": value, "title": title}
 		if parsed.DisableInlineCitations {
 			return "", annotation
 		}
-		// xAI inline form: [[N]](url)
+		// Inline marker keeps numeric label; annotation title is page name.
 		return fmt.Sprintf("[[%d]](%s)", index, value), annotation
 	default:
 		return "", nil
 	}
+}
+
+// citationPageTitle resolves a human page/source title for url_citation annotations.
+// Prefers tool_result / search pool titles; falls back to the URL.
+func citationPageTitle(parsed *parsedChat, rawURL string) string {
+	if parsed == nil {
+		return searchresult.NormalizeTitle("", rawURL)
+	}
+	if title := searchSourceTitle(parsed.SearchSources, rawURL); title != "" {
+		// searchSourceTitle returns the URL when no title is known — still usable.
+		return title
+	}
+	for _, call := range parsed.HostedSearchCalls {
+		if title := searchSourceTitle(call.Sources, rawURL); title != "" {
+			return title
+		}
+	}
+	return searchresult.NormalizeTitle("", rawURL)
 }
 
 func searchSourceTitle(sources []map[string]any, rawURL string) string {
@@ -1797,7 +1815,7 @@ func chatAnnotations(annotations []map[string]any) []any {
 }
 
 // chatURLCitation is Chat Completions nested url_citation (OpenAI-compatible wire).
-// xAI label semantics: title is the citation number string ("1", "2").
+// title is the page/source title (not the [[N]] display number).
 func chatURLCitation(annotation map[string]any) map[string]any {
 	inner := map[string]any{
 		"url": annotation["url"], "title": annotation["title"],
@@ -1883,15 +1901,19 @@ func finalizeXAIAnnotations(parsed *parsedChat) {
 	if len(parsed.SearchSources) == 0 {
 		return
 	}
-	for i, source := range parsed.SearchSources {
+	for _, source := range parsed.SearchSources {
 		u, _ := source["url"].(string)
 		if u == "" {
 			continue
 		}
+		title, _ := source["title"].(string)
+		if title == "" {
+			title = u
+		}
 		parsed.Annotations = append(parsed.Annotations, map[string]any{
 			"type":  "url_citation",
 			"url":   u,
-			"title": fmt.Sprintf("%d", i+1),
+			"title": title,
 		})
 	}
 }

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -32,6 +32,11 @@ const maxDeferredSearchTextBytes = 8 << 20
 
 const maxTrackedServerTools = 1024
 
+const (
+	maxTrackedCitationSources = 256
+	maxTrackedAnnotations     = 2048
+)
+
 var (
 	errWebAntiBot    = errors.New("Grok Web anti-bot rejection")
 	errWebUsageLimit = errors.New("Grok Web usage limit reached")
@@ -50,11 +55,11 @@ type openAIRequest struct {
 	PreviousResponseID string          `json:"previous_response_id"`
 	Messages           []chatMessage   `json:"messages"`
 	// Include is the xAI/OpenAI Responses include list (inline_citations / no_inline_citations).
-	Include            []string        `json:"include"`
-	Tools              json.RawMessage `json:"tools"`
-	ToolChoice         json.RawMessage `json:"tool_choice"`
-	ParallelToolCalls  *bool           `json:"parallel_tool_calls"`
-	ImageConfig        *struct {
+	Include           []string        `json:"include"`
+	Tools             json.RawMessage `json:"tools"`
+	ToolChoice        json.RawMessage `json:"tool_choice"`
+	ParallelToolCalls *bool           `json:"parallel_tool_calls"`
+	ImageConfig       *struct {
 		Count          *int   `json:"n"`
 		ResponseFormat string `json:"response_format"`
 	} `json:"image_config"`
@@ -92,36 +97,86 @@ type hostedSearchCall struct {
 	Sources []map[string]any
 }
 
+// trackedTextBuilder keeps OpenAI citation offsets in Unicode characters
+// without rescanning the complete response for every citation.
+type trackedTextBuilder struct {
+	builder    strings.Builder
+	characters int
+}
+
+func (b *trackedTextBuilder) WriteString(value string) (int, error) {
+	written, err := b.builder.WriteString(value)
+	b.characters += utf8.RuneCountInString(value[:written])
+	return written, err
+}
+
+func (b *trackedTextBuilder) Reset() {
+	b.builder.Reset()
+	b.characters = 0
+}
+
+func (b *trackedTextBuilder) String() string { return b.builder.String() }
+
+func (b *trackedTextBuilder) Len() int { return b.builder.Len() }
+
+func (b *trackedTextBuilder) CharacterLen() int { return b.characters }
+
 type parsedChat struct {
-	ResponseID      string
-	ConversationID  string
-	ParentID        string
-	Text            strings.Builder
-	upstreamText    strings.Builder
-	Reasoning       strings.Builder
-	Images          []string
-	SearchSources   []map[string]any
-	Annotations     []map[string]any
+	ResponseID     string
+	ConversationID string
+	ParentID       string
+	Text           trackedTextBuilder
+	upstreamText   strings.Builder
+	Reasoning      strings.Builder
+	Images         []string
+	SearchSources  []map[string]any
+	Annotations    []map[string]any
+	// ResponseOutput is populated by the Responses streaming state machine so
+	// response.completed reuses the exact item IDs and ordering emitted in SSE.
+	ResponseOutput []any
 	// HostedSearchCalls are ordered web_search_call / x_search_call items (xAI Responses).
 	HostedSearchCalls []hostedSearchCall
 	hostedSearchByID  map[string]int
 	// InlineCitations mirrors xAI default-on [[N]](url) embedding.
 	DisableInlineCitations bool
-	sourceKeys      map[string]struct{}
-	serverToolKeys  map[string]struct{}
-	webSearchKeys   map[string]struct{}
-	cardCache       map[string]map[string]any
-	moderatedImages map[string]struct{}
-	citationIndex   map[string]int
-	lastCitation    int
-	ServerTools     int64
-	WebSearchTools  int64
-	XSearchTools    int64
-	InputTokens     int64
-	ToolCalls       []parsedToolCall
-	Tools           []any
-	ToolChoice      any
-	ParallelTools   bool
+	sourceKeys             map[string]struct{}
+	serverToolKeys         map[string]struct{}
+	webSearchKeys          map[string]struct{}
+	xSearchKeys            map[string]struct{}
+	cardCache              map[string]map[string]any
+	moderatedImages        map[string]struct{}
+	citationIndex          map[string]int
+	lastCitation           int
+	ServerTools            int64
+	WebSearchTools         int64
+	XSearchTools           int64
+	InputTokens            int64
+	ToolCalls              []parsedToolCall
+	Tools                  []any
+	ToolChoice             any
+	ParallelTools          bool
+}
+
+func (p *parsedChat) textCharacterLen() int {
+	if p == nil {
+		return 0
+	}
+	return p.Text.CharacterLen()
+}
+
+func (p *parsedChat) appendText(value string) {
+	if p == nil || value == "" {
+		return
+	}
+	p.Text.WriteString(value)
+}
+
+func (p *parsedChat) resetText(value string) {
+	if p == nil {
+		return
+	}
+	p.Text.Reset()
+	p.Text.WriteString(value)
 }
 
 func (a *Adapter) ForwardResponse(ctx context.Context, request provider.ResponseResourceRequest) (*provider.Response, error) {
@@ -396,12 +451,25 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 		messagesStream := newWebMessagesStream(writer, responseID, model, parsed.InputTokens, options)
 		visiblePhase := webVisibleStreamPhase{}
 		annotationCursor := 0
-		hostedSearchCursor := 0
+		hostedSearchEmitted := make(map[string]struct{})
+		var responsesStream *webResponsesStream
+		if operation == conversation.OperationResponses {
+			responsesStream = newWebResponsesStream(writer, responseID)
+		}
 		writeDelta := func(kind, delta string) error {
 			if !visiblePhase.Allow(kind, delta) {
 				return nil
 			}
+			if responsesStream != nil {
+				return responsesStream.Delta(kind, delta)
+			}
 			return writeWebStreamDelta(writer, messagesStream, operation, responseID, model, kind, delta)
+		}
+		writeToolCalls := func(calls []parsedToolCall) error {
+			if responsesStream != nil {
+				return responsesStream.ToolCalls(calls)
+			}
+			return writeWebStreamToolCalls(writer, messagesStream, operation, responseID, model, calls)
 		}
 		flushAnnotations := func() error {
 			if annotationCursor >= len(parsed.Annotations) {
@@ -409,45 +477,27 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 			}
 			newOnes := parsed.Annotations[annotationCursor:]
 			annotationCursor = len(parsed.Annotations)
+			if responsesStream != nil {
+				return responsesStream.Annotations(newOnes, annotationCursor-len(newOnes))
+			}
 			return writeStreamAnnotations(writer, operation, responseID, model, newOnes, annotationCursor-len(newOnes))
 		}
 		flushHostedSearch := func() error {
 			if operation != conversation.OperationResponses {
 				return nil
 			}
-			for hostedSearchCursor < len(parsed.HostedSearchCalls) {
-				call := parsed.HostedSearchCalls[hostedSearchCursor]
+			for _, call := range parsed.HostedSearchCalls {
 				// Wait until the tool_result arrives (completed / has sources).
 				if call.Status != "completed" && len(call.Sources) == 0 {
-					break
-				}
-				items := xaiHostedSearchOutputItems(parsedChat{HostedSearchCalls: []hostedSearchCall{call}})
-				if len(items) == 0 {
-					hostedSearchCursor++
 					continue
 				}
-				item := items[0]
-				idx := hostedSearchCursor
-				hostedSearchCursor++
-				if err := writeSSE(writer, "response.output_item.added", map[string]any{
-					"type": "response.output_item.added", "response_id": responseID, "output_index": idx, "item": item,
-				}); err != nil {
+				if _, emitted := hostedSearchEmitted[call.ID]; emitted {
+					continue
+				}
+				if err := responsesStream.HostedSearch(call); err != nil {
 					return err
 				}
-				eventType := "response.web_search_call.completed"
-				if call.Kind == "x_search" {
-					eventType = "response.x_search_call.completed"
-				}
-				if err := writeSSE(writer, eventType, map[string]any{
-					"type": eventType, "response_id": responseID, "output_index": idx, "item_id": call.ID,
-				}); err != nil {
-					return err
-				}
-				if err := writeSSE(writer, "response.output_item.done", map[string]any{
-					"type": "response.output_item.done", "response_id": responseID, "output_index": idx, "item": item,
-				}); err != nil {
-					return err
-				}
+				hostedSearchEmitted[call.ID] = struct{}{}
 			}
 			return nil
 		}
@@ -474,7 +524,7 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 				if parsed.Text.Len() > 0 {
 					delta = "\n\n" + delta
 				}
-				parsed.Text.WriteString(delta)
+				parsed.appendText(delta)
 				archivedImages[rawURL] = struct{}{}
 				kind = "text"
 			}
@@ -495,7 +545,7 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 						return flushSideChannel()
 					}
 					parsed.ToolCalls = result.Calls
-					return writeWebStreamToolCalls(writer, messagesStream, operation, responseID, model, result.Calls)
+					return writeToolCalls(result.Calls)
 				}
 				return flushSideChannel()
 			}
@@ -527,7 +577,7 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 			}
 			if len(result.Calls) > 0 {
 				parsed.ToolCalls = result.Calls
-				if err := writeWebStreamToolCalls(writer, messagesStream, operation, responseID, model, result.Calls); err != nil {
+				if err := writeToolCalls(result.Calls); err != nil {
 					_ = writer.CloseWithError(err)
 					return
 				}
@@ -554,8 +604,14 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 				}
 			}
 		}
-		parsed.Text.Reset()
-		parsed.Text.WriteString(clientText.String())
+		parsed.resetText(clientText.String())
+		if operation == conversation.OperationResponses {
+			finalizeXAIAnnotations(parsed)
+			if finishErr := responsesStream.Finish(parsed); finishErr != nil {
+				_ = writer.CloseWithError(finishErr)
+				return
+			}
+		}
 		a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, http.StatusOK, nil)
 		payload := buildOpenAIResult(operation, responseID, model, *parsed, false, options)
 		data, _ := json.Marshal(payload)
@@ -913,7 +969,7 @@ func parseUpstreamFrame(data []byte, parsed *parsedChat) (string, string, error)
 	if token != "" && !thinking && (tag == "final" || tag == "") {
 		parsed.upstreamText.WriteString(token)
 		cleaned := cleanChatToken(parsed, token)
-		parsed.Text.WriteString(cleaned)
+		parsed.appendText(cleaned)
 		return "text", cleaned, nil
 	}
 	if modelResponse, _ := response["modelResponse"].(map[string]any); modelResponse != nil {
@@ -975,7 +1031,7 @@ func mergeModelResponseText(parsed *parsedChat, message string) string {
 	delta := message[len(raw):]
 	parsed.upstreamText.WriteString(delta)
 	delta = cleanChatToken(parsed, delta)
-	parsed.Text.WriteString(delta)
+	parsed.appendText(delta)
 	return delta
 }
 
@@ -1225,8 +1281,7 @@ func applyParsedToolCalls(parsed *parsedChat, configuration toolConfiguration) {
 		return
 	}
 	cleaned := removeToolSyntax(parsed.Text.String(), result)
-	parsed.Text.Reset()
-	parsed.Text.WriteString(cleaned)
+	parsed.resetText(cleaned)
 	parsed.ToolCalls = result.Calls
 }
 
@@ -1237,9 +1292,9 @@ func (a *Adapter) archiveChatImages(ctx context.Context, credential account.Cred
 			return err
 		}
 		if parsed.Text.Len() > 0 {
-			parsed.Text.WriteString("\n\n")
+			parsed.appendText("\n\n")
 		}
-		parsed.Text.WriteString(liteImageMarkdown(item))
+		parsed.appendText(liteImageMarkdown(item))
 	}
 	return nil
 }
@@ -1325,6 +1380,11 @@ func imageURLFromCardData(data map[string]any) string {
 
 func cleanChatToken(parsed *parsedChat, token string) string {
 	if !strings.Contains(token, "<grok:render") {
+		if token != "" {
+			// Visible assistant text separates two citations. Only truly adjacent
+			// duplicate render frames should be collapsed.
+			parsed.lastCitation = 0
+		}
 		return token
 	}
 	matches := grokRenderPattern.FindAllStringSubmatchIndex(token, -1)
@@ -1332,24 +1392,35 @@ func cleanChatToken(parsed *parsedChat, token string) string {
 		return token
 	}
 	var builder strings.Builder
+	builderCharacters := 0
 	cursor := 0
 	for _, match := range matches {
-		builder.WriteString(token[cursor:match[0]])
+		prefix := token[cursor:match[0]]
+		builder.WriteString(prefix)
+		builderCharacters += utf8.RuneCountInString(prefix)
+		if prefix != "" {
+			parsed.lastCitation = 0
+		}
 		cardID := token[match[2]:match[3]]
 		renderType := token[match[6]:match[7]]
 		replacement, annotation := renderChatCard(parsed, cardID, renderType)
 		if annotation != nil {
 			if replacement != "" {
-				start := parsed.Text.Len() + builder.Len()
+				start := parsed.textCharacterLen() + builderCharacters
 				annotation["start_index"] = start
-				annotation["end_index"] = start + len(replacement)
+				annotation["end_index"] = start + utf8.RuneCountInString(replacement)
 			}
 			parsed.Annotations = append(parsed.Annotations, annotation)
 		}
 		builder.WriteString(replacement)
+		builderCharacters += utf8.RuneCountInString(replacement)
 		cursor = match[1]
 	}
-	builder.WriteString(token[cursor:])
+	suffix := token[cursor:]
+	builder.WriteString(suffix)
+	if suffix != "" {
+		parsed.lastCitation = 0
+	}
 	return builder.String()
 }
 
@@ -1393,6 +1464,9 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 		}
 		index, exists := parsed.citationIndex[value]
 		if !exists {
+			if len(parsed.citationIndex) >= maxTrackedCitationSources {
+				return "", nil
+			}
 			index = len(parsed.citationIndex) + 1
 			parsed.citationIndex[value] = index
 		}
@@ -1400,34 +1474,47 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 			return "", nil
 		}
 		parsed.lastCitation = index
-		title := citationPageTitle(parsed, value, index)
-		annotation := map[string]any{"type": "url_citation", "url": value, "title": title}
+		annotation := citationAnnotation(parsed, value, index)
 		if parsed.DisableInlineCitations {
+			if len(parsed.Annotations) >= maxTrackedAnnotations {
+				return "", nil
+			}
 			return "", annotation
 		}
-		// Inline marker keeps numeric label; annotation title is page name (or N if unknown).
-		return fmt.Sprintf("[[%d]](%s)", index, value), annotation
+		// Inline marker keeps the numeric label. When the structured annotation
+		// cap is reached, keep the visible text without growing retained state.
+		replacement := fmt.Sprintf("[[%d]](%s)", index, value)
+		if len(parsed.Annotations) >= maxTrackedAnnotations {
+			return replacement, nil
+		}
+		return replacement, annotation
 	default:
 		return "", nil
 	}
 }
 
-// citationPageTitle resolves url_citation title: page/source title when known, else citation number.
-func citationPageTitle(parsed *parsedChat, rawURL string, index int) string {
-	if parsed != nil {
-		if title := lookupSourcePageTitle(parsed.SearchSources, rawURL); title != "" {
-			return title
-		}
-		for _, call := range parsed.HostedSearchCalls {
-			if title := lookupSourcePageTitle(call.Sources, rawURL); title != "" {
-				return title
-			}
-		}
-	}
+// citationAnnotation keeps the xAI citation label in title while retaining the
+// page title separately for the OpenAI Chat Completions nested citation shape.
+func citationAnnotation(parsed *parsedChat, rawURL string, index int) map[string]any {
 	if index < 1 {
 		index = 1
 	}
-	return fmt.Sprintf("%d", index)
+	annotation := map[string]any{
+		"type": "url_citation", "url": rawURL, "title": fmt.Sprintf("%d", index),
+	}
+	if parsed != nil {
+		if title := lookupSourcePageTitle(parsed.SearchSources, rawURL); title != "" {
+			annotation["source_title"] = title
+			return annotation
+		}
+		for _, call := range parsed.HostedSearchCalls {
+			if title := lookupSourcePageTitle(call.Sources, rawURL); title != "" {
+				annotation["source_title"] = title
+				return annotation
+			}
+		}
+	}
+	return annotation
 }
 
 // lookupSourcePageTitle returns a non-empty page title for rawURL, or "" if unknown.
@@ -1462,7 +1549,26 @@ func upsertHostedSearchCall(parsed *parsedChat, id, kind, query, status string) 
 		return nil
 	}
 	if id == "" {
-		id = fmt.Sprintf("%s_%d", kind, len(parsed.HostedSearchCalls)+1)
+		// Some mgw tool_result frames omit tool_call_id. Correlate only when
+		// exactly one unfinished call of the same kind exists; otherwise keep
+		// the result separate instead of attaching it to the wrong invocation.
+		matchedID := ""
+		for i := range parsed.HostedSearchCalls {
+			call := &parsed.HostedSearchCalls[i]
+			if call.Kind != kind || call.Status == "completed" {
+				continue
+			}
+			if matchedID != "" {
+				matchedID = ""
+				break
+			}
+			matchedID = call.ID
+		}
+		if matchedID != "" {
+			id = matchedID
+		} else {
+			id = fmt.Sprintf("%s_%d", kind, len(parsed.HostedSearchCalls)+1)
+		}
 	}
 	if parsed.hostedSearchByID == nil {
 		parsed.hostedSearchByID = make(map[string]int)
@@ -1555,6 +1661,9 @@ func xaiHostedSearchOutputItems(parsed parsedChat) []any {
 	}
 	items := make([]any, 0, len(parsed.HostedSearchCalls))
 	for _, call := range parsed.HostedSearchCalls {
+		if call.Status != "completed" && len(call.Sources) == 0 {
+			continue
+		}
 		typeName := "web_search_call"
 		if call.Kind == "x_search" {
 			typeName = "x_search_call"
@@ -1592,10 +1701,11 @@ func xaiServerSideToolUsage(parsed parsedChat) map[string]any {
 			x++
 		}
 	}
-	if web == 0 {
+	// Legacy Web frames do not expose hosted call completion records, so their
+	// deduplicated tool counters remain the only available signal. For mgw,
+	// never turn an in_progress/failed attempt into successful billable usage.
+	if len(parsed.HostedSearchCalls) == 0 {
 		web = parsed.WebSearchTools
-	}
-	if x == 0 {
 		x = parsed.XSearchTools
 	}
 	usage := map[string]any{}
@@ -1684,26 +1794,29 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 			"usage": usage,
 		}
 	}
-	output := make([]any, 0, 2)
-	if parsed.Reasoning.Len() > 0 {
-		output = append(output, map[string]any{"id": newWebID("rs"), "type": "reasoning", "status": "completed", "summary": []any{map[string]any{"type": "summary_text", "text": parsed.Reasoning.String()}}})
-	}
 	finalizeXAIAnnotations(&parsed)
-	// xAI Tool Usage Details: web_search_call / x_search_call precede the assistant message.
-	output = append(output, xaiHostedSearchOutputItems(parsed)...)
-	if parsed.Text.Len() > 0 || len(parsed.ToolCalls) == 0 {
-		annotations := responsesAnnotations(parsed.Annotations)
-		if annotations == nil {
-			annotations = []any{}
+	output := parsed.ResponseOutput
+	if output == nil {
+		output = make([]any, 0, 2)
+		if parsed.Reasoning.Len() > 0 {
+			output = append(output, map[string]any{"id": newWebID("rs"), "type": "reasoning", "status": "completed", "summary": []any{map[string]any{"type": "summary_text", "text": parsed.Reasoning.String()}}})
 		}
-		message := map[string]any{"id": newWebID("msg"), "type": "message", "role": "assistant", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": parsed.Text.String(), "annotations": annotations, "logprobs": []any{}}}}
-		output = append(output, message)
-	}
-	for _, call := range parsed.ToolCalls {
-		output = append(output, map[string]any{
-			"id": newWebID("fc"), "type": "function_call", "status": "completed",
-			"call_id": call.ID, "name": call.Name, "arguments": call.Arguments,
-		})
+		// xAI Tool Usage Details: web_search_call / x_search_call precede the assistant message.
+		output = append(output, xaiHostedSearchOutputItems(parsed)...)
+		if parsed.Text.Len() > 0 || len(parsed.ToolCalls) == 0 {
+			annotations := responsesAnnotations(parsed.Annotations)
+			if annotations == nil {
+				annotations = []any{}
+			}
+			message := map[string]any{"id": newWebID("msg"), "type": "message", "role": "assistant", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": parsed.Text.String(), "annotations": annotations, "logprobs": []any{}}}}
+			output = append(output, message)
+		}
+		for _, call := range parsed.ToolCalls {
+			output = append(output, map[string]any{
+				"id": newWebID("fc"), "type": "function_call", "status": "completed",
+				"call_id": call.ID, "name": call.Name, "arguments": call.Arguments,
+			})
+		}
 	}
 	tools := parsed.Tools
 	if tools == nil {
@@ -1828,10 +1941,14 @@ func chatAnnotations(annotations []map[string]any) []any {
 }
 
 // chatURLCitation is Chat Completions nested url_citation (OpenAI-compatible wire).
-// title is the page/source title (not the [[N]] display number).
+// OpenAI Chat Completions uses the page title; fall back to the numeric label.
 func chatURLCitation(annotation map[string]any) map[string]any {
+	title := annotation["title"]
+	if sourceTitle, _ := annotation["source_title"].(string); sourceTitle != "" {
+		title = sourceTitle
+	}
 	inner := map[string]any{
-		"url": annotation["url"], "title": annotation["title"],
+		"url": annotation["url"], "title": title,
 	}
 	if _, ok := annotation["start_index"]; ok {
 		inner["start_index"] = annotation["start_index"]
@@ -1864,32 +1981,30 @@ func responsesAnnotations(annotations []map[string]any) []any {
 
 // xaiCitationURLs builds response.citations: all source URLs from search tool results.
 func xaiCitationURLs(parsed parsedChat) []string {
-	if len(parsed.SearchSources) == 0 {
-		// Fall back to annotation URLs when tool results were not collected.
-		if len(parsed.Annotations) == 0 {
-			return nil
+	out := make([]string, 0, len(parsed.SearchSources)+len(parsed.Annotations))
+	seen := make(map[string]struct{}, cap(out))
+	appendURL := func(u string) {
+		if u == "" {
+			return
 		}
-		out := make([]string, 0, len(parsed.Annotations))
-		seen := make(map[string]struct{}, len(parsed.Annotations))
-		for _, ann := range parsed.Annotations {
-			u, _ := ann["url"].(string)
-			if u == "" {
-				continue
-			}
-			if _, ok := seen[u]; ok {
-				continue
-			}
-			seen[u] = struct{}{}
-			out = append(out, u)
+		if _, exists := seen[u]; exists {
+			return
 		}
-		return out
+		seen[u] = struct{}{}
+		out = append(out, u)
 	}
-	out := make([]string, 0, len(parsed.SearchSources))
 	for _, source := range parsed.SearchSources {
 		u, _ := source["url"].(string)
-		if u != "" {
-			out = append(out, u)
-		}
+		appendURL(u)
+	}
+	// render_citation can arrive for a source missing from tool_result (for
+	// example a truncated result pool); it must not disappear from citations.
+	for _, annotation := range parsed.Annotations {
+		u, _ := annotation["url"].(string)
+		appendURL(u)
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -1921,15 +2036,15 @@ func finalizeXAIAnnotations(parsed *parsedChat) {
 			continue
 		}
 		n++
-		title, _ := source["title"].(string)
-		if title == "" {
-			title = fmt.Sprintf("%d", n)
-		}
-		parsed.Annotations = append(parsed.Annotations, map[string]any{
+		annotation := map[string]any{
 			"type":  "url_citation",
 			"url":   u,
-			"title": title,
-		})
+			"title": fmt.Sprintf("%d", n),
+		}
+		if sourceTitle, _ := source["title"].(string); sourceTitle != "" {
+			annotation["source_title"] = sourceTitle
+		}
+		parsed.Annotations = append(parsed.Annotations, annotation)
 	}
 }
 
@@ -2364,11 +2479,7 @@ func writeStreamDelta(writer io.Writer, operation, responseID, model, kind, delt
 		}
 		return writeSSE(writer, "content_block_delta", map[string]any{"type": "content_block_delta", "index": 0, "delta": map[string]any{"type": "text_delta", "text": delta}})
 	}
-	event := "response.output_text.delta"
-	if kind == "reasoning" {
-		event = "response.reasoning_summary_text.delta"
-	}
-	return writeSSE(writer, event, map[string]any{"type": event, "response_id": responseID, "delta": delta})
+	return errors.New("Responses 流式 delta 必须通过统一 output 状态机发送")
 }
 
 func writeStreamToolCalls(writer io.Writer, operation, responseID, model string, calls []parsedToolCall) error {
@@ -2411,35 +2522,7 @@ func writeStreamToolCalls(writer io.Writer, operation, responseID, model string,
 		}
 		return nil
 	}
-	for index, call := range calls {
-		itemID := newWebID("fc")
-		item := map[string]any{"id": itemID, "type": "function_call", "status": "in_progress", "call_id": call.ID, "name": call.Name, "arguments": ""}
-		if err := writeSSE(writer, "response.output_item.added", map[string]any{
-			"type": "response.output_item.added", "response_id": responseID, "output_index": index, "item": item,
-		}); err != nil {
-			return err
-		}
-		if err := writeSSE(writer, "response.function_call_arguments.delta", map[string]any{
-			"type": "response.function_call_arguments.delta", "response_id": responseID,
-			"item_id": itemID, "output_index": index, "delta": call.Arguments,
-		}); err != nil {
-			return err
-		}
-		if err := writeSSE(writer, "response.function_call_arguments.done", map[string]any{
-			"type": "response.function_call_arguments.done", "response_id": responseID,
-			"item_id": itemID, "output_index": index, "arguments": call.Arguments,
-		}); err != nil {
-			return err
-		}
-		item["status"] = "completed"
-		item["arguments"] = call.Arguments
-		if err := writeSSE(writer, "response.output_item.done", map[string]any{
-			"type": "response.output_item.done", "response_id": responseID, "output_index": index, "item": item,
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
+	return errors.New("Responses 流式 tool call 必须通过统一 output 状态机发送")
 }
 
 func writeStreamDone(writer io.Writer, operation, responseID, model string, parsed parsedChat, payload map[string]any) {
@@ -2448,13 +2531,10 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		if len(parsed.ToolCalls) > 0 {
 			finishReason = "tool_calls"
 		}
-		// Final chat chunk: finish_reason + full nested annotations (OpenAI message.annotations shape).
-		// Progressive delta.annotations may already have been sent mid-stream.
+		// Progressive annotations were already emitted as deltas. Repeating all of
+		// them here makes clients that accumulate deltas display duplicates.
 		// Top-level citations + server_side_tool_usage match non-stream chat (xAI).
 		chunk := map[string]any{"id": strings.Replace(responseID, "resp_", "chatcmpl_", 1), "object": "chat.completion.chunk", "created": time.Now().Unix(), "model": model, "choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": finishReason}}, "usage": payload["usage"]}
-		if len(parsed.Annotations) > 0 {
-			chunk["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)["annotations"] = chatAnnotations(parsed.Annotations)
-		}
 		if citations := payload["citations"]; citations != nil {
 			chunk["citations"] = citations
 		}
@@ -2479,16 +2559,12 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		writeSSE(writer, "message_stop", map[string]any{"type": "message_stop"})
 		return
 	}
-	if parsed.Text.Len() > 0 {
-		writeSSE(writer, "response.output_text.done", map[string]any{"type": "response.output_text.done", "response_id": responseID, "text": parsed.Text.String()})
-	}
 	writeSSE(writer, "response.completed", map[string]any{"type": "response.completed", "response": payload})
 }
 
-// writeStreamAnnotations emits progressive citation events aligned with OpenAI shapes.
-// Chat Completions: delta.annotations with nested url_citation objects.
-// Responses: response.output_text.annotation.added with flat url_citation fields.
-func writeStreamAnnotations(writer io.Writer, operation, responseID, model string, annotations []map[string]any, startIndex int) error {
+// writeStreamAnnotations emits Chat Completions delta.annotations. Responses
+// annotations are owned by webResponsesStream so their item coordinates cannot drift.
+func writeStreamAnnotations(writer io.Writer, operation, responseID, model string, annotations []map[string]any, _ int) error {
 	if len(annotations) == 0 || operation == conversation.OperationMessages {
 		return nil
 	}
@@ -2501,22 +2577,6 @@ func writeStreamAnnotations(writer io.Writer, operation, responseID, model strin
 			}},
 		}
 		return writeSSE(writer, "", chunk)
-	}
-	if operation != conversation.OperationResponses {
-		return nil
-	}
-	for i, annotation := range annotations {
-		if err := writeSSE(writer, "response.output_text.annotation.added", map[string]any{
-			"type":             "response.output_text.annotation.added",
-			"response_id":      responseID,
-			"item_id":          "",
-			"output_index":     0,
-			"content_index":    0,
-			"annotation_index": startIndex + i,
-			"annotation":       responsesURLCitation(annotation),
-		}); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -374,11 +374,20 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 		}
 		messagesStream := newWebMessagesStream(writer, responseID, model, parsed.InputTokens, options)
 		visiblePhase := webVisibleStreamPhase{}
+		annotationCursor := 0
 		writeDelta := func(kind, delta string) error {
 			if !visiblePhase.Allow(kind, delta) {
 				return nil
 			}
 			return writeWebStreamDelta(writer, messagesStream, operation, responseID, model, kind, delta)
+		}
+		flushAnnotations := func() error {
+			if annotationCursor >= len(parsed.Annotations) {
+				return nil
+			}
+			newOnes := parsed.Annotations[annotationCursor:]
+			annotationCursor = len(parsed.Annotations)
+			return writeStreamAnnotations(writer, operation, responseID, model, newOnes, annotationCursor-len(newOnes))
 		}
 		if operation != conversation.OperationMessages {
 			writeStreamStart(writer, operation, responseID, model, parsed.InputTokens)
@@ -412,17 +421,23 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 				if result.Complete {
 					if len(result.Calls) == 0 {
 						clientText.WriteString(result.Raw)
-						return writeDelta(kind, result.Raw)
+						if err := writeDelta(kind, result.Raw); err != nil {
+							return err
+						}
+						return flushAnnotations()
 					}
 					parsed.ToolCalls = result.Calls
 					return writeWebStreamToolCalls(writer, messagesStream, operation, responseID, model, result.Calls)
 				}
-				return nil
+				return flushAnnotations()
 			}
 			if kind == "text" {
 				clientText.WriteString(delta)
 			}
-			return writeDelta(kind, delta)
+			if err := writeDelta(kind, delta); err != nil {
+				return err
+			}
+			return flushAnnotations()
 		})
 		if err != nil {
 			a.egress.Feedback(context.WithoutCancel(ctx), lease.NodeID, 0, err)
@@ -1401,9 +1416,9 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 		output = append(output, map[string]any{"id": newWebID("rs"), "type": "reasoning", "status": "completed", "summary": []any{map[string]any{"type": "summary_text", "text": parsed.Reasoning.String()}}})
 	}
 	if parsed.Text.Len() > 0 || len(parsed.ToolCalls) == 0 {
-		annotations := parsed.Annotations
+		annotations := responsesAnnotations(parsed.Annotations)
 		if annotations == nil {
-			annotations = []map[string]any{}
+			annotations = []any{}
 		}
 		message := map[string]any{"id": newWebID("msg"), "type": "message", "role": "assistant", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": parsed.Text.String(), "annotations": annotations, "logprobs": []any{}}}}
 		if len(parsed.SearchSources) > 0 {
@@ -1526,13 +1541,39 @@ func chatToolCalls(calls []parsedToolCall) []any {
 func chatAnnotations(annotations []map[string]any) []any {
 	values := make([]any, 0, len(annotations))
 	for _, annotation := range annotations {
-		values = append(values, map[string]any{
-			"type": "url_citation",
-			"url_citation": map[string]any{
-				"url": annotation["url"], "title": annotation["title"],
-				"start_index": annotation["start_index"], "end_index": annotation["end_index"],
-			},
-		})
+		values = append(values, chatURLCitation(annotation))
+	}
+	return values
+}
+
+// chatURLCitation is the Chat Completions shape:
+// { "type":"url_citation", "url_citation":{ url, title, start_index, end_index } }
+func chatURLCitation(annotation map[string]any) map[string]any {
+	return map[string]any{
+		"type": "url_citation",
+		"url_citation": map[string]any{
+			"url": annotation["url"], "title": annotation["title"],
+			"start_index": annotation["start_index"], "end_index": annotation["end_index"],
+		},
+	}
+}
+
+// responsesURLCitation is the Responses API shape (flat, no nested url_citation object):
+// { "type":"url_citation", "url", "title", "start_index", "end_index" }
+func responsesURLCitation(annotation map[string]any) map[string]any {
+	return map[string]any{
+		"type":        "url_citation",
+		"url":         annotation["url"],
+		"title":       annotation["title"],
+		"start_index": annotation["start_index"],
+		"end_index":   annotation["end_index"],
+	}
+}
+
+func responsesAnnotations(annotations []map[string]any) []any {
+	values := make([]any, 0, len(annotations))
+	for _, annotation := range annotations {
+		values = append(values, responsesURLCitation(annotation))
 	}
 	return values
 }
@@ -2052,6 +2093,8 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		if len(parsed.ToolCalls) > 0 {
 			finishReason = "tool_calls"
 		}
+		// Final chat chunk: finish_reason + full nested annotations (OpenAI message.annotations shape).
+		// Progressive delta.annotations may already have been sent mid-stream.
 		chunk := map[string]any{"id": strings.Replace(responseID, "resp_", "chatcmpl_", 1), "object": "chat.completion.chunk", "created": time.Now().Unix(), "model": model, "choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": finishReason}}, "usage": payload["usage"]}
 		if len(parsed.Annotations) > 0 {
 			chunk["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)["annotations"] = chatAnnotations(parsed.Annotations)
@@ -2081,6 +2124,42 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		writeSSE(writer, "response.output_text.done", map[string]any{"type": "response.output_text.done", "response_id": responseID, "text": parsed.Text.String()})
 	}
 	writeSSE(writer, "response.completed", map[string]any{"type": "response.completed", "response": payload})
+}
+
+// writeStreamAnnotations emits progressive citation events aligned with OpenAI shapes.
+// Chat Completions: delta.annotations with nested url_citation objects.
+// Responses: response.output_text.annotation.added with flat url_citation fields.
+func writeStreamAnnotations(writer io.Writer, operation, responseID, model string, annotations []map[string]any, startIndex int) error {
+	if len(annotations) == 0 || operation == conversation.OperationMessages {
+		return nil
+	}
+	if operation == "chat" {
+		chunk := map[string]any{
+			"id": strings.Replace(responseID, "resp_", "chatcmpl_", 1), "object": "chat.completion.chunk",
+			"created": time.Now().Unix(), "model": model,
+			"choices": []any{map[string]any{
+				"index": 0, "delta": map[string]any{"annotations": chatAnnotations(annotations)}, "finish_reason": nil,
+			}},
+		}
+		return writeSSE(writer, "", chunk)
+	}
+	if operation != conversation.OperationResponses {
+		return nil
+	}
+	for i, annotation := range annotations {
+		if err := writeSSE(writer, "response.output_text.annotation.added", map[string]any{
+			"type":             "response.output_text.annotation.added",
+			"response_id":      responseID,
+			"item_id":          "",
+			"output_index":     0,
+			"content_index":    0,
+			"annotation_index": startIndex + i,
+			"annotation":       responsesURLCitation(annotation),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeSSE(writer io.Writer, event string, value any) error {

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -2450,12 +2450,16 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		}
 		// Final chat chunk: finish_reason + full nested annotations (OpenAI message.annotations shape).
 		// Progressive delta.annotations may already have been sent mid-stream.
+		// Top-level citations + server_side_tool_usage match non-stream chat (xAI).
 		chunk := map[string]any{"id": strings.Replace(responseID, "resp_", "chatcmpl_", 1), "object": "chat.completion.chunk", "created": time.Now().Unix(), "model": model, "choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": finishReason}}, "usage": payload["usage"]}
 		if len(parsed.Annotations) > 0 {
 			chunk["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)["annotations"] = chatAnnotations(parsed.Annotations)
 		}
 		if citations := payload["citations"]; citations != nil {
 			chunk["citations"] = citations
+		}
+		if toolUsage := payload["server_side_tool_usage"]; toolUsage != nil {
+			chunk["server_side_tool_usage"] = toolUsage
 		}
 		writeSSE(writer, "", chunk)
 		_, _ = io.WriteString(writer, "data: [DONE]\n\n")

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -49,6 +49,8 @@ type openAIRequest struct {
 	Instructions       string          `json:"instructions"`
 	PreviousResponseID string          `json:"previous_response_id"`
 	Messages           []chatMessage   `json:"messages"`
+	// Include is the xAI/OpenAI Responses include list (inline_citations / no_inline_citations).
+	Include            []string        `json:"include"`
 	Tools              json.RawMessage `json:"tools"`
 	ToolChoice         json.RawMessage `json:"tool_choice"`
 	ParallelToolCalls  *bool           `json:"parallel_tool_calls"`
@@ -91,6 +93,8 @@ type parsedChat struct {
 	Images          []string
 	SearchSources   []map[string]any
 	Annotations     []map[string]any
+	// InlineCitations mirrors xAI default-on [[N]](url) embedding.
+	DisableInlineCitations bool
 	sourceKeys      map[string]struct{}
 	serverToolKeys  map[string]struct{}
 	webSearchKeys   map[string]struct{}
@@ -133,6 +137,9 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 	var input openAIRequest
 	if err := json.Unmarshal(request.Body, &input); err != nil {
 		return jsonProviderResponse(http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "请求 JSON 无效", "type": "invalid_request_error"}}), nil
+	}
+	if len(input.Include) > 0 {
+		conversationOptions.Include = append([]string{}, input.Include...)
 	}
 	normalized, err := normalizeOpenAIInput(input, request.Operation)
 	if err != nil {
@@ -242,7 +249,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			return nil, preflightErr
 		}
 
-		currentParsed, consumeErr := consumeUpstream(upstream.Body, nil)
+		currentParsed, consumeErr := consumeUpstreamWithCitations(upstream.Body, nil, conversationOptions.InlineCitationsEnabled())
 		_ = upstream.Body.Close()
 		if statsigTarget != "" && errors.Is(consumeErr, errWebAntiBot) && attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, statsigTarget) {
 			lease.Release()
@@ -362,6 +369,7 @@ func (a *Adapter) streamOpenAIResponse(ctx context.Context, source io.ReadCloser
 		parsed := &parsedChat{
 			ResponseID: responseID, InputTokens: estimateTokens(prompt), Tools: tools.ResponseTools,
 			ToolChoice: tools.ResponseChoice, ParallelTools: parallelTools,
+			DisableInlineCitations: !options.InlineCitationsEnabled(),
 		}
 		if previous != nil {
 			parsed.ConversationID = previous.ConversationID
@@ -708,7 +716,11 @@ func extractImageURL(part map[string]any) string {
 }
 
 func consumeUpstream(source io.Reader, emit func(string, string) error) (parsedChat, error) {
-	parsed := parsedChat{}
+	return consumeUpstreamWithCitations(source, emit, true)
+}
+
+func consumeUpstreamWithCitations(source io.Reader, emit func(string, string) error, inlineCitations bool) (parsedChat, error) {
+	parsed := parsedChat{DisableInlineCitations: !inlineCitations}
 	err := consumeUpstreamInto(source, &parsed, emit)
 	return parsed, err
 }
@@ -1261,9 +1273,11 @@ func cleanChatToken(parsed *parsedChat, token string) string {
 		renderType := token[match[6]:match[7]]
 		replacement, annotation := renderChatCard(parsed, cardID, renderType)
 		if annotation != nil {
-			start := parsed.Text.Len() + builder.Len()
-			annotation["start_index"] = start
-			annotation["end_index"] = start + len(replacement)
+			if replacement != "" {
+				start := parsed.Text.Len() + builder.Len()
+				annotation["start_index"] = start
+				annotation["end_index"] = start + len(replacement)
+			}
 			parsed.Annotations = append(parsed.Annotations, annotation)
 		}
 		builder.WriteString(replacement)
@@ -1320,10 +1334,13 @@ func renderChatCard(parsed *parsedChat, cardID, renderType string) (string, map[
 			return "", nil
 		}
 		parsed.lastCitation = index
-		citation := fmt.Sprintf(" [[%d]](%s)", index, value)
-		return citation, map[string]any{
-			"type": "url_citation", "url": value, "title": searchSourceTitle(parsed.SearchSources, value),
+		label := fmt.Sprintf("%d", index)
+		annotation := map[string]any{"type": "url_citation", "url": value, "title": label}
+		if parsed.DisableInlineCitations {
+			return "", annotation
 		}
+		// xAI inline form: [[N]](url)
+		return fmt.Sprintf("[[%d]](%s)", index, value), annotation
 	default:
 		return "", nil
 	}
@@ -1352,6 +1369,7 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	inputTokens := parsed.InputTokens
 	outputTokens := estimateTokens(parsed.Text.String()) + estimateTokens(parsed.Reasoning.String()) + estimateToolCallTokens(parsed.ToolCalls)
 	if operation == "chat" {
+		finalizeXAIAnnotations(&parsed)
 		message := map[string]any{"role": "assistant", "content": parsed.Text.String(), "reasoning_content": parsed.Reasoning.String()}
 		if len(parsed.Annotations) > 0 {
 			message["annotations"] = chatAnnotations(parsed.Annotations)
@@ -1369,8 +1387,9 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 			"choices": []any{map[string]any{"index": 0, "message": message, "finish_reason": finishReason}},
 			"usage":   map[string]any{"prompt_tokens": inputTokens, "completion_tokens": outputTokens, "total_tokens": inputTokens + outputTokens},
 		}
-		if len(parsed.SearchSources) > 0 {
-			value["search_sources"] = parsed.SearchSources
+		// xAI: top-level citations = all source URLs encountered (always when present).
+		if citations := xaiCitationURLs(parsed); len(citations) > 0 {
+			value["citations"] = citations
 		}
 		return value
 	}
@@ -1415,15 +1434,13 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	if parsed.Reasoning.Len() > 0 {
 		output = append(output, map[string]any{"id": newWebID("rs"), "type": "reasoning", "status": "completed", "summary": []any{map[string]any{"type": "summary_text", "text": parsed.Reasoning.String()}}})
 	}
+	finalizeXAIAnnotations(&parsed)
 	if parsed.Text.Len() > 0 || len(parsed.ToolCalls) == 0 {
 		annotations := responsesAnnotations(parsed.Annotations)
 		if annotations == nil {
 			annotations = []any{}
 		}
 		message := map[string]any{"id": newWebID("msg"), "type": "message", "role": "assistant", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": parsed.Text.String(), "annotations": annotations, "logprobs": []any{}}}}
-		if len(parsed.SearchSources) > 0 {
-			message["search_sources"] = parsed.SearchSources
-		}
 		output = append(output, message)
 	}
 	for _, call := range parsed.ToolCalls {
@@ -1440,7 +1457,7 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 	if toolChoice == nil {
 		toolChoice = "auto"
 	}
-	return map[string]any{
+	value := map[string]any{
 		"id": responseID, "object": "response", "created_at": created, "completed_at": created, "status": "completed", "model": model,
 		"output": output, "parallel_tool_calls": parsed.ParallelTools, "tools": tools, "tool_choice": toolChoice, "store": true,
 		"usage": map[string]any{
@@ -1450,6 +1467,11 @@ func buildOpenAIResult(operation, responseID, model string, parsed parsedChat, s
 			"num_sources_used":      int64(len(parsed.SearchSources)), "num_server_side_tools_used": parsed.ServerTools,
 		},
 	}
+	// xAI Citations docs: response.citations is the full URL list from tool research.
+	if citations := xaiCitationURLs(parsed); len(citations) > 0 {
+		value["citations"] = citations
+	}
+	return value
 }
 
 func applyWebStopSequences(text string, sequences []string) (string, string) {
@@ -1546,28 +1568,31 @@ func chatAnnotations(annotations []map[string]any) []any {
 	return values
 }
 
-// chatURLCitation is the Chat Completions shape:
-// { "type":"url_citation", "url_citation":{ url, title, start_index, end_index } }
+// chatURLCitation is Chat Completions nested url_citation (OpenAI-compatible wire).
+// xAI label semantics: title is the citation number string ("1", "2").
 func chatURLCitation(annotation map[string]any) map[string]any {
-	return map[string]any{
-		"type": "url_citation",
-		"url_citation": map[string]any{
-			"url": annotation["url"], "title": annotation["title"],
-			"start_index": annotation["start_index"], "end_index": annotation["end_index"],
-		},
+	inner := map[string]any{
+		"url": annotation["url"], "title": annotation["title"],
 	}
+	if _, ok := annotation["start_index"]; ok {
+		inner["start_index"] = annotation["start_index"]
+		inner["end_index"] = annotation["end_index"]
+	}
+	return map[string]any{"type": "url_citation", "url_citation": inner}
 }
 
-// responsesURLCitation is the Responses API shape (flat, no nested url_citation object):
-// { "type":"url_citation", "url", "title", "start_index", "end_index" }
+// responsesURLCitation is the xAI/OpenAI Responses flat url_citation on output_text.
 func responsesURLCitation(annotation map[string]any) map[string]any {
-	return map[string]any{
-		"type":        "url_citation",
-		"url":         annotation["url"],
-		"title":       annotation["title"],
-		"start_index": annotation["start_index"],
-		"end_index":   annotation["end_index"],
+	out := map[string]any{
+		"type":  "url_citation",
+		"url":   annotation["url"],
+		"title": annotation["title"],
 	}
+	if _, ok := annotation["start_index"]; ok {
+		out["start_index"] = annotation["start_index"]
+		out["end_index"] = annotation["end_index"]
+	}
+	return out
 }
 
 func responsesAnnotations(annotations []map[string]any) []any {
@@ -1576,6 +1601,71 @@ func responsesAnnotations(annotations []map[string]any) []any {
 		values = append(values, responsesURLCitation(annotation))
 	}
 	return values
+}
+
+// xaiCitationURLs builds response.citations: all source URLs from search tool results.
+func xaiCitationURLs(parsed parsedChat) []string {
+	if len(parsed.SearchSources) == 0 {
+		// Fall back to annotation URLs when tool results were not collected.
+		if len(parsed.Annotations) == 0 {
+			return nil
+		}
+		out := make([]string, 0, len(parsed.Annotations))
+		seen := make(map[string]struct{}, len(parsed.Annotations))
+		for _, ann := range parsed.Annotations {
+			u, _ := ann["url"].(string)
+			if u == "" {
+				continue
+			}
+			if _, ok := seen[u]; ok {
+				continue
+			}
+			seen[u] = struct{}{}
+			out = append(out, u)
+		}
+		return out
+	}
+	out := make([]string, 0, len(parsed.SearchSources))
+	for _, source := range parsed.SearchSources {
+		u, _ := source["url"].(string)
+		if u != "" {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// finalizeXAIAnnotations ensures annotations exist for no_inline mode from search pool
+// when render_citation did not emit per-hit markers.
+func finalizeXAIAnnotations(parsed *parsedChat) {
+	if parsed == nil {
+		return
+	}
+	if !parsed.DisableInlineCitations {
+		return
+	}
+	if len(parsed.Annotations) > 0 {
+		// Strip any accidental positional fields.
+		for _, ann := range parsed.Annotations {
+			delete(ann, "start_index")
+			delete(ann, "end_index")
+		}
+		return
+	}
+	if len(parsed.SearchSources) == 0 {
+		return
+	}
+	for i, source := range parsed.SearchSources {
+		u, _ := source["url"].(string)
+		if u == "" {
+			continue
+		}
+		parsed.Annotations = append(parsed.Annotations, map[string]any{
+			"type":  "url_citation",
+			"url":   u,
+			"title": fmt.Sprintf("%d", i+1),
+		})
+	}
 }
 
 func estimateToolCallTokens(calls []parsedToolCall) int64 {
@@ -2099,8 +2189,8 @@ func writeStreamDone(writer io.Writer, operation, responseID, model string, pars
 		if len(parsed.Annotations) > 0 {
 			chunk["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)["annotations"] = chatAnnotations(parsed.Annotations)
 		}
-		if sources := payload["search_sources"]; sources != nil {
-			chunk["search_sources"] = sources
+		if citations := payload["citations"]; citations != nil {
+			chunk["citations"] = citations
 		}
 		writeSSE(writer, "", chunk)
 		_, _ = io.WriteString(writer, "data: [DONE]\n\n")

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -575,7 +575,7 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	}
 	parsed.lastCitation = index
 
-	title := citationPageTitle(parsed, normalized)
+	title := citationPageTitle(parsed, normalized, index)
 	if parsed.DisableInlineCitations {
 		// no_inline_citations: no markdown in text; positional fields omitted later at finalize.
 		parsed.Annotations = append(parsed.Annotations, map[string]any{
@@ -585,7 +585,7 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 		})
 		return "", "", nil
 	}
-	// Inline marker keeps numeric label; structured title is the page name.
+	// Inline marker keeps numeric label; structured title is page name (or N if unknown).
 	replacement := fmt.Sprintf("[[%d]](%s)", index, normalized)
 	start := parsed.Text.Len()
 	parsed.upstreamText.WriteString(replacement)

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -20,6 +20,7 @@ import (
 	domainegress "github.com/chenyme/grok2api/backend/internal/domain/egress"
 	inferencedomain "github.com/chenyme/grok2api/backend/internal/domain/inference"
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/searchresult"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider/sessionidentity"
 	providerstreamidle "github.com/chenyme/grok2api/backend/internal/infra/provider/streamidle"
 	"github.com/chenyme/grok2api/backend/internal/repository"
@@ -370,6 +371,20 @@ func parseGatewayEvent(event map[string]any, parsed *parsedChat) (string, string
 		parsed.ConversationID, _ = conversation["id"].(string)
 	case "response.chunk":
 		chunk, _ := event["chunk"].(map[string]any)
+		if chunk == nil {
+			return "", "", nil
+		}
+		// Current grok.com mgw protocol streams search tools and citations as
+		// dedicated chunk fields (not <grok:render> tokens).
+		if card, _ := chunk["tool_usage_card"].(map[string]any); card != nil {
+			collectGatewayToolUsageCard(parsed, card)
+		}
+		if result, _ := chunk["tool_result"].(map[string]any); result != nil {
+			collectGatewayToolResult(parsed, result)
+		}
+		if cite, _ := chunk["render_citation"].(map[string]any); cite != nil {
+			return applyGatewayRenderCitation(parsed, cite)
+		}
 		text, _ := chunk["text"].(map[string]any)
 		delta, _ := text["text"].(string)
 		channel, _ := text["channel"].(string)
@@ -408,6 +423,139 @@ func parseGatewayEvent(event map[string]any, parsed *parsedChat) (string, string
 		return "", "", gatewayEventError(event)
 	}
 	return "", "", nil
+}
+
+// collectGatewayToolUsageCard records mgw tool_usage_card starts (web_search / x_search).
+func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
+	if parsed == nil || card == nil {
+		return
+	}
+	id := firstString(card, "tool_usage_card_id", "id")
+	if id == "" {
+		id = fmt.Sprintf("card:%d", parsed.ServerTools+1)
+	}
+	if parsed.serverToolKeys == nil {
+		parsed.serverToolKeys = make(map[string]struct{})
+	}
+	if _, exists := parsed.serverToolKeys[id]; !exists {
+		if len(parsed.serverToolKeys) >= maxTrackedServerTools {
+			return
+		}
+		parsed.serverToolKeys[id] = struct{}{}
+		parsed.ServerTools++
+	}
+	if _, ok := card["web_search"]; ok {
+		if parsed.webSearchKeys == nil {
+			parsed.webSearchKeys = make(map[string]struct{})
+		}
+		if _, exists := parsed.webSearchKeys[id]; !exists {
+			parsed.webSearchKeys[id] = struct{}{}
+			parsed.WebSearchTools++
+		}
+	}
+}
+
+// collectGatewayToolResult folds mgw tool_result webpages / X posts into SearchSources.
+func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
+	if parsed == nil || result == nil {
+		return
+	}
+	if web, _ := result["web_search"].(map[string]any); web != nil {
+		pages, _ := web["webpages"].([]any)
+		for _, raw := range pages {
+			item, _ := raw.(map[string]any)
+			if item == nil {
+				continue
+			}
+			appendSearchSource(parsed, firstString(item, "url"), firstString(item, "title"), "web")
+		}
+	}
+	if xPost, _ := result["x_post"].(map[string]any); xPost != nil {
+		posts, _ := xPost["posts"].([]any)
+		for _, raw := range posts {
+			item, _ := raw.(map[string]any)
+			if item == nil {
+				continue
+			}
+			handle := firstString(item, "userhandle", "username")
+			postID := firstString(item, "post_id", "postId")
+			if handle == "" || postID == "" {
+				continue
+			}
+			rawURL := "https://x.com/" + url.PathEscape(handle) + "/status/" + url.PathEscape(postID)
+			title := firstString(item, "name", "userhandle", "username")
+			if text, _ := item["text"].(string); text != "" && title != "" {
+				title = title + ": " + text
+			} else if text, _ := item["text"].(string); text != "" {
+				title = text
+			}
+			appendSearchSource(parsed, rawURL, title, "x_post")
+		}
+	}
+}
+
+// applyGatewayRenderCitation turns an inline render_citation chunk into text + url_citation.
+// Citations are streamed as separate chunks between text deltas; indices track the
+// synthetic [[n]](url) marker inserted at the current assistant text offset.
+func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string, string, error) {
+	if parsed == nil || cite == nil {
+		return "", "", nil
+	}
+	rawURL := firstString(cite, "url")
+	normalized, valid := searchresult.NormalizeURL(rawURL)
+	if !valid {
+		return "", "", nil
+	}
+	if parsed.citationIndex == nil {
+		parsed.citationIndex = make(map[string]int)
+	}
+	index, exists := parsed.citationIndex[normalized]
+	if !exists {
+		index = len(parsed.citationIndex) + 1
+		parsed.citationIndex[normalized] = index
+	}
+	// Skip consecutive duplicate of the same source (UI collapses them).
+	if parsed.lastCitation == index {
+		return "", "", nil
+	}
+	parsed.lastCitation = index
+
+	title := searchSourceTitle(parsed.SearchSources, normalized)
+	if title == "" || title == normalized {
+		if handle := xHandleFromStatusURL(normalized); handle != "" {
+			title = "@" + handle
+		}
+	}
+	replacement := fmt.Sprintf(" [[%d]](%s)", index, normalized)
+	start := parsed.Text.Len()
+	parsed.upstreamText.WriteString(replacement)
+	parsed.Text.WriteString(replacement)
+	parsed.Annotations = append(parsed.Annotations, map[string]any{
+		"type":        "url_citation",
+		"url":         normalized,
+		"title":       title,
+		"start_index": start,
+		"end_index":   start + len(replacement),
+	})
+	return "text", replacement, nil
+}
+
+func xHandleFromStatusURL(rawURL string) string {
+	// https://x.com/{handle}/status/{id}
+	const marker = "://x.com/"
+	idx := strings.Index(rawURL, marker)
+	if idx < 0 {
+		idx = strings.Index(rawURL, "://twitter.com/")
+		if idx < 0 {
+			return ""
+		}
+		rest := rawURL[idx+len("://twitter.com/"):]
+		handle, _, _ := strings.Cut(rest, "/")
+		return handle
+	}
+	rest := rawURL[idx+len(marker):]
+	handle, _, _ := strings.Cut(rest, "/")
+	return handle
 }
 
 func appendGatewayDelta(parsed *parsedChat, channel, delta string) (string, string, error) {

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -425,7 +425,8 @@ func parseGatewayEvent(event map[string]any, parsed *parsedChat) (string, string
 	return "", "", nil
 }
 
-// collectGatewayToolUsageCard records mgw tool_usage_card starts (web_search / x_search).
+// collectGatewayToolUsageCard records mgw tool_usage_card starts (web_search / x_search)
+// and maps them to xAI web_search_call / x_search_call skeletons.
 func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
 	if parsed == nil || card == nil {
 		return
@@ -444,7 +445,7 @@ func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
 		parsed.serverToolKeys[id] = struct{}{}
 		parsed.ServerTools++
 	}
-	if _, ok := card["web_search"]; ok {
+	if web, _ := card["web_search"].(map[string]any); web != nil {
 		if parsed.webSearchKeys == nil {
 			parsed.webSearchKeys = make(map[string]struct{})
 		}
@@ -452,25 +453,64 @@ func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
 			parsed.webSearchKeys[id] = struct{}{}
 			parsed.WebSearchTools++
 		}
+		query := nestedSearchQuery(web)
+		upsertHostedSearchCall(parsed, id, "web_search", query, "in_progress")
+		return
+	}
+	if xSearch, _ := card["x_search"].(map[string]any); xSearch != nil {
+		query := nestedSearchQuery(xSearch)
+		_, existed := parsed.hostedSearchByID[id]
+		upsertHostedSearchCall(parsed, id, "x_search", query, "in_progress")
+		if !existed {
+			parsed.XSearchTools++
+		}
 	}
 }
 
-// collectGatewayToolResult folds mgw tool_result webpages / X posts into SearchSources.
+func nestedSearchQuery(tool map[string]any) string {
+	if tool == nil {
+		return ""
+	}
+	if q := firstString(tool, "query"); q != "" {
+		return q
+	}
+	if args, _ := tool["args"].(map[string]any); args != nil {
+		return firstString(args, "query")
+	}
+	return ""
+}
+
+// collectGatewayToolResult folds mgw tool_result into SearchSources and completes hosted calls.
 func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 	if parsed == nil || result == nil {
 		return
 	}
+	callID := firstString(result, "tool_call_id", "tool_usage_card_id", "id")
 	if web, _ := result["web_search"].(map[string]any); web != nil {
+		var sources []map[string]any
 		pages, _ := web["webpages"].([]any)
 		for _, raw := range pages {
 			item, _ := raw.(map[string]any)
 			if item == nil {
 				continue
 			}
-			appendSearchSource(parsed, firstString(item, "url"), firstString(item, "title"), "web")
+			u := firstString(item, "url")
+			title := firstString(item, "title")
+			appendSearchSource(parsed, u, title, "web")
+			if normalized, ok := searchresult.NormalizeURL(u); ok {
+				sources = append(sources, map[string]any{
+					"url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
+				})
+			}
+		}
+		call := upsertHostedSearchCall(parsed, callID, "web_search", nestedSearchQuery(web), "completed")
+		appendHostedSearchSources(call, sources)
+		if call != nil {
+			call.Status = "completed"
 		}
 	}
 	if xPost, _ := result["x_post"].(map[string]any); xPost != nil {
+		var sources []map[string]any
 		posts, _ := xPost["posts"].([]any)
 		for _, raw := range posts {
 			item, _ := raw.(map[string]any)
@@ -490,6 +530,19 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 				title = text
 			}
 			appendSearchSource(parsed, rawURL, title, "x_post")
+			if normalized, ok := searchresult.NormalizeURL(rawURL); ok {
+				sources = append(sources, map[string]any{
+					"url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
+				})
+			}
+		}
+		call := upsertHostedSearchCall(parsed, callID, "x_search", "", "completed")
+		appendHostedSearchSources(call, sources)
+		if call != nil {
+			call.Status = "completed"
+			if call.Kind == "" {
+				call.Kind = "x_search"
+			}
 		}
 	}
 }

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	fhttp "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/websocket"
@@ -435,6 +436,25 @@ func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
 	if id == "" {
 		id = fmt.Sprintf("card:%d", parsed.ServerTools+1)
 	}
+	if web, _ := card["web_search"].(map[string]any); web != nil {
+		recordGatewaySearchTool(parsed, id, "web_search")
+		query := nestedSearchQuery(web)
+		upsertHostedSearchCall(parsed, id, "web_search", query, "in_progress")
+		return
+	}
+	if xSearch, _ := card["x_search"].(map[string]any); xSearch != nil {
+		recordGatewaySearchTool(parsed, id, "x_search")
+		query := nestedSearchQuery(xSearch)
+		upsertHostedSearchCall(parsed, id, "x_search", query, "in_progress")
+		return
+	}
+	recordGatewaySearchTool(parsed, id, "")
+}
+
+func recordGatewaySearchTool(parsed *parsedChat, id, kind string) {
+	if parsed == nil || id == "" {
+		return
+	}
 	if parsed.serverToolKeys == nil {
 		parsed.serverToolKeys = make(map[string]struct{})
 	}
@@ -445,26 +465,24 @@ func collectGatewayToolUsageCard(parsed *parsedChat, card map[string]any) {
 		parsed.serverToolKeys[id] = struct{}{}
 		parsed.ServerTools++
 	}
-	if web, _ := card["web_search"].(map[string]any); web != nil {
-		if parsed.webSearchKeys == nil {
-			parsed.webSearchKeys = make(map[string]struct{})
-		}
-		if _, exists := parsed.webSearchKeys[id]; !exists {
-			parsed.webSearchKeys[id] = struct{}{}
-			parsed.WebSearchTools++
-		}
-		query := nestedSearchQuery(web)
-		upsertHostedSearchCall(parsed, id, "web_search", query, "in_progress")
+	var keys *map[string]struct{}
+	var count *int64
+	switch kind {
+	case "web_search":
+		keys, count = &parsed.webSearchKeys, &parsed.WebSearchTools
+	case "x_search":
+		keys, count = &parsed.xSearchKeys, &parsed.XSearchTools
+	default:
 		return
 	}
-	if xSearch, _ := card["x_search"].(map[string]any); xSearch != nil {
-		query := nestedSearchQuery(xSearch)
-		_, existed := parsed.hostedSearchByID[id]
-		upsertHostedSearchCall(parsed, id, "x_search", query, "in_progress")
-		if !existed {
-			parsed.XSearchTools++
-		}
+	if *keys == nil {
+		*keys = make(map[string]struct{})
 	}
+	if _, exists := (*keys)[id]; exists || len(*keys) >= maxTrackedServerTools {
+		return
+	}
+	(*keys)[id] = struct{}{}
+	*count++
 }
 
 func nestedSearchQuery(tool map[string]any) string {
@@ -509,6 +527,7 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 		appendHostedSearchSources(call, sources)
 		if call != nil {
 			call.Status = "completed"
+			recordGatewaySearchTool(parsed, call.ID, "web_search")
 		}
 	}
 	if xPost, _ := result["x_post"].(map[string]any); xPost != nil {
@@ -545,13 +564,14 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 			if call.Kind == "" {
 				call.Kind = "x_search"
 			}
+			recordGatewaySearchTool(parsed, call.ID, "x_search")
 		}
 	}
 }
 
 // applyGatewayRenderCitation turns an mgw render_citation chunk into client citations.
 // When InlineCitations is enabled (default), embeds [[N]](url) and records positional
-// annotations. Annotation title is the page/source title (OpenAI-style); N stays in the marker.
+// annotations. N stays in the marker while structured metadata retains the source title.
 func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string, string, error) {
 	if parsed == nil || cite == nil {
 		return "", "", nil
@@ -566,6 +586,9 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	}
 	index, exists := parsed.citationIndex[normalized]
 	if !exists {
+		if len(parsed.citationIndex) >= maxTrackedCitationSources {
+			return "", "", nil
+		}
 		index = len(parsed.citationIndex) + 1
 		parsed.citationIndex[normalized] = index
 	}
@@ -575,47 +598,25 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	}
 	parsed.lastCitation = index
 
-	title := citationPageTitle(parsed, normalized, index)
+	annotation := citationAnnotation(parsed, normalized, index)
 	if parsed.DisableInlineCitations {
 		// no_inline_citations: no markdown in text; positional fields omitted later at finalize.
-		parsed.Annotations = append(parsed.Annotations, map[string]any{
-			"type":  "url_citation",
-			"url":   normalized,
-			"title": title,
-		})
+		if len(parsed.Annotations) < maxTrackedAnnotations {
+			parsed.Annotations = append(parsed.Annotations, annotation)
+		}
 		return "", "", nil
 	}
-	// Inline marker keeps numeric label; structured title is page name (or N if unknown).
+	// Inline marker and xAI Responses annotation use the same numeric label.
 	replacement := fmt.Sprintf("[[%d]](%s)", index, normalized)
-	start := parsed.Text.Len()
+	start := parsed.textCharacterLen()
 	parsed.upstreamText.WriteString(replacement)
-	parsed.Text.WriteString(replacement)
-	parsed.Annotations = append(parsed.Annotations, map[string]any{
-		"type":        "url_citation",
-		"url":         normalized,
-		"title":       title,
-		"start_index": start,
-		"end_index":   start + len(replacement),
-	})
-	return "text", replacement, nil
-}
-
-func xHandleFromStatusURL(rawURL string) string {
-	// https://x.com/{handle}/status/{id}
-	const marker = "://x.com/"
-	idx := strings.Index(rawURL, marker)
-	if idx < 0 {
-		idx = strings.Index(rawURL, "://twitter.com/")
-		if idx < 0 {
-			return ""
-		}
-		rest := rawURL[idx+len("://twitter.com/"):]
-		handle, _, _ := strings.Cut(rest, "/")
-		return handle
+	parsed.appendText(replacement)
+	annotation["start_index"] = start
+	annotation["end_index"] = start + utf8.RuneCountInString(replacement)
+	if len(parsed.Annotations) < maxTrackedAnnotations {
+		parsed.Annotations = append(parsed.Annotations, annotation)
 	}
-	rest := rawURL[idx+len(marker):]
-	handle, _, _ := strings.Cut(rest, "/")
-	return handle
+	return "text", replacement, nil
 }
 
 func appendGatewayDelta(parsed *parsedChat, channel, delta string) (string, string, error) {
@@ -632,7 +633,7 @@ func appendGatewayDelta(parsed *parsedChat, channel, delta string) (string, stri
 	}
 	parsed.upstreamText.WriteString(delta)
 	cleaned := cleanChatToken(parsed, delta)
-	parsed.Text.WriteString(cleaned)
+	parsed.appendText(cleaned)
 	return "text", cleaned, nil
 }
 

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -549,9 +549,9 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 	}
 }
 
-// applyGatewayRenderCitation turns an mgw render_citation chunk into xAI-style citations.
+// applyGatewayRenderCitation turns an mgw render_citation chunk into client citations.
 // When InlineCitations is enabled (default), embeds [[N]](url) and records positional
-// annotations with title = display number. When disabled, skips text markers.
+// annotations. Annotation title is the page/source title (OpenAI-style); N stays in the marker.
 func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string, string, error) {
 	if parsed == nil || cite == nil {
 		return "", "", nil
@@ -575,18 +575,17 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	}
 	parsed.lastCitation = index
 
-	// xAI: title is the visible citation number ("1", "2"), not the page title.
-	label := fmt.Sprintf("%d", index)
+	title := citationPageTitle(parsed, normalized)
 	if parsed.DisableInlineCitations {
 		// no_inline_citations: no markdown in text; positional fields omitted later at finalize.
 		parsed.Annotations = append(parsed.Annotations, map[string]any{
 			"type":  "url_citation",
 			"url":   normalized,
-			"title": label,
+			"title": title,
 		})
 		return "", "", nil
 	}
-	// xAI markdown form: [[N]](url) with no mandatory leading space.
+	// Inline marker keeps numeric label; structured title is the page name.
 	replacement := fmt.Sprintf("[[%d]](%s)", index, normalized)
 	start := parsed.Text.Len()
 	parsed.upstreamText.WriteString(replacement)
@@ -594,7 +593,7 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	parsed.Annotations = append(parsed.Annotations, map[string]any{
 		"type":        "url_citation",
 		"url":         normalized,
-		"title":       label,
+		"title":       title,
 		"start_index": start,
 		"end_index":   start + len(replacement),
 	})

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -494,9 +494,9 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 	}
 }
 
-// applyGatewayRenderCitation turns an inline render_citation chunk into text + url_citation.
-// Citations are streamed as separate chunks between text deltas; indices track the
-// synthetic [[n]](url) marker inserted at the current assistant text offset.
+// applyGatewayRenderCitation turns an mgw render_citation chunk into xAI-style citations.
+// When InlineCitations is enabled (default), embeds [[N]](url) and records positional
+// annotations with title = display number. When disabled, skips text markers.
 func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string, string, error) {
 	if parsed == nil || cite == nil {
 		return "", "", nil
@@ -520,20 +520,26 @@ func applyGatewayRenderCitation(parsed *parsedChat, cite map[string]any) (string
 	}
 	parsed.lastCitation = index
 
-	title := searchSourceTitle(parsed.SearchSources, normalized)
-	if title == "" || title == normalized {
-		if handle := xHandleFromStatusURL(normalized); handle != "" {
-			title = "@" + handle
-		}
+	// xAI: title is the visible citation number ("1", "2"), not the page title.
+	label := fmt.Sprintf("%d", index)
+	if parsed.DisableInlineCitations {
+		// no_inline_citations: no markdown in text; positional fields omitted later at finalize.
+		parsed.Annotations = append(parsed.Annotations, map[string]any{
+			"type":  "url_citation",
+			"url":   normalized,
+			"title": label,
+		})
+		return "", "", nil
 	}
-	replacement := fmt.Sprintf(" [[%d]](%s)", index, normalized)
+	// xAI markdown form: [[N]](url) with no mandatory leading space.
+	replacement := fmt.Sprintf("[[%d]](%s)", index, normalized)
 	start := parsed.Text.Len()
 	parsed.upstreamText.WriteString(replacement)
 	parsed.Text.WriteString(replacement)
 	parsed.Annotations = append(parsed.Annotations, map[string]any{
 		"type":        "url_citation",
 		"url":         normalized,
-		"title":       title,
+		"title":       label,
 		"start_index": start,
 		"end_index":   start + len(replacement),
 	})

--- a/backend/internal/infra/provider/web/gateway.go
+++ b/backend/internal/infra/provider/web/gateway.go
@@ -498,8 +498,10 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 			title := firstString(item, "title")
 			appendSearchSource(parsed, u, title, "web")
 			if normalized, ok := searchresult.NormalizeURL(u); ok {
+				// OpenAPI WebSearchActionSearch.sources item requires type:"url";
+				// keep title as a non-breaking extension for UI clients.
 				sources = append(sources, map[string]any{
-					"url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
+					"type": "url", "url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
 				})
 			}
 		}
@@ -532,7 +534,7 @@ func collectGatewayToolResult(parsed *parsedChat, result map[string]any) {
 			appendSearchSource(parsed, rawURL, title, "x_post")
 			if normalized, ok := searchresult.NormalizeURL(rawURL); ok {
 				sources = append(sources, map[string]any{
-					"url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
+					"type": "url", "url": normalized, "title": searchresult.NormalizeTitle(title, normalized),
 				})
 			}
 		}

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -98,3 +98,52 @@ func TestParseGatewayErrorUsesExistingClassification(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
+	parsed := &parsedChat{}
+	frames := []string{
+		`{"event":{"type":"response.chunk","chunk":{"tool_usage_card":{"tool_usage_card_id":"tool-1","web_search":{"args":{"query":"grok 4.6"}}}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"tool_result":{"tool_call_id":"tool-1","web_search":{"webpages":[{"url":"https://www.ithome.com/0/981/947.htm","title":"IT之家 Grok 4.6","snippet":"..."}]}}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"tool_usage_card":{"tool_usage_card_id":"tool-2","x_search":{"args":{"query":"from:elonmusk"}}}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"tool_result":{"tool_call_id":"tool-2","x_post":{"posts":[{"userhandle":"elonmusk","name":"Elon Musk","text":"And Grok 4.6 comes out in a week","post_id":"2082707547203518569"}]}}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"预计发布","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"id":"c1","kind":"CITATION_KIND_X_POST","url":"https://x.com/elonmusk/status/2082707547203518569","citation_id":1}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"id":"c2","kind":"CITATION_KIND_WEB_PAGE","url":"https://www.ithome.com/0/981/947.htm","citation_id":0}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"。","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+	}
+	var emitted strings.Builder
+	for _, frame := range frames {
+		kind, delta, err := parseUpstreamFrame([]byte(frame), parsed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if kind == "text" {
+			emitted.WriteString(delta)
+		}
+	}
+	if parsed.ServerTools != 2 || parsed.WebSearchTools != 1 {
+		t.Fatalf("tools server=%d web=%d", parsed.ServerTools, parsed.WebSearchTools)
+	}
+	if len(parsed.SearchSources) < 2 {
+		t.Fatalf("search sources = %#v", parsed.SearchSources)
+	}
+	if len(parsed.Annotations) != 2 {
+		t.Fatalf("annotations = %#v", parsed.Annotations)
+	}
+	text := parsed.Text.String()
+	if !strings.Contains(text, "预计发布") || !strings.Contains(text, "[[1]](https://x.com/elonmusk/status/2082707547203518569)") || !strings.Contains(text, "[[2]](https://www.ithome.com/0/981/947.htm)") {
+		t.Fatalf("text = %q emitted = %q", text, emitted.String())
+	}
+	first := parsed.Annotations[0]
+	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" {
+		t.Fatalf("first annotation = %#v", first)
+	}
+	chatPayload := buildOpenAIResult("chat", "resp_1", "grok-chat-fast", *parsed, false)
+	msg := chatPayload["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
+	if msg["annotations"] == nil {
+		t.Fatalf("chat annotations missing: %#v", msg)
+	}
+	if chatPayload["search_sources"] == nil {
+		t.Fatalf("search_sources missing: %#v", chatPayload)
+	}
+}

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -128,6 +128,18 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if len(parsed.SearchSources) < 2 {
 		t.Fatalf("search sources = %#v", parsed.SearchSources)
 	}
+	if len(parsed.HostedSearchCalls) < 2 {
+		t.Fatalf("hosted search calls = %#v", parsed.HostedSearchCalls)
+	}
+	if parsed.HostedSearchCalls[0].Kind != "web_search" || parsed.HostedSearchCalls[0].Status != "completed" {
+		t.Fatalf("web call = %#v", parsed.HostedSearchCalls[0])
+	}
+	if parsed.HostedSearchCalls[1].Kind != "x_search" || parsed.HostedSearchCalls[1].Query == "" && parsed.HostedSearchCalls[1].Status != "completed" {
+		// x call should be completed with sources
+		if parsed.HostedSearchCalls[1].Kind != "x_search" || parsed.HostedSearchCalls[1].Status != "completed" {
+			t.Fatalf("x call = %#v", parsed.HostedSearchCalls[1])
+		}
+	}
 	if len(parsed.Annotations) != 2 {
 		t.Fatalf("annotations = %#v", parsed.Annotations)
 	}
@@ -168,7 +180,24 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if respPayload["citations"] == nil {
 		t.Fatalf("responses citations missing: %#v", respPayload)
 	}
-	outMsg := respPayload["output"].([]any)[len(respPayload["output"].([]any))-1].(map[string]any)
+	if respPayload["server_side_tool_usage"] == nil {
+		t.Fatalf("server_side_tool_usage missing: %#v", respPayload)
+	}
+	out := respPayload["output"].([]any)
+	if len(out) < 3 {
+		t.Fatalf("output should include search calls + message: %#v", out)
+	}
+	if out[0].(map[string]any)["type"] != "web_search_call" {
+		t.Fatalf("first output item = %#v", out[0])
+	}
+	if out[1].(map[string]any)["type"] != "x_search_call" {
+		t.Fatalf("second output item = %#v", out[1])
+	}
+	webAction := out[0].(map[string]any)["action"].(map[string]any)
+	if webAction["type"] != "search" || webAction["query"] == nil {
+		t.Fatalf("web action = %#v", webAction)
+	}
+	outMsg := out[len(out)-1].(map[string]any)
 	part := outMsg["content"].([]any)[0].(map[string]any)
 	flat := part["annotations"].([]any)[0].(map[string]any)
 	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != "1" {

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -224,6 +224,29 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	}
 }
 
+func TestCitationTitleFallsBackToIndex(t *testing.T) {
+	parsed := &parsedChat{}
+	// render_citation without prior tool_result titles → title should be "1"
+	frames := []string{
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"hi","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"url":"https://example.com/no-title","kind":"CITATION_KIND_WEB_PAGE"}}}}`,
+	}
+	for _, frame := range frames {
+		if _, _, err := parseUpstreamFrame([]byte(frame), parsed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(parsed.Annotations) != 1 {
+		t.Fatalf("annotations = %#v", parsed.Annotations)
+	}
+	if parsed.Annotations[0]["title"] != "1" {
+		t.Fatalf("want title fallback to index, got %#v", parsed.Annotations[0])
+	}
+	if !strings.Contains(parsed.Text.String(), "[[1]](https://example.com/no-title)") {
+		t.Fatalf("text = %q", parsed.Text.String())
+	}
+}
+
 func TestNoInlineCitationsOmitsMarkdownMarkers(t *testing.T) {
 	parsed := &parsedChat{DisableInlineCitations: true}
 	frames := []string{

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -134,11 +135,8 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if parsed.HostedSearchCalls[0].Kind != "web_search" || parsed.HostedSearchCalls[0].Status != "completed" {
 		t.Fatalf("web call = %#v", parsed.HostedSearchCalls[0])
 	}
-	if parsed.HostedSearchCalls[1].Kind != "x_search" || parsed.HostedSearchCalls[1].Query == "" && parsed.HostedSearchCalls[1].Status != "completed" {
-		// x call should be completed with sources
-		if parsed.HostedSearchCalls[1].Kind != "x_search" || parsed.HostedSearchCalls[1].Status != "completed" {
-			t.Fatalf("x call = %#v", parsed.HostedSearchCalls[1])
-		}
+	if parsed.HostedSearchCalls[1].Kind != "x_search" || parsed.HostedSearchCalls[1].Query == "" || parsed.HostedSearchCalls[1].Status != "completed" {
+		t.Fatalf("x call = %#v", parsed.HostedSearchCalls[1])
 	}
 	if len(parsed.Annotations) != 2 {
 		t.Fatalf("annotations = %#v", parsed.Annotations)
@@ -148,9 +146,10 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 		t.Fatalf("text = %q emitted = %q", text, emitted.String())
 	}
 	first := parsed.Annotations[0]
-	// Annotation title = page/source title; [[N]] still carries the number in text.
+	// xAI Responses title is the visible citation number; source_title is kept
+	// internally so Chat Completions can expose the page title.
 	wantTitle := "Elon Musk: And Grok 4.6 comes out in a week"
-	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" || first["title"] != wantTitle {
+	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" || first["title"] != "1" || first["source_title"] != wantTitle {
 		t.Fatalf("first annotation = %#v want title %q", first, wantTitle)
 	}
 	chatPayload := buildOpenAIResult("chat", "resp_1", "grok-chat-fast", *parsed, false)
@@ -219,8 +218,8 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	outMsg := out[len(out)-1].(map[string]any)
 	part := outMsg["content"].([]any)[0].(map[string]any)
 	flat := part["annotations"].([]any)[0].(map[string]any)
-	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != wantTitle {
-		t.Fatalf("responses annotation must be flat url_citation with page title, got %#v", flat)
+	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != "1" {
+		t.Fatalf("responses annotation must be flat url_citation with numeric label, got %#v", flat)
 	}
 }
 
@@ -244,6 +243,131 @@ func TestCitationTitleFallsBackToIndex(t *testing.T) {
 	}
 	if !strings.Contains(parsed.Text.String(), "[[1]](https://example.com/no-title)") {
 		t.Fatalf("text = %q", parsed.Text.String())
+	}
+}
+
+func TestGatewayCitationReusesNumberAfterInterveningText(t *testing.T) {
+	parsed := &parsedChat{}
+	frames := []string{
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"甲","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"url":"https://example.com/a"}}}}`,
+		// A duplicate frame with no intervening text is transport noise and is collapsed.
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"url":"https://example.com/a"}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"，乙","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+		// A later citation of the same source remains visible and reuses [[1]].
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"url":"https://example.com/a"}}}}`,
+	}
+	for _, frame := range frames {
+		if _, _, err := parseUpstreamFrame([]byte(frame), parsed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := "甲[[1]](https://example.com/a)，乙[[1]](https://example.com/a)"
+	if got := parsed.Text.String(); got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+	if len(parsed.Annotations) != 2 {
+		t.Fatalf("annotations = %#v", parsed.Annotations)
+	}
+	first, second := parsed.Annotations[0], parsed.Annotations[1]
+	if first["start_index"] != 1 || first["end_index"] != 29 {
+		t.Fatalf("first annotation uses character offsets: %#v", first)
+	}
+	if second["start_index"] != 31 || second["end_index"] != 59 {
+		t.Fatalf("second annotation uses character offsets: %#v", second)
+	}
+}
+
+func TestGatewayCitationStateIsBounded(t *testing.T) {
+	parsed := &parsedChat{citationIndex: make(map[string]int, maxTrackedCitationSources)}
+	for i := 0; i < maxTrackedCitationSources; i++ {
+		parsed.citationIndex[fmt.Sprintf("https://example.com/%d", i)] = i + 1
+	}
+	if kind, delta, err := applyGatewayRenderCitation(parsed, map[string]any{"url": "https://example.com/overflow"}); err != nil || kind != "" || delta != "" {
+		t.Fatalf("overflow citation kind=%q delta=%q err=%v", kind, delta, err)
+	}
+	if len(parsed.citationIndex) != maxTrackedCitationSources {
+		t.Fatalf("citation sources grew to %d", len(parsed.citationIndex))
+	}
+
+	parsed = &parsedChat{
+		citationIndex: map[string]int{"https://example.com/a": 1},
+		Annotations:   make([]map[string]any, maxTrackedAnnotations),
+	}
+	kind, delta, err := applyGatewayRenderCitation(parsed, map[string]any{"url": "https://example.com/a"})
+	if err != nil || kind != "text" || delta != "[[1]](https://example.com/a)" {
+		t.Fatalf("existing citation kind=%q delta=%q err=%v", kind, delta, err)
+	}
+	if len(parsed.Annotations) != maxTrackedAnnotations {
+		t.Fatalf("annotations grew to %d", len(parsed.Annotations))
+	}
+}
+
+func TestGatewayToolResultWithoutIDCompletesSingleMatchingCall(t *testing.T) {
+	parsed := &parsedChat{}
+	collectGatewayToolUsageCard(parsed, map[string]any{
+		"tool_usage_card_id": "tool-1",
+		"web_search":         map[string]any{"args": map[string]any{"query": "query"}},
+	})
+	collectGatewayToolResult(parsed, map[string]any{
+		"web_search": map[string]any{"webpages": []any{map[string]any{"url": "https://example.com"}}},
+	})
+	if len(parsed.HostedSearchCalls) != 1 {
+		t.Fatalf("hosted calls = %#v", parsed.HostedSearchCalls)
+	}
+	call := parsed.HostedSearchCalls[0]
+	if call.ID != "tool-1" || call.Status != "completed" || len(call.Sources) != 1 {
+		t.Fatalf("call = %#v", call)
+	}
+	if parsed.ServerTools != 1 || parsed.WebSearchTools != 1 {
+		t.Fatalf("tool counters server=%d web=%d", parsed.ServerTools, parsed.WebSearchTools)
+	}
+}
+
+func TestGatewayResultOnlyStillRecordsSuccessfulTool(t *testing.T) {
+	parsed := &parsedChat{}
+	collectGatewayToolResult(parsed, map[string]any{
+		"tool_call_id": "result-only",
+		"x_post": map[string]any{"posts": []any{map[string]any{
+			"userhandle": "xai", "post_id": "1", "text": "news",
+		}}},
+	})
+	if parsed.ServerTools != 1 || parsed.XSearchTools != 1 {
+		t.Fatalf("tool counters server=%d x=%d", parsed.ServerTools, parsed.XSearchTools)
+	}
+	usage := xaiServerSideToolUsage(*parsed)
+	if usage["SERVER_SIDE_TOOL_X_SEARCH"] != int64(1) {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestXAIToolUsageCountsCompletedGatewayCallsOnly(t *testing.T) {
+	parsed := parsedChat{
+		WebSearchTools: 2,
+		XSearchTools:   1,
+		HostedSearchCalls: []hostedSearchCall{
+			{ID: "pending-web", Kind: "web_search", Status: "in_progress"},
+			{ID: "done-x", Kind: "x_search", Status: "completed"},
+		},
+	}
+	usage := xaiServerSideToolUsage(parsed)
+	if usage["SERVER_SIDE_TOOL_WEB_SEARCH"] != nil || usage["SERVER_SIDE_TOOL_X_SEARCH"] != int64(1) {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
+func TestXAICitationsUnionSearchResultsAndRenderedSources(t *testing.T) {
+	parsed := parsedChat{
+		SearchSources: []map[string]any{{"url": "https://example.com/from-result"}},
+		Annotations: []map[string]any{
+			{"url": "https://example.com/from-result"},
+			{"url": "https://example.com/render-only"},
+		},
+	}
+	want := []string{"https://example.com/from-result", "https://example.com/render-only"}
+	got := xaiCitationURLs(parsed)
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("citations = %#v, want %#v", got, want)
 	}
 }
 
@@ -307,7 +431,8 @@ func TestWriteStreamAnnotationsShapes(t *testing.T) {
 		t.Fatalf("chat stream = %s", chatBuf.String())
 	}
 	var respBuf strings.Builder
-	if err := writeStreamAnnotations(&respBuf, conversation.OperationResponses, "resp_1", "m", ann, 3); err != nil {
+	responsesStream := newWebResponsesStream(&respBuf, "resp_1")
+	if err := responsesStream.Annotations(ann, 3); err != nil {
 		t.Fatal(err)
 	}
 	out := respBuf.String()
@@ -316,6 +441,118 @@ func TestWriteStreamAnnotationsShapes(t *testing.T) {
 	}
 	if strings.Contains(out, `"url_citation":{`) {
 		t.Fatalf("responses annotation must stay flat: %s", out)
+	}
+	if !strings.Contains(out, `"item_id":"msg_`) || strings.Contains(out, `"item_id":""`) {
+		t.Fatalf("responses annotation needs a stable message item id: %s", out)
+	}
+}
+
+func TestResponsesStreamUsesOneStableOutputSequence(t *testing.T) {
+	var buf strings.Builder
+	stream := newWebResponsesStream(&buf, "resp_1")
+	if err := stream.Delta("reasoning", "thinking"); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.HostedSearch(hostedSearchCall{ID: "search_1", Kind: "web_search", Status: "completed"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Delta("text", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	call := parsedToolCall{ID: "call_1", Name: "lookup", Arguments: `{}`}
+	if err := stream.ToolCalls([]parsedToolCall{call}); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parsedChat{ToolCalls: []parsedToolCall{call}}
+	parsed.Reasoning.WriteString("thinking")
+	parsed.Text.WriteString("hello")
+	if err := stream.Finish(&parsed); err != nil {
+		t.Fatal(err)
+	}
+	wantTypes := []string{"reasoning", "web_search_call", "message", "function_call"}
+	if len(parsed.ResponseOutput) != len(wantTypes) {
+		t.Fatalf("output = %#v", parsed.ResponseOutput)
+	}
+	seenIDs := make(map[string]struct{}, len(wantTypes))
+	for index, wantType := range wantTypes {
+		item := parsed.ResponseOutput[index].(map[string]any)
+		if item["type"] != wantType || item["status"] != "completed" {
+			t.Fatalf("output[%d] = %#v", index, item)
+		}
+		id, _ := item["id"].(string)
+		if id == "" {
+			t.Fatalf("output[%d] missing id: %#v", index, item)
+		}
+		if _, duplicate := seenIDs[id]; duplicate {
+			t.Fatalf("duplicate output id %q", id)
+		}
+		seenIDs[id] = struct{}{}
+	}
+	payload := buildOpenAIResult(conversation.OperationResponses, "resp_1", "m", parsed, false)
+	payloadOutput := payload["output"].([]any)
+	for index := range parsed.ResponseOutput {
+		wantID := parsed.ResponseOutput[index].(map[string]any)["id"]
+		if gotID := payloadOutput[index].(map[string]any)["id"]; gotID != wantID {
+			t.Fatalf("completed output[%d] id=%v, want %v", index, gotID, wantID)
+		}
+	}
+	out := buf.String()
+	addedIDs := make(map[int]string, len(wantTypes))
+	doneIDs := make(map[int]string, len(wantTypes))
+	for _, event := range decodeSSEPayloads(t, out) {
+		typeName, _ := event["type"].(string)
+		if typeName != "response.output_item.added" && typeName != "response.output_item.done" {
+			continue
+		}
+		index, ok := numberAsInt(event["output_index"])
+		if !ok {
+			t.Fatalf("event missing output_index: %#v", event)
+		}
+		item := event["item"].(map[string]any)
+		id, _ := item["id"].(string)
+		if typeName == "response.output_item.added" {
+			if item["status"] != "in_progress" {
+				t.Fatalf("added item[%d] = %#v", index, item)
+			}
+			addedIDs[index] = id
+		} else {
+			if item["status"] != "completed" {
+				t.Fatalf("done item[%d] = %#v", index, item)
+			}
+			doneIDs[index] = id
+		}
+	}
+	for index := range wantTypes {
+		if addedIDs[index] == "" || doneIDs[index] != addedIDs[index] {
+			t.Fatalf("item[%d] lifecycle added=%q done=%q\n%s", index, addedIDs[index], doneIDs[index], out)
+		}
+	}
+}
+
+func TestResponsesStreamLateReasoningDoesNotRenumberEarlierItems(t *testing.T) {
+	var buf strings.Builder
+	stream := newWebResponsesStream(&buf, "resp_1")
+	if err := stream.HostedSearch(hostedSearchCall{ID: "search_1", Kind: "web_search", Status: "completed"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Delta("text", "answer"); err != nil {
+		t.Fatal(err)
+	}
+	parsed := parsedChat{}
+	parsed.Text.WriteString("answer")
+	parsed.Reasoning.WriteString("late reasoning")
+	if err := stream.Finish(&parsed); err != nil {
+		t.Fatal(err)
+	}
+	wantTypes := []string{"web_search_call", "message", "reasoning"}
+	for index, wantType := range wantTypes {
+		item := parsed.ResponseOutput[index].(map[string]any)
+		if item["type"] != wantType {
+			t.Fatalf("output[%d] = %#v", index, item)
+		}
+	}
+	if !strings.Contains(buf.String(), `"output_index":0`) || !strings.Contains(buf.String(), `"output_index":1`) || !strings.Contains(buf.String(), `"output_index":2`) {
+		t.Fatalf("stream indices = %s", buf.String())
 	}
 }
 
@@ -348,4 +585,25 @@ func TestWriteStreamDoneChatIncludesServerSideToolUsage(t *testing.T) {
 	if !strings.Contains(out, "data: [DONE]") {
 		t.Fatalf("missing DONE: %s", out)
 	}
+	if strings.Contains(out, `"annotations"`) {
+		t.Fatalf("final chunk must not repeat progressive annotations: %s", out)
+	}
+}
+
+func decodeSSEPayloads(t *testing.T, stream string) []map[string]any {
+	t.Helper()
+	var payloads []map[string]any
+	for _, block := range strings.Split(stream, "\n\n") {
+		for _, line := range strings.Split(block, "\n") {
+			if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
+				continue
+			}
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &payload); err != nil {
+				t.Fatalf("decode SSE payload %q: %v", line, err)
+			}
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
 }

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -148,18 +148,20 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 		t.Fatalf("text = %q emitted = %q", text, emitted.String())
 	}
 	first := parsed.Annotations[0]
-	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" || first["title"] != "1" {
-		t.Fatalf("first annotation = %#v", first)
+	// Annotation title = page/source title; [[N]] still carries the number in text.
+	wantTitle := "Elon Musk: And Grok 4.6 comes out in a week"
+	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" || first["title"] != wantTitle {
+		t.Fatalf("first annotation = %#v want title %q", first, wantTitle)
 	}
 	chatPayload := buildOpenAIResult("chat", "resp_1", "grok-chat-fast", *parsed, false)
 	msg := chatPayload["choices"].([]any)[0].(map[string]any)["message"].(map[string]any)
 	if msg["annotations"] == nil {
 		t.Fatalf("chat annotations missing: %#v", msg)
 	}
-	// Chat Completions: nested url_citation; xAI title is display number.
+	// Chat Completions: nested url_citation; title is page name.
 	firstAnn := msg["annotations"].([]any)[0].(map[string]any)
 	nested, _ := firstAnn["url_citation"].(map[string]any)
-	if firstAnn["type"] != "url_citation" || nested == nil || nested["url"] == nil || nested["title"] != "1" {
+	if firstAnn["type"] != "url_citation" || nested == nil || nested["url"] == nil || nested["title"] != wantTitle {
 		t.Fatalf("chat annotation shape = %#v", firstAnn)
 	}
 	citations, _ := chatPayload["citations"].([]string)
@@ -217,8 +219,8 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	outMsg := out[len(out)-1].(map[string]any)
 	part := outMsg["content"].([]any)[0].(map[string]any)
 	flat := part["annotations"].([]any)[0].(map[string]any)
-	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != "1" {
-		t.Fatalf("responses annotation must be flat xAI url_citation, got %#v", flat)
+	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != wantTitle {
+		t.Fatalf("responses annotation must be flat url_citation with page title, got %#v", flat)
 	}
 }
 

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -197,6 +197,23 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if webAction["type"] != "search" || webAction["query"] == nil {
 		t.Fatalf("web action = %#v", webAction)
 	}
+	webSources, _ := webAction["sources"].([]map[string]any)
+	if len(webSources) == 0 {
+		// buildOpenAIResult may re-box as []any depending on path
+		if raw, ok := webAction["sources"].([]any); ok && len(raw) > 0 {
+			firstSrc, _ := raw[0].(map[string]any)
+			if firstSrc["type"] != "url" || firstSrc["url"] == nil {
+				t.Fatalf("web action.sources[0] want type=url: %#v", firstSrc)
+			}
+			if firstSrc["title"] == nil || firstSrc["title"] == "" {
+				t.Fatalf("web action.sources[0] should keep title extension: %#v", firstSrc)
+			}
+		} else {
+			t.Fatalf("web action.sources missing: %#v", webAction["sources"])
+		}
+	} else if webSources[0]["type"] != "url" || webSources[0]["url"] == nil || webSources[0]["title"] == nil {
+		t.Fatalf("web action.sources[0] = %#v", webSources[0])
+	}
 	outMsg := out[len(out)-1].(map[string]any)
 	part := outMsg["content"].([]any)[0].(map[string]any)
 	flat := part["annotations"].([]any)[0].(map[string]any)

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -8,6 +8,7 @@ import (
 
 	inferencedomain "github.com/chenyme/grok2api/backend/internal/domain/inference"
 	infraegress "github.com/chenyme/grok2api/backend/internal/infra/egress"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 )
 
 func TestGatewayEndpointAndHeadersMatchBrowserProtocol(t *testing.T) {
@@ -143,7 +144,46 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if msg["annotations"] == nil {
 		t.Fatalf("chat annotations missing: %#v", msg)
 	}
+	// Chat Completions: nested url_citation object
+	firstAnn := msg["annotations"].([]any)[0].(map[string]any)
+	nested, _ := firstAnn["url_citation"].(map[string]any)
+	if firstAnn["type"] != "url_citation" || nested == nil || nested["url"] == nil {
+		t.Fatalf("chat annotation shape = %#v", firstAnn)
+	}
 	if chatPayload["search_sources"] == nil {
 		t.Fatalf("search_sources missing: %#v", chatPayload)
+	}
+
+	respPayload := buildOpenAIResult(conversation.OperationResponses, "resp_1", "grok-chat-fast", *parsed, false)
+	outMsg := respPayload["output"].([]any)[len(respPayload["output"].([]any))-1].(map[string]any)
+	part := outMsg["content"].([]any)[0].(map[string]any)
+	flat := part["annotations"].([]any)[0].(map[string]any)
+	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil {
+		t.Fatalf("responses annotation must be flat url_citation, got %#v", flat)
+	}
+}
+
+func TestWriteStreamAnnotationsShapes(t *testing.T) {
+	ann := []map[string]any{{
+		"type": "url_citation", "url": "https://example.com", "title": "Example",
+		"start_index": 1, "end_index": 10,
+	}}
+	var chatBuf strings.Builder
+	if err := writeStreamAnnotations(&chatBuf, "chat", "resp_1", "m", ann, 0); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(chatBuf.String(), `"url_citation"`) || !strings.Contains(chatBuf.String(), `"annotations"`) {
+		t.Fatalf("chat stream = %s", chatBuf.String())
+	}
+	var respBuf strings.Builder
+	if err := writeStreamAnnotations(&respBuf, conversation.OperationResponses, "resp_1", "m", ann, 3); err != nil {
+		t.Fatal(err)
+	}
+	out := respBuf.String()
+	if !strings.Contains(out, "response.output_text.annotation.added") || !strings.Contains(out, `"annotation_index":3`) {
+		t.Fatalf("responses stream = %s", out)
+	}
+	if strings.Contains(out, `"url_citation":{`) {
+		t.Fatalf("responses annotation must stay flat: %s", out)
 	}
 }

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -136,7 +136,7 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 		t.Fatalf("text = %q emitted = %q", text, emitted.String())
 	}
 	first := parsed.Annotations[0]
-	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" {
+	if first["type"] != "url_citation" || first["url"] != "https://x.com/elonmusk/status/2082707547203518569" || first["title"] != "1" {
 		t.Fatalf("first annotation = %#v", first)
 	}
 	chatPayload := buildOpenAIResult("chat", "resp_1", "grok-chat-fast", *parsed, false)
@@ -144,28 +144,88 @@ func TestParseGatewayChunkCollectsToolResultsAndRenderCitations(t *testing.T) {
 	if msg["annotations"] == nil {
 		t.Fatalf("chat annotations missing: %#v", msg)
 	}
-	// Chat Completions: nested url_citation object
+	// Chat Completions: nested url_citation; xAI title is display number.
 	firstAnn := msg["annotations"].([]any)[0].(map[string]any)
 	nested, _ := firstAnn["url_citation"].(map[string]any)
-	if firstAnn["type"] != "url_citation" || nested == nil || nested["url"] == nil {
+	if firstAnn["type"] != "url_citation" || nested == nil || nested["url"] == nil || nested["title"] != "1" {
 		t.Fatalf("chat annotation shape = %#v", firstAnn)
 	}
-	if chatPayload["search_sources"] == nil {
-		t.Fatalf("search_sources missing: %#v", chatPayload)
+	citations, _ := chatPayload["citations"].([]string)
+	if len(citations) < 2 {
+		// JSON marshal may use []any after rebuild — accept both
+		if raw, ok := chatPayload["citations"].([]any); !ok || len(raw) < 2 {
+			t.Fatalf("citations missing: %#v", chatPayload["citations"])
+		}
+	}
+	if chatPayload["search_sources"] != nil {
+		t.Fatalf("search_sources must not be emitted: %#v", chatPayload["search_sources"])
 	}
 
 	respPayload := buildOpenAIResult(conversation.OperationResponses, "resp_1", "grok-chat-fast", *parsed, false)
+	if respPayload["search_sources"] != nil {
+		t.Fatalf("responses search_sources must not be emitted")
+	}
+	if respPayload["citations"] == nil {
+		t.Fatalf("responses citations missing: %#v", respPayload)
+	}
 	outMsg := respPayload["output"].([]any)[len(respPayload["output"].([]any))-1].(map[string]any)
 	part := outMsg["content"].([]any)[0].(map[string]any)
 	flat := part["annotations"].([]any)[0].(map[string]any)
-	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil {
-		t.Fatalf("responses annotation must be flat url_citation, got %#v", flat)
+	if flat["type"] != "url_citation" || flat["url"] == nil || flat["url_citation"] != nil || flat["title"] != "1" {
+		t.Fatalf("responses annotation must be flat xAI url_citation, got %#v", flat)
+	}
+}
+
+func TestNoInlineCitationsOmitsMarkdownMarkers(t *testing.T) {
+	parsed := &parsedChat{DisableInlineCitations: true}
+	frames := []string{
+		`{"event":{"type":"response.chunk","chunk":{"tool_result":{"web_search":{"webpages":[{"url":"https://example.com/a","title":"A"}]}}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"text":{"text":"hello","channel":"CHANNEL_ASSISTANT_RESPONSE"}}}}`,
+		`{"event":{"type":"response.chunk","chunk":{"render_citation":{"url":"https://example.com/a","kind":"CITATION_KIND_WEB_PAGE"}}}}`,
+	}
+	for _, frame := range frames {
+		if _, _, err := parseUpstreamFrame([]byte(frame), parsed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if strings.Contains(parsed.Text.String(), "[[") {
+		t.Fatalf("inline markers should be absent: %q", parsed.Text.String())
+	}
+	if len(parsed.Annotations) != 1 {
+		t.Fatalf("annotations = %#v", parsed.Annotations)
+	}
+	if _, ok := parsed.Annotations[0]["start_index"]; ok {
+		t.Fatalf("no_inline annotations must omit positions: %#v", parsed.Annotations[0])
+	}
+	payload := buildOpenAIResult(conversation.OperationResponses, "resp_1", "m", *parsed, false)
+	if payload["citations"] == nil {
+		t.Fatalf("citations still required: %#v", payload)
+	}
+}
+
+func TestInlineCitationsIncludeSwitch(t *testing.T) {
+	opts := conversation.ResponseOptions{}
+	if !opts.InlineCitationsEnabled() {
+		t.Fatal("default should enable inline citations")
+	}
+	opts.Include = []string{"no_inline_citations"}
+	if opts.InlineCitationsEnabled() {
+		t.Fatal("no_inline_citations should disable")
+	}
+	opts.Include = []string{"no_inline_citations", "inline_citations"}
+	if !opts.InlineCitationsEnabled() {
+		t.Fatal("later inline_citations should re-enable")
+	}
+	off := false
+	opts.InlineCitations = &off
+	if opts.InlineCitationsEnabled() {
+		t.Fatal("explicit false should win")
 	}
 }
 
 func TestWriteStreamAnnotationsShapes(t *testing.T) {
 	ann := []map[string]any{{
-		"type": "url_citation", "url": "https://example.com", "title": "Example",
+		"type": "url_citation", "url": "https://example.com", "title": "1",
 		"start_index": 1, "end_index": 10,
 	}}
 	var chatBuf strings.Builder

--- a/backend/internal/infra/provider/web/gateway_test.go
+++ b/backend/internal/infra/provider/web/gateway_test.go
@@ -318,3 +318,34 @@ func TestWriteStreamAnnotationsShapes(t *testing.T) {
 		t.Fatalf("responses annotation must stay flat: %s", out)
 	}
 }
+
+func TestWriteStreamDoneChatIncludesServerSideToolUsage(t *testing.T) {
+	parsed := parsedChat{
+		HostedSearchCalls: []hostedSearchCall{
+			{ID: "w1", Kind: "web_search", Status: "completed"},
+			{ID: "x1", Kind: "x_search", Status: "completed"},
+		},
+		Annotations: []map[string]any{
+			{"type": "url_citation", "url": "https://example.com", "title": "Example", "start_index": 0, "end_index": 5},
+		},
+	}
+	payload := buildOpenAIResult("chat", "resp_test", "m", parsed, false)
+	if payload["server_side_tool_usage"] == nil {
+		t.Fatalf("payload missing server_side_tool_usage: %#v", payload)
+	}
+	var buf strings.Builder
+	writeStreamDone(&buf, "chat", "resp_test", "m", parsed, payload)
+	out := buf.String()
+	if !strings.Contains(out, `"server_side_tool_usage"`) {
+		t.Fatalf("final chat chunk missing server_side_tool_usage: %s", out)
+	}
+	if !strings.Contains(out, `"SERVER_SIDE_TOOL_WEB_SEARCH"`) || !strings.Contains(out, `"SERVER_SIDE_TOOL_X_SEARCH"`) {
+		t.Fatalf("tool usage keys missing: %s", out)
+	}
+	if !strings.Contains(out, `"finish_reason":"stop"`) {
+		t.Fatalf("expected finish chunk: %s", out)
+	}
+	if !strings.Contains(out, "data: [DONE]") {
+		t.Fatalf("missing DONE: %s", out)
+	}
+}

--- a/backend/internal/infra/provider/web/image.go
+++ b/backend/internal/infra/provider/web/image.go
@@ -510,9 +510,9 @@ func (a *Adapter) forwardLiteChatCompletion(ctx context.Context, request provide
 			return nil, err
 		}
 		if parsed.Text.Len() > 0 {
-			parsed.Text.WriteString("\n\n")
+			parsed.appendText("\n\n")
 		}
-		parsed.Text.WriteString(liteImageMarkdown(item))
+		parsed.appendText(liteImageMarkdown(item))
 	}
 	payload := buildOpenAIResult("chat", responseID, input.Model, parsed, false)
 	data, err := json.Marshal(payload)
@@ -540,7 +540,7 @@ func (a *Adapter) streamLiteChatImages(ctx context.Context, writer *io.PipeWrite
 		if parsed.Text.Len() > 0 {
 			delta = "\n\n" + delta
 		}
-		parsed.Text.WriteString(delta)
+		parsed.appendText(delta)
 		if err := writeStreamDelta(writer, "chat", responseID, model, "text", delta); err != nil {
 			_ = writer.CloseWithError(err)
 			return

--- a/backend/internal/infra/provider/web/responses_stream.go
+++ b/backend/internal/infra/provider/web/responses_stream.go
@@ -1,0 +1,380 @@
+package web
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type responsesReasoningStreamItem struct {
+	id    string
+	index int
+	text  strings.Builder
+}
+
+type responsesMessageStreamItem struct {
+	id          string
+	index       int
+	text        strings.Builder
+	annotations []map[string]any
+}
+
+// webResponsesStream owns the Responses output sequence. Every output item is
+// assigned once, completed once, and then reused verbatim in response.completed.
+type webResponsesStream struct {
+	writer            io.Writer
+	responseID        string
+	nextOutputIndex   int
+	outputs           []any
+	reasoning         *responsesReasoningStreamItem
+	message           *responsesMessageStreamItem
+	messageCount      int
+	streamedReasoning strings.Builder
+}
+
+func newWebResponsesStream(writer io.Writer, responseID string) *webResponsesStream {
+	return &webResponsesStream{writer: writer, responseID: responseID}
+}
+
+func (s *webResponsesStream) allocateOutputIndex() int {
+	index := s.nextOutputIndex
+	s.nextOutputIndex++
+	s.outputs = append(s.outputs, nil)
+	return index
+}
+
+func (s *webResponsesStream) completeOutput(index int, item map[string]any) error {
+	if index < 0 || index >= len(s.outputs) {
+		return fmt.Errorf("Responses output_index %d 超出已分配范围", index)
+	}
+	if s.outputs[index] != nil {
+		return fmt.Errorf("Responses output_index %d 被重复完成", index)
+	}
+	s.outputs[index] = item
+	return nil
+}
+
+func (s *webResponsesStream) Delta(kind, delta string) error {
+	if delta == "" {
+		return nil
+	}
+	if kind == "reasoning" {
+		return s.reasoningDelta(delta)
+	}
+	if err := s.closeReasoning(); err != nil {
+		return err
+	}
+	if err := s.ensureMessage(); err != nil {
+		return err
+	}
+	s.message.text.WriteString(delta)
+	return writeSSE(s.writer, "response.output_text.delta", map[string]any{
+		"type": "response.output_text.delta", "response_id": s.responseID,
+		"item_id": s.message.id, "output_index": s.message.index, "content_index": 0,
+		"delta": delta, "logprobs": []any{},
+	})
+}
+
+func (s *webResponsesStream) reasoningDelta(delta string) error {
+	if s.reasoning == nil {
+		if err := s.closeMessage(nil); err != nil {
+			return err
+		}
+		item := &responsesReasoningStreamItem{id: newWebID("rs"), index: s.allocateOutputIndex()}
+		s.reasoning = item
+		if err := writeSSE(s.writer, "response.output_item.added", map[string]any{
+			"type": "response.output_item.added", "response_id": s.responseID, "output_index": item.index,
+			"item": map[string]any{"id": item.id, "type": "reasoning", "status": "in_progress", "summary": []any{}},
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(s.writer, "response.reasoning_summary_part.added", map[string]any{
+			"type": "response.reasoning_summary_part.added", "response_id": s.responseID,
+			"item_id": item.id, "output_index": item.index, "summary_index": 0,
+			"part": map[string]any{"type": "summary_text", "text": ""},
+		}); err != nil {
+			return err
+		}
+	}
+	s.reasoning.text.WriteString(delta)
+	s.streamedReasoning.WriteString(delta)
+	return writeSSE(s.writer, "response.reasoning_summary_text.delta", map[string]any{
+		"type": "response.reasoning_summary_text.delta", "response_id": s.responseID,
+		"item_id": s.reasoning.id, "output_index": s.reasoning.index, "summary_index": 0, "delta": delta,
+	})
+}
+
+func (s *webResponsesStream) closeReasoning() error {
+	if s == nil || s.reasoning == nil {
+		return nil
+	}
+	item := s.reasoning
+	text := item.text.String()
+	if err := writeSSE(s.writer, "response.reasoning_summary_text.done", map[string]any{
+		"type": "response.reasoning_summary_text.done", "response_id": s.responseID,
+		"item_id": item.id, "output_index": item.index, "summary_index": 0, "text": text,
+	}); err != nil {
+		return err
+	}
+	part := map[string]any{"type": "summary_text", "text": text}
+	if err := writeSSE(s.writer, "response.reasoning_summary_part.done", map[string]any{
+		"type": "response.reasoning_summary_part.done", "response_id": s.responseID,
+		"item_id": item.id, "output_index": item.index, "summary_index": 0, "part": part,
+	}); err != nil {
+		return err
+	}
+	completed := map[string]any{"id": item.id, "type": "reasoning", "status": "completed", "summary": []any{part}}
+	if err := writeSSE(s.writer, "response.output_item.done", map[string]any{
+		"type": "response.output_item.done", "response_id": s.responseID, "output_index": item.index, "item": completed,
+	}); err != nil {
+		return err
+	}
+	if err := s.completeOutput(item.index, completed); err != nil {
+		return err
+	}
+	s.reasoning = nil
+	return nil
+}
+
+func (s *webResponsesStream) ensureMessage() error {
+	if s.message != nil {
+		return nil
+	}
+	item := &responsesMessageStreamItem{id: newWebID("msg"), index: s.allocateOutputIndex()}
+	s.message = item
+	s.messageCount++
+	if err := writeSSE(s.writer, "response.output_item.added", map[string]any{
+		"type": "response.output_item.added", "response_id": s.responseID, "output_index": item.index,
+		"item": map[string]any{"id": item.id, "type": "message", "role": "assistant", "status": "in_progress", "content": []any{}},
+	}); err != nil {
+		return err
+	}
+	return writeSSE(s.writer, "response.content_part.added", map[string]any{
+		"type": "response.content_part.added", "response_id": s.responseID,
+		"item_id": item.id, "output_index": item.index, "content_index": 0,
+		"part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}, "logprobs": []any{}},
+	})
+}
+
+func (s *webResponsesStream) Annotations(annotations []map[string]any, startIndex int) error {
+	if len(annotations) == 0 {
+		return nil
+	}
+	if err := s.closeReasoning(); err != nil {
+		return err
+	}
+	if err := s.ensureMessage(); err != nil {
+		return err
+	}
+	for i, annotation := range annotations {
+		if err := writeSSE(s.writer, "response.output_text.annotation.added", map[string]any{
+			"type": "response.output_text.annotation.added", "response_id": s.responseID,
+			"item_id": s.message.id, "output_index": s.message.index, "content_index": 0,
+			"annotation_index": startIndex + i, "annotation": responsesURLCitation(annotation),
+		}); err != nil {
+			return err
+		}
+	}
+	s.message.annotations = append(s.message.annotations, annotations...)
+	return nil
+}
+
+func (s *webResponsesStream) closeMessage(finalAnnotations []map[string]any) error {
+	if s == nil || s.message == nil {
+		return nil
+	}
+	item := s.message
+	annotations := item.annotations
+	if len(finalAnnotations) > 0 && s.messageCount == 1 {
+		annotations = finalAnnotations
+	}
+	wireAnnotations := responsesAnnotations(annotations)
+	if wireAnnotations == nil {
+		wireAnnotations = []any{}
+	}
+	text := item.text.String()
+	if err := writeSSE(s.writer, "response.output_text.done", map[string]any{
+		"type": "response.output_text.done", "response_id": s.responseID,
+		"item_id": item.id, "output_index": item.index, "content_index": 0, "text": text, "logprobs": []any{},
+	}); err != nil {
+		return err
+	}
+	part := map[string]any{"type": "output_text", "text": text, "annotations": wireAnnotations, "logprobs": []any{}}
+	if err := writeSSE(s.writer, "response.content_part.done", map[string]any{
+		"type": "response.content_part.done", "response_id": s.responseID,
+		"item_id": item.id, "output_index": item.index, "content_index": 0, "part": part,
+	}); err != nil {
+		return err
+	}
+	completed := map[string]any{
+		"id": item.id, "type": "message", "role": "assistant", "status": "completed", "content": []any{part},
+	}
+	if err := writeSSE(s.writer, "response.output_item.done", map[string]any{
+		"type": "response.output_item.done", "response_id": s.responseID, "output_index": item.index, "item": completed,
+	}); err != nil {
+		return err
+	}
+	if err := s.completeOutput(item.index, completed); err != nil {
+		return err
+	}
+	s.message = nil
+	return nil
+}
+
+func (s *webResponsesStream) HostedSearch(call hostedSearchCall) error {
+	if err := s.closeReasoning(); err != nil {
+		return err
+	}
+	items := xaiHostedSearchOutputItems(parsedChat{HostedSearchCalls: []hostedSearchCall{call}})
+	if len(items) == 0 {
+		return nil
+	}
+	completed := items[0].(map[string]any)
+	index := s.allocateOutputIndex()
+	added := cloneAnyMap(completed)
+	added["status"] = "in_progress"
+	if err := writeSSE(s.writer, "response.output_item.added", map[string]any{
+		"type": "response.output_item.added", "response_id": s.responseID, "output_index": index, "item": added,
+	}); err != nil {
+		return err
+	}
+	eventType := "response.web_search_call.completed"
+	if call.Kind == "x_search" {
+		eventType = "response.x_search_call.completed"
+	}
+	if err := writeSSE(s.writer, eventType, map[string]any{
+		"type": eventType, "response_id": s.responseID, "output_index": index, "item_id": call.ID,
+	}); err != nil {
+		return err
+	}
+	if err := writeSSE(s.writer, "response.output_item.done", map[string]any{
+		"type": "response.output_item.done", "response_id": s.responseID, "output_index": index, "item": completed,
+	}); err != nil {
+		return err
+	}
+	return s.completeOutput(index, completed)
+}
+
+func (s *webResponsesStream) ToolCalls(calls []parsedToolCall) error {
+	if err := s.closeReasoning(); err != nil {
+		return err
+	}
+	for _, call := range calls {
+		index := s.allocateOutputIndex()
+		itemID := newWebID("fc")
+		added := map[string]any{"id": itemID, "type": "function_call", "status": "in_progress", "call_id": call.ID, "name": call.Name, "arguments": ""}
+		if err := writeSSE(s.writer, "response.output_item.added", map[string]any{
+			"type": "response.output_item.added", "response_id": s.responseID, "output_index": index, "item": added,
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(s.writer, "response.function_call_arguments.delta", map[string]any{
+			"type": "response.function_call_arguments.delta", "response_id": s.responseID,
+			"item_id": itemID, "output_index": index, "delta": call.Arguments,
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(s.writer, "response.function_call_arguments.done", map[string]any{
+			"type": "response.function_call_arguments.done", "response_id": s.responseID,
+			"item_id": itemID, "output_index": index, "arguments": call.Arguments,
+		}); err != nil {
+			return err
+		}
+		completed := map[string]any{"id": itemID, "type": "function_call", "status": "completed", "call_id": call.ID, "name": call.Name, "arguments": call.Arguments}
+		if err := writeSSE(s.writer, "response.output_item.done", map[string]any{
+			"type": "response.output_item.done", "response_id": s.responseID, "output_index": index, "item": completed,
+		}); err != nil {
+			return err
+		}
+		if err := s.completeOutput(index, completed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *webResponsesStream) Finish(parsed *parsedChat) error {
+	if s == nil || parsed == nil {
+		return nil
+	}
+	if err := s.closeReasoning(); err != nil {
+		return err
+	}
+	if err := s.closeMessage(parsed.Annotations); err != nil {
+		return err
+	}
+	allReasoning := parsed.Reasoning.String()
+	streamedReasoning := s.streamedReasoning.String()
+	lateReasoning := ""
+	if strings.HasPrefix(allReasoning, streamedReasoning) {
+		lateReasoning = allReasoning[len(streamedReasoning):]
+	} else if allReasoning != streamedReasoning {
+		lateReasoning = allReasoning
+	}
+	if lateReasoning != "" {
+		if err := s.appendCompletedReasoning(lateReasoning); err != nil {
+			return err
+		}
+	}
+	if s.messageCount == 0 && len(parsed.ToolCalls) == 0 {
+		if err := s.ensureMessage(); err != nil {
+			return err
+		}
+		if err := s.closeMessage(parsed.Annotations); err != nil {
+			return err
+		}
+	}
+	for index, item := range s.outputs {
+		if item == nil {
+			return fmt.Errorf("Responses output_index %d 未完成", index)
+		}
+	}
+	parsed.ResponseOutput = append([]any(nil), s.outputs...)
+	return nil
+}
+
+func (s *webResponsesStream) appendCompletedReasoning(text string) error {
+	index := s.allocateOutputIndex()
+	id := newWebID("rs")
+	added := map[string]any{"id": id, "type": "reasoning", "status": "in_progress", "summary": []any{}}
+	if err := writeSSE(s.writer, "response.output_item.added", map[string]any{
+		"type": "response.output_item.added", "response_id": s.responseID, "output_index": index, "item": added,
+	}); err != nil {
+		return err
+	}
+	part := map[string]any{"type": "summary_text", "text": text}
+	if err := writeSSE(s.writer, "response.reasoning_summary_part.added", map[string]any{
+		"type": "response.reasoning_summary_part.added", "response_id": s.responseID,
+		"item_id": id, "output_index": index, "summary_index": 0,
+		"part": map[string]any{"type": "summary_text", "text": ""},
+	}); err != nil {
+		return err
+	}
+	if err := writeSSE(s.writer, "response.reasoning_summary_text.done", map[string]any{
+		"type": "response.reasoning_summary_text.done", "response_id": s.responseID,
+		"item_id": id, "output_index": index, "summary_index": 0, "text": text,
+	}); err != nil {
+		return err
+	}
+	if err := writeSSE(s.writer, "response.reasoning_summary_part.done", map[string]any{
+		"type": "response.reasoning_summary_part.done", "response_id": s.responseID,
+		"item_id": id, "output_index": index, "summary_index": 0, "part": part,
+	}); err != nil {
+		return err
+	}
+	completed := map[string]any{"id": id, "type": "reasoning", "status": "completed", "summary": []any{part}}
+	if err := writeSSE(s.writer, "response.output_item.done", map[string]any{
+		"type": "response.output_item.done", "response_id": s.responseID, "output_index": index, "item": completed,
+	}); err != nil {
+		return err
+	}
+	return s.completeOutput(index, completed)
+}
+
+func cloneAnyMap(value map[string]any) map[string]any {
+	cloned := make(map[string]any, len(value))
+	for key, item := range value {
+		cloned[key] = item
+	}
+	return cloned
+}

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -676,11 +676,13 @@ func TestGrokRenderCitationBecomesMarkdownAndAnnotation(t *testing.T) {
 	}
 	tokenData, _ := json.Marshal(tokenFrame)
 	kind, delta, err := parseUpstreamFrame(tokenData, parsed)
-	if err != nil || kind != "text" || delta != "Answer [[1]](https://example.com)" || len(parsed.Annotations) != 1 {
+	wantDelta := `Answer[[1]](https://example.com)`
+	if err != nil || kind != "text" || delta != wantDelta || len(parsed.Annotations) != 1 {
 		t.Fatalf("kind=%q delta=%q annotations=%#v err=%v", kind, delta, parsed.Annotations, err)
 	}
 	annotation := parsed.Annotations[0]
-	if annotation["title"] != "Example" || annotation["start_index"] != 6 || annotation["end_index"] != len(delta) {
+	// xAI: title is citation display number; indices cover the [[N]](url) span.
+	if annotation["title"] != "1" || annotation["start_index"] != 6 || annotation["end_index"] != len(wantDelta) {
 		t.Fatalf("annotation = %#v", annotation)
 	}
 }

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -681,9 +681,45 @@ func TestGrokRenderCitationBecomesMarkdownAndAnnotation(t *testing.T) {
 		t.Fatalf("kind=%q delta=%q annotations=%#v err=%v", kind, delta, parsed.Annotations, err)
 	}
 	annotation := parsed.Annotations[0]
-	// title is page name from search results; indices cover the [[N]](url) span.
-	if annotation["title"] != "Example" || annotation["start_index"] != 6 || annotation["end_index"] != len(wantDelta) {
+	// Responses title is the visible citation number; source title remains
+	// available for the Chat Completions nested annotation.
+	if annotation["title"] != "1" || annotation["source_title"] != "Example" || annotation["start_index"] != 6 || annotation["end_index"] != len(wantDelta) {
 		t.Fatalf("annotation = %#v", annotation)
+	}
+}
+
+func TestGrokRenderCitationUsesCharacterOffsets(t *testing.T) {
+	parsed := &parsedChat{cardCache: map[string]map[string]any{
+		"cite_1": {"url": "https://example.com"},
+	}}
+	token := `中文<grok:render card_id="cite_1" card_type="citation" type="render_inline_citation"></grok:render>`
+	cleaned := cleanChatToken(parsed, token)
+	parsed.Text.WriteString(cleaned)
+	if len(parsed.Annotations) != 1 {
+		t.Fatalf("annotations = %#v", parsed.Annotations)
+	}
+	annotation := parsed.Annotations[0]
+	if annotation["start_index"] != 2 || annotation["end_index"] != 28 {
+		t.Fatalf("annotation uses byte offsets: %#v", annotation)
+	}
+}
+
+func TestParsedChatTextCharacterCountTracksAllWrites(t *testing.T) {
+	parsed := &parsedChat{}
+	parsed.appendText("中文")
+	if got := parsed.textCharacterLen(); got != 2 {
+		t.Fatalf("appendText character length = %d, want 2", got)
+	}
+
+	// Direct builder writes must use the same counter as production helpers.
+	parsed.Text.WriteString("🙂")
+	if got := parsed.textCharacterLen(); got != 3 {
+		t.Fatalf("direct write character length = %d, want 3", got)
+	}
+
+	parsed.resetText("a界")
+	if got := parsed.textCharacterLen(); got != 2 {
+		t.Fatalf("resetText character length = %d, want 2", got)
 	}
 }
 

--- a/backend/internal/infra/provider/web/tools_test.go
+++ b/backend/internal/infra/provider/web/tools_test.go
@@ -681,8 +681,8 @@ func TestGrokRenderCitationBecomesMarkdownAndAnnotation(t *testing.T) {
 		t.Fatalf("kind=%q delta=%q annotations=%#v err=%v", kind, delta, parsed.Annotations, err)
 	}
 	annotation := parsed.Annotations[0]
-	// xAI: title is citation display number; indices cover the [[N]](url) span.
-	if annotation["title"] != "1" || annotation["start_index"] != 6 || annotation["end_index"] != len(wantDelta) {
+	// title is page name from search results; indices cover the [[N]](url) span.
+	if annotation["title"] != "Example" || annotation["start_index"] != 6 || annotation["end_index"] != len(wantDelta) {
 		t.Fatalf("annotation = %#v", annotation)
 	}
 }


### PR DESCRIPTION
## 这是做什么的 / What this does

**一句话：** 修 **Web 上游**（grok.com 网页/App 那条渠道）联网搜索后，OpenAI 兼容 API **拿不到引用/搜索结果** 的问题。

Grok2api 有 **三个上游渠道**，本 PR **只动 Web**：

| 上游 | 作用 | 本 PR |
|---|---|---|
| **Web** (`grok_web`) | grok.com 网页/App 会话（mgw WebSocket） | ✅ **改这里** |
| **Build** (`grok_build`) | Grok Build / 工程向 | ❌ 不动 |
| **Console** (`grok_console`) | console.x.ai API 向 | ❌ 不动 |

客户端走 `grok-chat-fast` 等 **Web 模型** 时，上游会跑 web/X 搜索，但引用帧协议已变成 Gateway 的 `render_citation` + `tool_*`；旧解析对不上 → 答案有、**annotations / citations / 搜索调用详情空**。本 PR 把 Web 渠道解析与出站字段重新对齐，让支持「搜索来源展示」的客户端能正常显示。

**EN one-liner:** Fix missing search citations for the **Web** upstream only (one of three: Build / Web / Console). Map current mgw Gateway citation frames into OpenAI/xAI-compatible client fields.

---

## 功能说明 / Features

对 **Web 渠道** 请求（Chat Completions / Responses，流式与非流式）：

1. **解析上游 mgw WS**
   - `tool_usage_card`（web_search / x_search 开始）
   - `tool_result`（网页 / X 帖结果池）
   - **`render_citation`**（文内引用实时帧；**不是**只靠旧 `grok:render` / card）

2. **发给客户端的能力**

   | 能力 | 形态 |
   |---|---|
   | 文内可点引用 | 正文 `[[N]](url)`（可用 `include: no_inline_citations` 关掉） |
   | 结构化角标 | Chat：**嵌套** `url_citation`；Responses：**扁平** + 流式 `annotation.added` |
   | 完整来源 URL 列表 | 顶层 **`citations: string[]`**（**不**再发非标 `search_sources`） |
   | 搜索调用详情（Responses） | `web_search_call` / `x_search_call`，含 query；`action.sources` 为 `{type:"url", url, title?}` |
   | 角标标题 | **优先页面/帖子标题**；没有则回退 `"1"`/`"2"` |
   | 服务端 tool 计数 | 非流 + **Chat 流收尾 chunk** 均有 `server_side_tool_usage` |

3. **明确不改**
   - Build / Console 上游逻辑
   - 其它 provider 目录

---

## 为什么只改 Web / Why Web only

- 引用丢包发生在 **Web Gateway WS**（`/ws/mgw/`）新帧格式。
- Build / Console 有各自的上游协议与引用路径，**不在本次范围**。
- 代码面：`backend/internal/infra/provider/web/*`（+ 少量 conversation `include` 选项）。

---

## Test plan / 测试计划

- [x] `go test ./internal/infra/provider/web/`（解析、annotations 形、title 回退、`type:url`、chat 流 usage）
- [x] 实机 Web 模型（如 `grok-chat-fast`）四路径：chat/responses × 流/非流
  - [x] 正文 `[[N]]`、页面 title annotations、`citations`
  - [x] Responses `*_search_call` + `sources[].type=="url"`
  - [x] 无 wire 上的 `search_sources`
  - [ ] 部署含 chat 流 `server_side_tool_usage` 的构建后再扫一眼流式收尾
- [ ] 本 PR CI

---

## Risk / 风险

**中等，但范围清晰：** 仅 Web 出站/解析；Build、Console 用户路径不受影响。  
若客户端曾依赖已移除的 `search_sources`，需改读 `citations` 或 `web_search_call.action.sources`。

---

## Commits

```
fix(web): emit server_side_tool_usage on chat stream final chunk
fix(web): fall back annotation title to citation index
feat(web): change annotation title to page/source title
fix(web): add type:url on web_search_call action.sources
feat(web): map mgw tools to xAI web_search_call/x_search_call
fix(web): align citations with xAI Responses/Chat format
fix(web): align citation output with OpenAI chat/responses shapes
fix(web): parse Gateway render_citation and search tool chunks
```
