### PR TITLE
feat(console): 注册 grok-imagine-video-1.5 并支持原生 1080p

### DIFF
--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -340,7 +340,7 @@ func (s *Service) runVideoJob(parent context.Context, job media.Job, route model
 	}
 	lastProgress := job.Progress
 	result, err := adapter.GenerateVideo(ctx, provider.VideoRequest{
-		Credential: lease.Credential, Billing: lease.Billing, JobID: job.ID, Prompt: job.Prompt, Duration: job.Seconds, AspectRatio: job.Size, Resolution: job.Quality,
+		Credential: lease.Credential, Billing: lease.Billing, JobID: job.ID, UpstreamModel: route.UpstreamModel, Prompt: job.Prompt, Duration: job.Seconds, AspectRatio: job.Size, Resolution: job.Quality,
 		ReferenceURLs: referenceURLs,
 		Progress: func(value int) {
 			value = min(99, max(1, value))

--- a/backend/internal/domain/audit/pricing.go
+++ b/backend/internal/domain/audit/pricing.go
@@ -317,6 +317,13 @@ func EstimateOfficialVideoCost(model, resolution string, seconds int) (PricingRe
 		ticksPerSecond = 800_000_000
 	case "720p":
 		ticksPerSecond = 1_400_000_000
+	case "1080p":
+		// 仅 grok-imagine-video-1.5 起原生支持 1080p:x.ai 官方 $0.25/s(1e10 ticks=$1)。
+		// 基础 grok-imagine-video(v1)无 1080p 档(media.go 亦按模型拦截),此处返回 false 保持一致。
+		if baseModel == "grok-imagine-video" {
+			return PricingResult{}, false
+		}
+		ticksPerSecond = 2_500_000_000
 	default:
 		return PricingResult{}, false
 	}
@@ -356,6 +363,8 @@ func ReconstructOfficialCost(model string, inputTokens, cachedInputTokens, outpu
 		return reconstructVideoCost("grok-imagine-video-1.5", "480p", outputSeconds)
 	case "grok-imagine-video-1.5-720p":
 		return reconstructVideoCost("grok-imagine-video-1.5", "720p", outputSeconds)
+	case "grok-imagine-video-1.5-1080p":
+		return reconstructVideoCost("grok-imagine-video-1.5", "1080p", outputSeconds)
 	default:
 		return reconstructTextCost(normalized, inputTokens, cachedInputTokens, outputTokens, contextInputTokens)
 	}

--- a/backend/internal/domain/audit/pricing_test.go
+++ b/backend/internal/domain/audit/pricing_test.go
@@ -153,6 +153,13 @@ func TestEstimateOfficialVideoCost(t *testing.T) {
 	if !ok || result.Model != "grok-imagine-video-1.5-720p" || result.CostInUSDTicks != 8_400_000_000 {
 		t.Fatalf("1.5 720p video result = %#v, ok = %v", result, ok)
 	}
+	result, ok = EstimateOfficialVideoCost("grok-imagine-video-1.5", "1080p", 4)
+	if !ok || result.Model != "grok-imagine-video-1.5-1080p" || result.CostInUSDTicks != 10_000_000_000 {
+		t.Fatalf("1.5 1080p video result = %#v, ok = %v", result, ok)
+	}
+	if result, ok = EstimateOfficialVideoCost("grok-imagine-video", "1080p", 6); ok || result.CostInUSDTicks != 0 {
+		t.Fatalf("base v1 must not price 1080p = %#v, ok = %v", result, ok)
+	}
 	result, ok = EstimateOfficialVideoCost("Build/grok-imagine-video-1.5", "480p", 1)
 	if !ok || result.Model != "grok-imagine-video-1.5-480p" || result.CostInUSDTicks != 800_000_000 {
 		t.Fatalf("prefixed 1.5 video result = %#v, ok = %v", result, ok)
@@ -181,5 +188,9 @@ func TestReconstructOfficialCostReturnsExactStoredFormulaInputs(t *testing.T) {
 	videoResult, ok := ReconstructOfficialCost("grok-imagine-video-1.5-720p", 0, 0, 0, 0, 1, 0, 6)
 	if !ok || videoResult.CostInUSDTicks != 8_400_000_000 || videoResult.Components[0].Unit != PricingUnitSecond {
 		t.Fatalf("video reconstruction = %#v, %v", videoResult, ok)
+	}
+	video1080, ok := ReconstructOfficialCost("grok-imagine-video-1.5-1080p", 0, 0, 0, 0, 1, 0, 4)
+	if !ok || video1080.CostInUSDTicks != 10_000_000_000 || video1080.Components[0].Unit != PricingUnitSecond {
+		t.Fatalf("1080p video reconstruction = %#v, %v", video1080, ok)
 	}
 }

--- a/backend/internal/infra/persistence/relational/model_repository.go
+++ b/backend/internal/infra/persistence/relational/model_repository.go
@@ -752,7 +752,7 @@ func discoveredRouteDefaults(provider account.Provider, upstreamModel string) (s
 			// Discovery only needs one existing managed capability to remain
 			// idempotent and must never synthesize a Responses route.
 			return upstreamModel, model.CapabilityImage
-		case "grok-imagine-video":
+		case "grok-imagine-video", "grok-imagine-video-1.5":
 			return upstreamModel, model.CapabilityVideo
 		default:
 			return upstreamModel, model.CapabilityResponses

--- a/backend/internal/infra/provider/console/catalog.go
+++ b/backend/internal/infra/provider/console/catalog.go
@@ -38,6 +38,7 @@ var mediaCatalog = []struct {
 	{PublicID: "grok-imagine-image-quality", UpstreamModel: "grok-imagine-image-quality", Capabilities: []modeldomain.Capability{modeldomain.CapabilityImage, modeldomain.CapabilityImageEdit}},
 	{PublicID: "grok-imagine-image", UpstreamModel: "grok-imagine-image", Capabilities: []modeldomain.Capability{modeldomain.CapabilityImage, modeldomain.CapabilityImageEdit}},
 	{PublicID: "grok-imagine-video", UpstreamModel: "grok-imagine-video", Capabilities: []modeldomain.Capability{modeldomain.CapabilityVideo}},
+	{PublicID: "grok-imagine-video-1.5", UpstreamModel: "grok-imagine-video-1.5", Capabilities: []modeldomain.Capability{modeldomain.CapabilityVideo}},
 }
 
 // Effort-suffixed aliases only include levels each Provider/model combination

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -52,6 +52,7 @@ func TestCatalogContainsAllConsoleModelsAndAliases(t *testing.T) {
 		{publicID: "Console/grok-imagine-image", capability: modeldomain.CapabilityImage}:               "grok-imagine-image",
 		{publicID: "Console/grok-imagine-image", capability: modeldomain.CapabilityImageEdit}:           "grok-imagine-image",
 		{publicID: "Console/grok-imagine-video", capability: modeldomain.CapabilityVideo}:               "grok-imagine-video",
+		{publicID: "Console/grok-imagine-video-1.5", capability: modeldomain.CapabilityVideo}:           "grok-imagine-video-1.5",
 	}
 	routes := Routes()
 	if len(routes) != len(expected) {

--- a/backend/internal/infra/provider/console/media.go
+++ b/backend/internal/infra/provider/console/media.go
@@ -394,20 +394,32 @@ func trustedConsoleImageHost(host string) bool {
 }
 
 func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoRequest) (provider.VideoResult, error) {
-	if !ResolveMedia("grok-imagine-video", modeldomain.CapabilityVideo) {
+	videoModel := strings.TrimSpace(request.UpstreamModel)
+	if videoModel == "" {
+		videoModel = "grok-imagine-video"
+	}
+	if !ResolveMedia(videoModel, modeldomain.CapabilityVideo) {
 		return provider.VideoResult{}, errors.New("Console 视频模型未注册")
 	}
 	if len(request.ReferenceURLs) > consoleMaxVideoImages {
-		return provider.VideoResult{}, fmt.Errorf("Console grok-imagine-video 最多支持 1 张首图，当前为 %d 张", len(request.ReferenceURLs))
+		return provider.VideoResult{}, fmt.Errorf("Console %s 最多支持 %d 张首图，当前为 %d 张", videoModel, consoleMaxVideoImages, len(request.ReferenceURLs))
 	}
 	if request.Duration < 1 || request.Duration > 15 {
 		return provider.VideoResult{}, errors.New("duration 必须在 1 到 15 秒之间")
 	}
-	if request.Resolution != "" && request.Resolution != "480p" && request.Resolution != "720p" {
+	// 分辨率：基础 grok-imagine-video（v1）仅支持 480p/720p；grok-imagine-video-1.5 起原生支持 1080p。
+	switch res := strings.TrimSpace(request.Resolution); {
+	case res == "" || res == "480p" || res == "720p":
+		// 两个模型都支持
+	case res == "1080p" && videoModel != "grok-imagine-video":
+		// grok-imagine-video-1.5 起放行 1080p
+	case videoModel == "grok-imagine-video":
 		return provider.VideoResult{}, errors.New("grok-imagine-video 仅支持 480p 或 720p")
+	default:
+		return provider.VideoResult{}, fmt.Errorf("%s 仅支持 480p、720p 或 1080p", videoModel)
 	}
 	payload := map[string]any{
-		"model": "grok-imagine-video", "duration": request.Duration,
+		"model": videoModel, "duration": request.Duration,
 	}
 	if prompt := strings.TrimSpace(request.Prompt); prompt != "" {
 		payload["prompt"] = prompt

--- a/backend/internal/infra/provider/provider.go
+++ b/backend/internal/infra/provider/provider.go
@@ -279,6 +279,7 @@ type VideoRequest struct {
 	Billing *account.Billing
 	// JobID binds the local video job to XAI ZDR upload tickets and result assets.
 	JobID         string
+	UpstreamModel string
 	Prompt        string
 	Duration      int
 	AspectRatio   string


### PR DESCRIPTION
## 背景

Console 通道目前只注册了 `grok-imagine-video`（v1），视频生成里把上游模型名硬编码成了 `grok-imagine-video`。实际上 x.ai 已提供 **`grok-imagine-video-1.5`**，且该模型原生支持 **1080p**（v1 只有 480p/720p）。本 PR 把 1.5 接进来，并让分辨率与计价随模型区分。

## 改动

- **注册模型**：`console/catalog.go` 的 `mediaCatalog` 增加 `grok-imagine-video-1.5`（Video 能力）；`model_repository.go` 的路由发现把它与 `grok-imagine-video` 一并识别为 Video 能力。
- **按模型分流**：`provider.VideoRequest` 新增 `UpstreamModel` 字段，`gateway/video.go` 透传当前路由的上游模型；`console/media.go` 的 `GenerateVideo` 不再硬编码 `grok-imagine-video`，改用请求携带的模型名（缺省仍回落到 `grok-imagine-video`，保持向后兼容）。
- **分辨率规则**：基础 `grok-imagine-video` 维持仅 `480p`/`720p`；`grok-imagine-video-1.5` 起放行 `1080p`。
- **计价**：`audit/pricing.go` 补齐 `grok-imagine-video-1.5` 的 `1080p` 档（x.ai 官方 $0.25/s，即 `2_500_000_000` ticks/s），并对基础 `grok-imagine-video` 的 `1080p` 明确返回不支持，避免误计价。
- **测试**：更新 `console_test.go` 的路由数量断言（11→12），并在 `pricing_test.go` 增加 1.5 的 1080p 估价与还原用例、基础模型拒绝 1080p 的用例。

## 验证

- `go build ./...`、`go vet` 通过。
- `go test ./internal/infra/provider/console/ ./internal/domain/audit/` 全部通过。

## 说明

- 本 PR 只涉及 Console 视频**模型注册 + 1080p 分辨率/计价**，是最小、自包含的一块；不改前端、不改上传/参考图数量等其它行为。
