### PR TITLE
fix: honor required search tools across providers

### DIFF
--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -628,10 +628,66 @@ func (s *Service) selectConversationRoute(routes []modeldomain.Route, key client
 // rendezvous score. Provider priority remains stable, while a session seed keeps
 // Codex/Claude continuations on the same target without global mutable state.
 func orderConversationRouteTargets(routes []modeldomain.Route, seed string) []modeldomain.Route {
+	return orderConversationRouteTargetsForTools(routes, seed, conversationToolRequirements{})
+}
+
+type conversationToolRequirements struct {
+	xSearch           bool
+	requiredWebSearch bool
+}
+
+func parseConversationToolRequirements(body []byte) conversationToolRequirements {
+	var payload struct {
+		Tools      []map[string]any `json:"tools"`
+		ToolChoice any              `json:"tool_choice"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		return conversationToolRequirements{}
+	}
+	var requirements conversationToolRequirements
+	hasWebSearch := false
+	for _, tool := range payload.Tools {
+		typeName, _ := tool["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(typeName)) {
+		case "x_search":
+			requirements.xSearch = true
+		case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
+			hasWebSearch = true
+		}
+	}
+	required := false
+	switch choice := payload.ToolChoice.(type) {
+	case string:
+		required = strings.EqualFold(strings.TrimSpace(choice), "required")
+	case map[string]any:
+		typeName, _ := choice["type"].(string)
+		switch strings.ToLower(strings.TrimSpace(typeName)) {
+		case "required", "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
+			required = true
+		}
+	}
+	requirements.requiredWebSearch = hasWebSearch && required
+	return requirements
+}
+
+func filterConversationRoutesForTools(routes []modeldomain.Route, requirements conversationToolRequirements) []modeldomain.Route {
+	if !requirements.xSearch {
+		return routes
+	}
+	filtered := make([]modeldomain.Route, 0, len(routes))
+	for _, route := range routes {
+		if route.Provider != accountdomain.ProviderWeb {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func orderConversationRouteTargetsForTools(routes []modeldomain.Route, seed string, requirements conversationToolRequirements) []modeldomain.Route {
 	ordered := append([]modeldomain.Route(nil), routes...)
 	sort.SliceStable(ordered, func(left, right int) bool {
-		leftPriority := routeProviderPriority(ordered[left].Provider)
-		rightPriority := routeProviderPriority(ordered[right].Provider)
+		leftPriority := routeProviderPriorityForTools(ordered[left], requirements)
+		rightPriority := routeProviderPriorityForTools(ordered[right], requirements)
 		if leftPriority != rightPriority {
 			return leftPriority < rightPriority
 		}
@@ -643,6 +699,42 @@ func orderConversationRouteTargets(routes []modeldomain.Route, seed string) []mo
 		return ordered[left].ID < ordered[right].ID
 	})
 	return ordered
+}
+
+func routeProviderPriorityForTools(route modeldomain.Route, requirements conversationToolRequirements) int {
+	providerValue := route.Provider
+	publicModel := modeldomain.ExternalPublicID(providerValue, route.PublicID)
+	if publicModel == "" {
+		publicModel = modeldomain.DisplayUpstreamModel(providerValue, route.UpstreamModel)
+		if separator := strings.IndexByte(publicModel, '/'); separator >= 0 {
+			publicModel = publicModel[separator+1:]
+		}
+	}
+	if (requirements.xSearch || requirements.requiredWebSearch) && strings.EqualFold(strings.TrimSpace(publicModel), "grok-4.5") {
+		switch providerValue {
+		case accountdomain.ProviderConsole:
+			return 0
+		case accountdomain.ProviderBuild:
+			return 1
+		case accountdomain.ProviderWeb:
+			return 2
+		default:
+			return 3
+		}
+	}
+	if requirements.requiredWebSearch {
+		switch providerValue {
+		case accountdomain.ProviderBuild:
+			return 0
+		case accountdomain.ProviderConsole:
+			return 1
+		case accountdomain.ProviderWeb:
+			return 2
+		default:
+			return 3
+		}
+	}
+	return routeProviderPriority(providerValue)
 }
 
 func routeTargetScore(seed string, routeID uint64) uint64 {
@@ -767,8 +859,14 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	route := fallbackRoute
 	orderedRoutes := eligibleRoutes
 	if routeErr == nil {
-		orderedRoutes = orderConversationRouteTargets(eligibleRoutes, routeTargetSeed(input))
-		route = orderedRoutes[0]
+		toolRequirements := parseConversationToolRequirements(input.Body)
+		orderedRoutes = filterConversationRoutesForTools(eligibleRoutes, toolRequirements)
+		if len(orderedRoutes) == 0 {
+			routeErr = ErrConversationUnsupported
+		} else {
+			orderedRoutes = orderConversationRouteTargetsForTools(orderedRoutes, routeTargetSeed(input), toolRequirements)
+			route = orderedRoutes[0]
+		}
 	}
 	accountScope := input.ClientKey.AccountScope()
 	var preselectedSession *selectionSession

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -845,6 +845,38 @@ func TestOrderConversationRouteTargetsIsSessionStableAndProviderScoped(t *testin
 	}
 }
 
+func TestConversationToolRequirementsRouteByProviderCapability(t *testing.T) {
+	routes := []modeldomain.Route{
+		{ID: 10, Provider: account.ProviderBuild},
+		{ID: 20, Provider: account.ProviderWeb},
+		{ID: 30, Provider: account.ProviderConsole},
+	}
+	requirements := parseConversationToolRequirements([]byte(`{
+		"tools":[{"type":"web_search"},{"type":"x_search"}],
+		"tool_choice":"required"
+	}`))
+	if !requirements.xSearch || !requirements.requiredWebSearch {
+		t.Fatalf("requirements = %#v", requirements)
+	}
+	filtered := filterConversationRoutesForTools(routes, requirements)
+	if len(filtered) != 2 || filtered[0].Provider != account.ProviderBuild || filtered[1].Provider != account.ProviderConsole {
+		t.Fatalf("x_search routes = %#v", filtered)
+	}
+	ordered := orderConversationRouteTargetsForTools(routes, "session", conversationToolRequirements{requiredWebSearch: true})
+	if ordered[0].Provider != account.ProviderBuild || ordered[1].Provider != account.ProviderConsole || ordered[2].Provider != account.ProviderWeb {
+		t.Fatalf("required web_search order = %#v", ordered)
+	}
+	searchRoutes := []modeldomain.Route{
+		{ID: 10, PublicID: "Build/grok-4.5", Provider: account.ProviderBuild, UpstreamModel: "grok-4.5"},
+		{ID: 20, PublicID: "Web/grok-4.5", Provider: account.ProviderWeb, UpstreamModel: "grok-4.5"},
+		{ID: 30, PublicID: "Console/grok-4.5", Provider: account.ProviderConsole, UpstreamModel: "grok-4.5"},
+	}
+	ordered = orderConversationRouteTargetsForTools(searchRoutes, "session", conversationToolRequirements{xSearch: true})
+	if ordered[0].Provider != account.ProviderConsole || ordered[1].Provider != account.ProviderBuild || ordered[2].Provider != account.ProviderWeb {
+		t.Fatalf("grok-4.5 search order = %#v", ordered)
+	}
+}
+
 func TestRouteTargetSeedUsesSessionSignalsAndSoftMessageAnchor(t *testing.T) {
 	base := Input{
 		RequestID: "request-a", ClientKey: clientkey.Key{ID: 17},

--- a/backend/internal/infra/provider/cli/responses_cache_route_test.go
+++ b/backend/internal/infra/provider/cli/responses_cache_route_test.go
@@ -172,7 +172,7 @@ func TestFilterBuildPromptCacheResponseJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	if strings.Contains(text, `"id":"internal"`) || strings.Contains(text, `"type":"x_search"`) || !strings.Contains(text, `"id":"client_custom"`) || !strings.Contains(text, `"id":"client"`) || !strings.Contains(text, `"id":"msg_1"`) || !strings.Contains(text, `"cost_in_usd_ticks":9007199254740993`) {
+	if strings.Contains(text, `"id":"internal"`) || !strings.Contains(text, `"type":"x_search_call"`) || !strings.Contains(text, `"status":"completed"`) || !strings.Contains(text, `"id":"client_custom"`) || !strings.Contains(text, `"id":"client"`) || !strings.Contains(text, `"id":"msg_1"`) || !strings.Contains(text, `"cost_in_usd_ticks":9007199254740993`) {
 		t.Fatalf("filtered response = %s", text)
 	}
 	if response.ContentLength != int64(len(data)) || response.Header.Get("Content-Length") != strconv.Itoa(len(data)) {
@@ -228,7 +228,7 @@ func TestFilterBuildPromptCacheResponseStream(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	if strings.Contains(text, "x_semantic_search") || strings.Contains(text, "ctc_1") || strings.Contains(text, `"type":"x_search"`) {
+	if strings.Contains(text, "x_semantic_search") || strings.Contains(text, "ctc_1") || !strings.Contains(text, `"type":"x_search_call"`) || !strings.Contains(text, `"status":"completed"`) {
 		t.Fatalf("internal x_search trace leaked:\n%s", text)
 	}
 	if !strings.Contains(text, `"output_index":1`) || !strings.Contains(text, `"id":"msg_1"`) {

--- a/backend/internal/infra/provider/cli/responses_x_search_filter.go
+++ b/backend/internal/infra/provider/cli/responses_x_search_filter.go
@@ -17,7 +17,10 @@ type buildXSearchResponseFilter struct {
 	injectedToolTypes    map[string]struct{}
 	droppedOutputIndexes map[int]struct{}
 	droppedItemIDs       map[string]struct{}
+	xSearchOutputIndex   *int
 }
+
+const syntheticXSearchCallID = "x_search_call_grok2api"
 
 func newBuildXSearchResponseFilter(route buildPromptCacheRoute) *buildXSearchResponseFilter {
 	return &buildXSearchResponseFilter{
@@ -106,7 +109,20 @@ func (f *buildXSearchResponseFilter) filterEvent(data []byte) ([]byte, bool, err
 		return data, true, nil
 	}
 	if item := payload["item"]; !isEmptyJSON(item) && f.isInternalCall(item) {
-		f.recordDroppedItem(payload, item)
+		index, hasIndex := rawJSONInt(payload["output_index"])
+		if f.xSearchOutputIndex == nil && hasIndex {
+			f.xSearchOutputIndex = &index
+		}
+		f.recordDroppedItem(payload, item, f.xSearchOutputIndex == nil || !hasIndex || index != *f.xSearchOutputIndex)
+		if f.xSearchOutputIndex != nil && hasIndex && index == *f.xSearchOutputIndex {
+			status := "in_progress"
+			if strings.TrimSpace(rawJSONString(payload["type"])) == "response.output_item.done" {
+				status = "completed"
+			}
+			payload["item"] = mustJSON(syntheticXSearchCall(status))
+			filtered, err := json.Marshal(payload)
+			return filtered, true, err
+		}
 		return nil, false, nil
 	}
 	if err := f.filterEnvelope(payload); err != nil {
@@ -155,14 +171,27 @@ func (f *buildXSearchResponseFilter) filterOutput(envelope map[string]json.RawMe
 		return fmt.Errorf("解析 Grok Build Responses output 失败")
 	}
 	filtered := make([]json.RawMessage, 0, len(output))
+	syntheticAdded := false
 	for _, rawItem := range output {
 		if f.isInternalCall(rawItem) {
+			if !syntheticAdded {
+				filtered = append(filtered, mustJSON(syntheticXSearchCall("completed")))
+				syntheticAdded = true
+			}
 			continue
 		}
 		filtered = append(filtered, rawItem)
 	}
 	envelope["output"] = mustJSON(filtered)
 	return nil
+}
+
+func syntheticXSearchCall(status string) map[string]any {
+	return map[string]any{
+		"type":   "x_search_call",
+		"id":     syntheticXSearchCallID,
+		"status": status,
+	}
 }
 
 func (f *buildXSearchResponseFilter) filterTools(envelope map[string]json.RawMessage) error {
@@ -237,8 +266,8 @@ func isBuildInternalXSearchToolName(name string) bool {
 	}
 }
 
-func (f *buildXSearchResponseFilter) recordDroppedItem(payload map[string]json.RawMessage, rawItem json.RawMessage) {
-	if index, ok := rawJSONInt(payload["output_index"]); ok {
+func (f *buildXSearchResponseFilter) recordDroppedItem(payload map[string]json.RawMessage, rawItem json.RawMessage, dropOutputIndex bool) {
+	if index, ok := rawJSONInt(payload["output_index"]); ok && dropOutputIndex {
 		f.droppedOutputIndexes[index] = struct{}{}
 	}
 	var item buildXSearchResponseItem

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -265,7 +265,7 @@ func TestNormalizeRequestAppliesConsoleCompatibilityBoundary(t *testing.T) {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload["response_format"] != nil || payload["reasoning"] != nil || payload["tool_choice"] != "auto" {
+	if payload["response_format"] != nil || payload["reasoning"] != nil || payload["tool_choice"] != "required" {
 		t.Fatalf("payload boundary = %#v", payload)
 	}
 	include, _ := payload["include"].([]any)

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -230,12 +230,14 @@ func normalizeConsoleTools(payload map[string]any) bool {
 				clean["enable_image_understanding"] = enabled
 			}
 			result = append(result, clean)
+			retainedClientTools = true
 		case "x_search":
 			clean := map[string]any{"type": "x_search", "enable_video_understanding": true}
 			if enabled, ok := tool["enable_video_understanding"].(bool); ok {
 				clean["enable_video_understanding"] = enabled
 			}
 			result = append(result, clean)
+			retainedClientTools = true
 		case "function":
 			name, _ := tool["name"].(string)
 			if strings.TrimSpace(name) == "" {

--- a/frontend/src/features/creative-console/creative-console-api.ts
+++ b/frontend/src/features/creative-console/creative-console-api.ts
@@ -76,7 +76,10 @@ export async function createChatResponse(input: {
   const tools: Array<{ type: string }> = [];
   if (input.webSearch) tools.push({ type: "web_search" });
   if (input.xSearch) tools.push({ type: "x_search" });
-  if (tools.length > 0) body.tools = tools;
+  if (tools.length > 0) {
+    body.tools = tools;
+    body.tool_choice = "required";
+  }
   return publicResponsesStream(input.apiKey, body, input.onUpdate, input.signal);
 }
 


### PR DESCRIPTION
## 中文说明

### 修复内容

- Creative Console 开启 Web/X 搜索时发送 `tool_choice: "required"`，避免模型自行跳过搜索。
- Console 请求归一化保留 Hosted `web_search` / `x_search` 的 `required` 语义，不再错误降级为 `auto`。
- 增加搜索能力感知路由：X 搜索排除不支持它的 Web Provider；强制 Web 搜索优先选择支持搜索的 Provider。
- `grok-4.5` 搜索请求优先选择 Console，因为实测 Build 即使收到 `required` 仍可能只返回文本、不执行搜索。
- Build 继续隐藏 `x_keyword_search`、`x_semantic_search` 等内部实现细节，但合成只读的标准 `x_search_call` 状态节点，让客户端确认搜索确实执行过。

### 问题原因

Creative Console 原先只声明搜索工具，没有指定 `tool_choice`，模型可以选择不调用。Console 归一化又没有把 Hosted Search 视为保留下来的客户端工具，导致 `required` 被改回 `auto`。此外，原有 Provider 回退顺序不感知工具能力，X 搜索可能进入 Web，而 `grok-4.5` 强制搜索也可能先落到当前不会执行搜索的 Build。

Build 响应过滤器会隐藏内部 X 搜索调用。该设计避免泄漏上游实现细节，但也让客户端无法区分“执行过搜索”和“没有搜索”。因此本 PR 只合成通用状态节点，不暴露关键词、用户搜索或线程抓取等内部数据。

### 路由行为

- X 搜索：排除 Web Provider。
- 强制 Web 搜索：`Build → Console → Web`。
- `grok-4.5` 强制 Web/X 搜索：`Console → Build → Web`。

`grok-4.5` 的顺序是根据实际兼容性测试增加的处理。长期方案更适合建立 Provider/模型级工具能力元数据，替代模型名特判。

### 验证

- `go test -run TestConversationToolRequirementsRouteByProviderCapability ./internal/application/gateway`
- `go test -run 'TestFilterBuildPromptCacheResponse(JSON|Stream)' ./internal/infra/provider/cli`
- `go test -run TestNormalizeRequestAppliesConsoleCompatibilityBoundary ./internal/infra/provider/console`
- 使用仓库 Dockerfile 完成前端 TypeScript 与 Vite 生产构建。

实测同等 `required` 请求下，Build 的 `grok-4.5` 没有产生搜索调用；Console 可以完成原生 Web/X 搜索。Web Provider 不能执行 X Search，因此路由层会将其排除。

---

## Summary

- send `tool_choice: "required"` when Creative Console search switches are enabled
- preserve required hosted `web_search` and `x_search` tools in Console request normalization
- make conversation routing aware of search capabilities and keep X search away from Web routes
- prefer Console for `grok-4.5` search requests because Build currently ignores required hosted search
- expose a synthetic completed `x_search_call` after filtering Build internal search implementation details

## Problem

Creative Console previously declared search tools without a `tool_choice`, so the upstream model could skip them. Console normalization also treated hosted search tools as if no client tool had survived and downgraded `required` to `auto`. In addition, provider fallback was not capability-aware: Web cannot execute X search, and a required `grok-4.5` search could land on Build even though that route currently returns plain text without a search call.

The Build response filter intentionally hides internal calls such as `x_keyword_search` and `x_semantic_search`, but that also made a successful X search indistinguishable from no search. This change retains the filtering and emits only a provider-neutral, read-only `x_search_call` status item.

## Routing behavior

- X search excludes Web routes.
- Required Web search prefers Build, then Console, then Web.
- `grok-4.5` with required Web or X search prefers Console, then Build, then Web.

The `grok-4.5` ordering is an observed compatibility workaround. A longer-term model/provider capability registry would be preferable to a model-name special case.

## Verification

- `go test -run TestConversationToolRequirementsRouteByProviderCapability ./internal/application/gateway`
- `go test -run 'TestFilterBuildPromptCacheResponse(JSON|Stream)' ./internal/infra/provider/cli`
- `go test -run TestNormalizeRequestAppliesConsoleCompatibilityBoundary ./internal/infra/provider/console`
- frontend TypeScript and Vite production build via the repository Dockerfile

Upstream validation with equivalent required requests showed Build `grok-4.5` returning no search calls, while Console completed native Web and X searches. Web remains excluded from X search because it cannot execute that hosted tool.