### PR TITLE
feat: add grok-4.6 reasoning levels and Codex metadata

### DIFF
--- a/backend/internal/domain/model/reasoning.go
+++ b/backend/internal/domain/model/reasoning.go
@@ -37,12 +37,14 @@ var reasoningEffortSuffixes = []string{
 // generally accepted by the model family. Provider-specific wire restrictions are
 // applied by providerReasoningEffortOverrides:
 //   - grok-4.5: low/medium/high (reasoning cannot be disabled; no xhigh/max)
+//   - grok-4.6: low/medium/high/xhigh (reasoning cannot be disabled)
 //   - grok-4.3: none/low/medium/high
 //   - grok-4.20-multi-agent: low/medium/high/xhigh (effort controls agent count)
 //
 // Unknown models default to none-only and never expand into effort aliases.
 var grokReasoningCapabilities = map[string][]string{
 	"grok-4.5":                     {ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh},
+	"grok-4.6":                     {ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh},
 	"grok-4.3":                     {ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh},
 	"grok-build-0.1":               {ReasoningEffortNone},
 	"grok-4.20-0309-reasoning":     {ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh},

--- a/backend/internal/transport/http/inference/codex_models.go
+++ b/backend/internal/transport/http/inference/codex_models.go
@@ -87,6 +87,7 @@ type grokModelCapability struct {
 // Codex catalogs never diverge from the levels each model actually supports.
 var grokCapabilities = map[string]grokModelCapability{
 	"grok-4.5":                     {500000, "xAI Grok 4.5 frontier model with reasoning and vision.", true},
+	"grok-4.6":                     {500000, "xAI Grok 4.6 frontier model with reasoning and vision.", true},
 	"grok-4.3":                     {1000000, "xAI Grok 4.3 high-capacity reasoning model.", true},
 	"grok-build-0.1":               {256000, "xAI Grok Build 0.1 coding model.", false},
 	"grok-4.20-0309-reasoning":     {2000000, "xAI Grok 4.20 reasoning model.", true},


### PR DESCRIPTION
grok-4.6 is now served via Grok Build. This registers its real reasoning capabilities and Codex metadata so Build-discovered requests stop falling back to the unknown-model defaults.

## Changes
- `reasoning.go`: `grok-4.6` \u2192 `low/medium/high/xhigh` (reasoning cannot be disabled). Previously unknown \u2192 none-only.
- `codex_models.go`: `grok-4.6` \u2192 500k context, vision input, reasoning enabled. Previously fell back to 128k / generic.

## Not included
- No Console catalog entry: grok-4.6 is Build-discovered only.
- Pricing already exists in `audit/pricing.go` ($2/$6, cached ~$0.50, >200k long-context) and matches the official numbers.