### PR TITLE
fix(console): filter client tools for multi-agent models

### DIFF
--- a/backend/internal/infra/provider/console/catalog.go
+++ b/backend/internal/infra/provider/console/catalog.go
@@ -17,6 +17,7 @@ type ModelSpec struct {
 	UpstreamModel           string
 	SupportsReasoning       bool
 	SupportsReasoningEffort bool
+	DisallowsClientTools    bool
 	DefaultReasoningEffort  string
 	MaxOutputTokens         int
 }
@@ -25,7 +26,7 @@ var catalog = []ModelSpec{
 	{PublicID: "grok-4.3", UpstreamModel: "grok-4.3", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000},
 	{PublicID: "grok-4.20-0309-reasoning", UpstreamModel: "grok-4.20-0309-reasoning", SupportsReasoning: true, MaxOutputTokens: 1_000_000},
 	{PublicID: "grok-4.20-0309-non-reasoning", UpstreamModel: "grok-4.20-0309-non-reasoning", MaxOutputTokens: 1_000_000},
-	{PublicID: "grok-4.20-multi-agent-0309", UpstreamModel: "grok-4.20-multi-agent-0309", SupportsReasoning: true, SupportsReasoningEffort: true, MaxOutputTokens: 1_000_000},
+	{PublicID: "grok-4.20-multi-agent-0309", UpstreamModel: "grok-4.20-multi-agent-0309", SupportsReasoning: true, SupportsReasoningEffort: true, DisallowsClientTools: true, MaxOutputTokens: 1_000_000},
 	{PublicID: "grok-4.5", UpstreamModel: "grok-4.5", SupportsReasoning: true, SupportsReasoningEffort: true, DefaultReasoningEffort: "medium", MaxOutputTokens: 1_000_000},
 	{PublicID: "grok-build-0.1", UpstreamModel: "grok-build-0.1", MaxOutputTokens: 256_000},
 }

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -38,8 +38,10 @@ func normalizeRequest(body []byte, spec ModelSpec) ([]byte, error) {
 	}
 	normalizeReasoning(payload, spec)
 	ensureReasoningInclude(payload)
-	retainedClientTools := normalizeConsoleTools(payload)
-	normalizeConsoleToolChoice(payload, retainedClientTools)
+	toolSummary := normalizeConsoleTools(payload, spec.DisallowsClientTools)
+	if err := normalizeConsoleToolChoice(payload, toolSummary, spec.DisallowsClientTools); err != nil {
+		return nil, err
+	}
 	return json.Marshal(payload)
 }
 
@@ -202,35 +204,59 @@ func ensureReasoningInclude(payload map[string]any) {
 	payload["include"] = result
 }
 
-func normalizeConsoleTools(payload map[string]any) bool {
+type consoleToolSummary struct {
+	retainedClientTools bool
+	removedClientTools  bool
+}
+
+func normalizeConsoleTools(payload map[string]any, disallowsClientTools bool) consoleToolSummary {
+	summary := consoleToolSummary{}
 	value, exists := payload["tools"]
 	if !exists || value == nil {
 		delete(payload, "tools")
-		delete(payload, "tool_choice")
-		return false
+		return summary
 	}
 	tools, ok := value.([]any)
 	if !ok {
 		delete(payload, "tools")
-		delete(payload, "tool_choice")
-		return false
+		return summary
 	}
 	result := make([]any, 0, len(tools))
-	retainedClientTools := false
+	seenServerTools := make(map[string]struct{})
 	for _, rawTool := range tools {
 		tool, ok := rawTool.(map[string]any)
 		if !ok {
 			continue
 		}
 		typeName, _ := tool["type"].(string)
-		switch strings.ToLower(strings.TrimSpace(typeName)) {
+		normalizedType := strings.ToLower(strings.TrimSpace(typeName))
+		if disallowsClientTools {
+			normalizedType = strings.ReplaceAll(normalizedType, "-", "_")
+		}
+		if disallowsClientTools && isMultiAgentClientTool(normalizedType) {
+			summary.removedClientTools = true
+			continue
+		}
+		switch normalizedType {
 		case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
+			if disallowsClientTools {
+				if _, exists := seenServerTools["web_search"]; exists {
+					continue
+				}
+				seenServerTools["web_search"] = struct{}{}
+			}
 			clean := map[string]any{"type": "web_search", "enable_image_understanding": true}
 			if enabled, ok := tool["enable_image_understanding"].(bool); ok {
 				clean["enable_image_understanding"] = enabled
 			}
 			result = append(result, clean)
 		case "x_search":
+			if disallowsClientTools {
+				if _, exists := seenServerTools["x_search"]; exists {
+					continue
+				}
+				seenServerTools["x_search"] = struct{}{}
+			}
 			clean := map[string]any{"type": "x_search", "enable_video_understanding": true}
 			if enabled, ok := tool["enable_video_understanding"].(bool); ok {
 				clean["enable_video_understanding"] = enabled
@@ -248,56 +274,87 @@ func normalizeConsoleTools(payload map[string]any) bool {
 				}
 			}
 			result = append(result, clean)
-			retainedClientTools = true
+			summary.retainedClientTools = true
 		case "mcp", "shell", "image_generation", "collections_search", "file_search", "code_execution", "code_interpreter":
 			// These are native xAI Responses tool variants. Keep their payloads,
 			// while namespace/tool_search remain client-side abstractions and are
 			// intentionally omitted instead of causing an upstream 400.
 			result = append(result, tool)
-			retainedClientTools = true
+			summary.retainedClientTools = true
 		}
 	}
 	if len(result) == 0 {
 		delete(payload, "tools")
-		delete(payload, "tool_choice")
-		return false
+		return summary
 	}
 	payload["tools"] = result
-	return retainedClientTools
+	return summary
 }
 
-func normalizeConsoleToolChoice(payload map[string]any, retainedClientTools bool) {
+func isMultiAgentClientTool(toolType string) bool {
+	return toolType == "function" || toolType == "custom" || toolType == "shell" ||
+		toolType == "mcp" || strings.HasPrefix(toolType, "mcp_")
+}
+
+func normalizeConsoleToolChoice(payload map[string]any, summary consoleToolSummary, disallowsClientTools bool) error {
 	if _, exists := payload["tools"]; !exists {
+		if disallowsClientTools && summary.removedClientTools && toolChoiceRequiresTool(payload["tool_choice"]) {
+			return fmt.Errorf("模型不支持请求中必需的客户端工具")
+		}
 		delete(payload, "tool_choice")
-		return
+		return nil
+	}
+	if disallowsClientTools {
+		choice, exists := payload["tool_choice"]
+		if !exists {
+			payload["tool_choice"] = "auto"
+			return nil
+		}
+		if value, ok := choice.(string); ok {
+			switch strings.ToLower(strings.TrimSpace(value)) {
+			case "none", "auto", "required":
+				payload["tool_choice"] = strings.ToLower(strings.TrimSpace(value))
+			default:
+				payload["tool_choice"] = "auto"
+			}
+			return nil
+		}
+		if object, ok := choice.(map[string]any); ok {
+			typeName, _ := object["type"].(string)
+			if isMultiAgentClientTool(strings.ReplaceAll(strings.ToLower(strings.TrimSpace(typeName)), "-", "_")) {
+				return fmt.Errorf("模型不支持请求中指定的客户端工具")
+			}
+		}
+		payload["tool_choice"] = "required"
+		return nil
 	}
 	choice, exists := payload["tool_choice"]
 	if !exists {
 		payload["tool_choice"] = "auto"
-		return
+		return nil
 	}
 	if value, ok := choice.(string); ok {
 		switch strings.ToLower(strings.TrimSpace(value)) {
 		case "none", "auto":
 			payload["tool_choice"] = strings.ToLower(strings.TrimSpace(value))
 		case "required":
-			if !retainedClientTools {
+			if !summary.retainedClientTools {
 				payload["tool_choice"] = "auto"
 			}
 		default:
 			payload["tool_choice"] = "auto"
 		}
-		return
+		return nil
 	}
 	object, ok := choice.(map[string]any)
 	if !ok {
 		payload["tool_choice"] = "auto"
-		return
+		return nil
 	}
 	typeName, _ := object["type"].(string)
-	if typeName != "function" || !retainedClientTools {
+	if typeName != "function" || !summary.retainedClientTools {
 		payload["tool_choice"] = "auto"
-		return
+		return nil
 	}
 	name, _ := object["name"].(string)
 	if strings.TrimSpace(name) == "" {
@@ -307,9 +364,18 @@ func normalizeConsoleToolChoice(payload map[string]any, retainedClientTools bool
 	}
 	if strings.TrimSpace(name) == "" {
 		payload["tool_choice"] = "auto"
-		return
+		return nil
 	}
 	payload["tool_choice"] = map[string]any{"type": "function", "name": strings.TrimSpace(name)}
+	return nil
+}
+
+func toolChoiceRequiresTool(choice any) bool {
+	if value, ok := choice.(string); ok {
+		return strings.EqualFold(strings.TrimSpace(value), "required")
+	}
+	_, isObject := choice.(map[string]any)
+	return isObject
 }
 
 func toolIdentity(value any) string {


### PR DESCRIPTION
## 背景

Grok 上游对 `grok-4.20-multi-agent-*` 设置了客户端工具的 Beta 功能权限门控。这里的 Beta 限制是上游模型能力权限限制：普通账号请求一旦携带 `function`、`custom`、`shell` 或 MCP 等客户端工具，就可能被拒绝并返回：

```text
Client-side tools for multi-agent models require beta access
```

`grok-4.5` 不受同样的限制。

## 修复内容

- 在 Console 模型能力声明中标记 `grok-4.20-multi-agent-0309` 不允许客户端工具。
- 在 Console 出站请求归一化阶段，仅对该模型过滤 `function`、`custom`、`shell`、`mcp` 和 `mcp_*` 工具。
- 保留调用方明确声明的 `web_search` / `x_search` 服务端工具，并规范化搜索工具别名和重复项。
- 保留 `none`、`auto`、`required` 的有效 `tool_choice` 语义。
- 对明确指定已被该模型禁止的客户端工具返回本地 `invalid_request_error`，避免静默降级为普通文本响应。
- 不修改 Build、Web Provider，也不改变 `grok-4.5` 等其他 Console 模型的客户端工具行为。

Responses、Chat Completions 和 Anthropic Messages 在转换后都会经过同一 Console 出站归一化边界，因此修复对三种公开 API 一致生效。

## 修复前后

相同请求携带可选客户端工具和 `web_search`：

| API | 修复前 | 修复后 |
| --- | --- | --- |
| `/v1/responses` | HTTP 400，Beta 权限错误 | HTTP 200 |
| `/v1/chat/completions` | HTTP 400，Beta 权限错误 | HTTP 200 |
| `/v1/messages` | HTTP 400，Beta 权限错误 | HTTP 200 |

## 验证

- `go test ./... -count=1` 通过
- `go vet ./...` 通过
- `git diff --check` 通过
- 使用 5 个真实 Grok Console 账号通过项目原生 Console 出口代理完成三协议验证：
  - `grok-4.5` 控制请求：HTTP 200
  - Responses：HTTP 200
  - Chat Completions：HTTP 200
  - Anthropic Messages：HTTP 200
- 修复前通过确定性上游契约模拟，三种协议均可复现上述 Beta 权限错误；修复后均通过。

真实账号凭据、客户端 Key 和本地测试配置未包含在本 PR 中。