### PR TITLE
fix(video): accept chat messages as generation prompt

### DIFF
--- a/backend/internal/application/gateway/video_options.go
+++ b/backend/internal/application/gateway/video_options.go
@@ -1,0 +1,367 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	"github.com/chenyme/grok2api/backend/internal/domain/clientkey"
+	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+)
+
+const (
+	videoOptionParseTimeout     = 45 * time.Second
+	videoOptionAttemptTimeout   = 15 * time.Second
+	videoOptionMaxResponseBytes = 64 << 10
+)
+
+var defaultVideoOptionModels = []string{
+	"grok-4.6",
+	"grok-4.5",
+	"grok-4.20-0309-non-reasoning",
+	"grok-4.20-0309-reasoning",
+	"grok-4.3",
+	"grok-chat-expert",
+	"grok-chat-auto",
+	"grok-chat-heavy",
+	"grok-chat-fast",
+	"grok-4.20-multi-agent-0309",
+	"grok-3-mini-fast",
+	"grok-3-mini",
+	"grok-build-0.1",
+}
+
+// VideoOptionParseInput describes only the final selected user prompt and the
+// fields that the client omitted. The original prompt is never rewritten.
+type VideoOptionParseInput struct {
+	RequestID             string
+	ClientKey             clientkey.Key
+	Prompt                string
+	NeedDuration          bool
+	NeedAspectRatio       bool
+	NeedResolution        bool
+	PreferredPublicModels []string
+}
+
+type VideoOptionHints struct {
+	Duration    *int    `json:"duration"`
+	AspectRatio *string `json:"aspect_ratio"`
+	Resolution  *string `json:"resolution"`
+}
+
+type enabledRouteLister interface {
+	ListEnabled(context.Context) ([]modeldomain.Route, error)
+}
+
+type videoOptionChatResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens           int64 `json:"prompt_tokens"`
+		CompletionTokens       int64 `json:"completion_tokens"`
+		TotalTokens            int64 `json:"total_tokens"`
+		CostInUSDTicks         int64 `json:"cost_in_usd_ticks"`
+		NumSourcesUsed         int64 `json:"num_sources_used"`
+		NumServerSideToolsUsed int64 `json:"num_server_side_tools_used"`
+		PromptTokensDetails    struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+		CompletionTokensDetails struct {
+			ReasoningTokens int64 `json:"reasoning_tokens"`
+		} `json:"completion_tokens_details"`
+		ContextDetails struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"context_details"`
+	} `json:"usage"`
+}
+
+// InferVideoOptions asks enabled text routes, in quality order, to extract only
+// missing structured video options. It falls through every available provider.
+func (s *Service) InferVideoOptions(ctx context.Context, input VideoOptionParseInput) (VideoOptionHints, error) {
+	if strings.TrimSpace(input.Prompt) == "" || (!input.NeedDuration && !input.NeedAspectRatio && !input.NeedResolution) {
+		return VideoOptionHints{}, nil
+	}
+	candidates, err := s.videoOptionModelCandidates(ctx, input.PreferredPublicModels)
+	if err != nil {
+		return VideoOptionHints{}, err
+	}
+	if len(candidates) == 0 {
+		return VideoOptionHints{}, errors.New("没有可用文本模型用于解析视频参数")
+	}
+	parseCtx, cancel := context.WithTimeout(ctx, videoOptionParseTimeout)
+	defer cancel()
+	internalKey := input.ClientKey
+	internalKey.AllowedModels = nil
+	internalKey.ProviderScope = clientkey.ProviderScopeAll
+	internalKey.TierScope = clientkey.TierScopeAll
+	internalKey.AllowModelAliases = false
+	internalKey.BillingLimitUSDTicks = 0
+
+	var lastErr error
+	for index, candidate := range candidates {
+		attemptCtx, attemptCancel := context.WithTimeout(parseCtx, videoOptionAttemptTimeout)
+		requestBody, marshalErr := buildVideoOptionRequest(input, candidate)
+		if marshalErr != nil {
+			attemptCancel()
+			return VideoOptionHints{}, marshalErr
+		}
+		result, requestErr := s.CreateChatCompletion(attemptCtx, Input{
+			RequestID:   fmt.Sprintf("%s_video_options_%d", input.RequestID, index+1),
+			ClientKey:   internalKey,
+			PublicModel: candidate,
+			Body:        requestBody,
+			Streaming:   false,
+		})
+		if requestErr != nil {
+			attemptCancel()
+			lastErr = requestErr
+			if parseCtx.Err() != nil {
+				break
+			}
+			continue
+		}
+		hints, readErr := readVideoOptionResult(result)
+		attemptCancel()
+		if readErr == nil {
+			return hints, nil
+		}
+		lastErr = readErr
+		if parseCtx.Err() != nil {
+			break
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("视频参数解析模型没有返回有效结果")
+	}
+	if s.logger != nil {
+		s.logger.Warn("video_option_parser_failed", "request_id", input.RequestID, "candidate_count", len(candidates), "error", lastErr)
+	}
+	return VideoOptionHints{}, lastErr
+}
+
+func (s *Service) videoOptionModelCandidates(ctx context.Context, preferred []string) ([]string, error) {
+	lister, ok := s.models.(enabledRouteLister)
+	if !ok {
+		return nil, errors.New("模型仓储不支持列出视频参数解析候选")
+	}
+	routes, err := lister.ListEnabled(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("读取视频参数解析模型: %w", err)
+	}
+	priority := normalizeVideoOptionModelPriority(preferred)
+	priorityIndex := make(map[string]int, len(priority))
+	for index, value := range priority {
+		priorityIndex[strings.ToLower(value)] = index
+	}
+	eligible := make([]modeldomain.Route, 0, len(routes))
+	for _, route := range routes {
+		if route.Capability != modeldomain.CapabilityResponses && route.Capability != modeldomain.CapabilityChat {
+			continue
+		}
+		if s.providers == nil || !s.providers.SupportsConversation(route.Provider, "chat") {
+			continue
+		}
+		eligible = append(eligible, route)
+	}
+	sort.SliceStable(eligible, func(left, right int) bool {
+		leftPriority := videoOptionRoutePriority(eligible[left], priorityIndex, len(priority))
+		rightPriority := videoOptionRoutePriority(eligible[right], priorityIndex, len(priority))
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		if eligible[left].SupportedAccounts != eligible[right].SupportedAccounts {
+			return eligible[left].SupportedAccounts > eligible[right].SupportedAccounts
+		}
+		leftProvider := videoOptionProviderPriority(eligible[left].Provider)
+		rightProvider := videoOptionProviderPriority(eligible[right].Provider)
+		if leftProvider != rightProvider {
+			return leftProvider < rightProvider
+		}
+		return eligible[left].PublicID < eligible[right].PublicID
+	})
+	result := make([]string, 0, len(eligible))
+	seen := make(map[uint64]struct{}, len(eligible))
+	for _, route := range eligible {
+		if _, exists := seen[route.ID]; exists {
+			continue
+		}
+		seen[route.ID] = struct{}{}
+		result = append(result, route.PublicID)
+	}
+	return result, nil
+}
+
+func normalizeVideoOptionModelPriority(preferred []string) []string {
+	if len(preferred) == 0 {
+		preferred = defaultVideoOptionModels
+	}
+	result := make([]string, 0, len(preferred))
+	seen := make(map[string]struct{}, len(preferred))
+	for _, value := range preferred {
+		value = strings.TrimSpace(value)
+		key := strings.ToLower(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+	}
+	if len(result) == 0 {
+		return append([]string(nil), defaultVideoOptionModels...)
+	}
+	return result
+}
+
+func videoOptionRoutePriority(route modeldomain.Route, priority map[string]int, fallback int) int {
+	for _, value := range []string{route.UpstreamModel, modeldomain.ExternalPublicID(route.Provider, route.PublicID)} {
+		if index, ok := priority[strings.ToLower(strings.TrimSpace(value))]; ok {
+			return index
+		}
+	}
+	return fallback
+}
+
+func videoOptionProviderPriority(value account.Provider) int {
+	switch value {
+	case account.ProviderBuild:
+		return 0
+	case account.ProviderConsole:
+		return 1
+	case account.ProviderWeb:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func buildVideoOptionRequest(input VideoOptionParseInput, publicModel string) ([]byte, error) {
+	wanted := make([]string, 0, 3)
+	if input.NeedDuration {
+		wanted = append(wanted, "duration")
+	}
+	if input.NeedAspectRatio {
+		wanted = append(wanted, "aspect_ratio")
+	}
+	if input.NeedResolution {
+		wanted = append(wanted, "resolution")
+	}
+	system := `Extract only explicitly requested video generation settings from the user text. Return one JSON object and nothing else. Keys: duration (integer 1-15 seconds or null), aspect_ratio (one of "1:1","16:9","9:16","4:3","3:4","3:2","2:3" or null), resolution (one of "480p","720p","1080p" or null). Do not infer unspecified values. Understand the user's language without translating or rewriting their text.`
+	return json.Marshal(map[string]any{
+		"model": publicModel,
+		"messages": []map[string]string{
+			{"role": "system", "content": system},
+			{"role": "user", "content": fmt.Sprintf("Fields to extract: %s\nUser text:\n%s", strings.Join(wanted, ", "), input.Prompt)},
+		},
+		"stream":                false,
+		"temperature":           0,
+		"max_completion_tokens": 96,
+		"response_format":       map[string]string{"type": "json_object"},
+	})
+}
+
+func readVideoOptionResult(result *Result) (hints VideoOptionHints, err error) {
+	if result == nil || result.Body == nil {
+		return VideoOptionHints{}, errors.New("视频参数解析模型返回空响应")
+	}
+	usage := Usage{}
+	responseID := ""
+	errorCode := "video_option_parser_invalid_response"
+	defer result.Body.Close()
+	if result.Finalize != nil {
+		defer func() { result.Finalize(usage, responseID, errorCode) }()
+	}
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		errorCode = "video_option_parser_upstream_error"
+		_, _ = io.Copy(io.Discard, io.LimitReader(result.Body, videoOptionMaxResponseBytes))
+		return VideoOptionHints{}, fmt.Errorf("视频参数解析模型返回 HTTP %d", result.StatusCode)
+	}
+	body, readErr := io.ReadAll(io.LimitReader(result.Body, videoOptionMaxResponseBytes+1))
+	if readErr != nil {
+		return VideoOptionHints{}, fmt.Errorf("读取视频参数解析响应: %w", readErr)
+	}
+	if len(body) > videoOptionMaxResponseBytes {
+		return VideoOptionHints{}, errors.New("视频参数解析响应过大")
+	}
+	var response videoOptionChatResponse
+	if json.Unmarshal(body, &response) != nil || len(response.Choices) == 0 {
+		return VideoOptionHints{}, errors.New("视频参数解析响应格式无效")
+	}
+	responseID = response.ID
+	usage = Usage{
+		InputTokens: response.Usage.PromptTokens, CachedInputTokens: response.Usage.PromptTokensDetails.CachedTokens,
+		OutputTokens: response.Usage.CompletionTokens, ReasoningTokens: response.Usage.CompletionTokensDetails.ReasoningTokens,
+		TotalTokens: response.Usage.TotalTokens, CostInUSDTicks: response.Usage.CostInUSDTicks,
+		NumSourcesUsed: response.Usage.NumSourcesUsed, NumServerSideToolsUsed: response.Usage.NumServerSideToolsUsed,
+		ContextInputTokens: response.Usage.ContextDetails.InputTokens, ContextOutputTokens: response.Usage.ContextDetails.OutputTokens,
+		ResponseModel: response.Model,
+	}
+	hints, err = decodeVideoOptionHints(response.Choices[0].Message.Content)
+	if err != nil {
+		return VideoOptionHints{}, err
+	}
+	errorCode = ""
+	return hints, nil
+}
+
+func decodeVideoOptionHints(value string) (VideoOptionHints, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "```") && strings.HasSuffix(value, "```") {
+		lines := strings.Split(value, "\n")
+		if len(lines) >= 3 {
+			value = strings.TrimSpace(strings.Join(lines[1:len(lines)-1], "\n"))
+		}
+	}
+	var hints VideoOptionHints
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&hints); err != nil {
+		return VideoOptionHints{}, fmt.Errorf("解析视频参数 JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return VideoOptionHints{}, errors.New("视频参数 JSON 包含额外内容")
+	}
+	if hints.Duration != nil && (*hints.Duration < 1 || *hints.Duration > 15) {
+		return VideoOptionHints{}, errors.New("视频参数 duration 超出 1 到 15")
+	}
+	if hints.AspectRatio != nil {
+		value := strings.TrimSpace(*hints.AspectRatio)
+		if !validInferredVideoAspectRatio(value) {
+			return VideoOptionHints{}, errors.New("视频参数 aspect_ratio 无效")
+		}
+		*hints.AspectRatio = value
+	}
+	if hints.Resolution != nil {
+		value := strings.ToLower(strings.TrimSpace(*hints.Resolution))
+		if value != "480p" && value != "720p" && value != "1080p" {
+			return VideoOptionHints{}, errors.New("视频参数 resolution 无效")
+		}
+		*hints.Resolution = value
+	}
+	return hints, nil
+}
+
+func validInferredVideoAspectRatio(value string) bool {
+	switch value {
+	case "1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/application/gateway/video_options_test.go
+++ b/backend/internal/application/gateway/video_options_test.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/chenyme/grok2api/backend/internal/domain/account"
+	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+)
+
+func TestDecodeVideoOptionHintsStrictValidation(t *testing.T) {
+	valid, err := decodeVideoOptionHints("```json\n{\"duration\":10,\"aspect_ratio\":\"9:16\",\"resolution\":\"1080P\"}\n```")
+	if err != nil || valid.Duration == nil || *valid.Duration != 10 || valid.AspectRatio == nil || *valid.AspectRatio != "9:16" || valid.Resolution == nil || *valid.Resolution != "1080p" {
+		t.Fatalf("valid = %#v, err = %v", valid, err)
+	}
+	for _, value := range []string{
+		`{"duration":16,"aspect_ratio":null,"resolution":null}`,
+		`{"duration":8,"aspect_ratio":"21:9","resolution":"720p"}`,
+		`{"duration":8,"aspect_ratio":"16:9","resolution":"4k"}`,
+		`{"duration":8,"aspect_ratio":"16:9","resolution":"720p","prompt":"rewritten"}`,
+		`{"duration":8,"aspect_ratio":"16:9","resolution":"720p"} trailing`,
+	} {
+		if _, err := decodeVideoOptionHints(value); err == nil {
+			t.Fatalf("expected invalid hints for %s", value)
+		}
+	}
+}
+
+func TestBuildVideoOptionRequestPreservesArbitraryLanguageAndOnlyRequestedFields(t *testing.T) {
+	prompt := "اصنع مقطعًا عموديًا مدته ١٠ ثوانٍ بدقة ١٠٨٠p عن المحيط"
+	body, err := buildVideoOptionRequest(VideoOptionParseInput{
+		Prompt: prompt, NeedDuration: true, NeedResolution: true,
+	}, "Console/grok-4.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Model != "Console/grok-4.3" || len(payload.Messages) != 2 || !strings.Contains(payload.Messages[1].Content, prompt) {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if strings.Contains(payload.Messages[1].Content, "aspect_ratio") {
+		t.Fatalf("unrequested field leaked into extraction list: %q", payload.Messages[1].Content)
+	}
+}
+
+func TestReadVideoOptionResultFinalizesUsage(t *testing.T) {
+	finalized := false
+	result := &Result{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(`{
+			"id":"chatcmpl_options","model":"grok-4.6",
+			"choices":[{"message":{"content":"{\"duration\":12,\"aspect_ratio\":null,\"resolution\":\"720p\"}"}}],
+			"usage":{"prompt_tokens":20,"completion_tokens":8,"total_tokens":28}
+		}`)),
+		Finalize: func(usage Usage, responseID, errorCode string) {
+			finalized = responseID == "chatcmpl_options" && errorCode == "" && usage.InputTokens == 20 && usage.OutputTokens == 8 && usage.TotalTokens == 28 && usage.ResponseModel == "grok-4.6"
+		},
+	}
+	hints, err := readVideoOptionResult(result)
+	if err != nil || hints.Duration == nil || *hints.Duration != 12 || hints.Resolution == nil || *hints.Resolution != "720p" || !finalized {
+		t.Fatalf("hints = %#v, err = %v, finalized = %t", hints, err, finalized)
+	}
+}
+
+func TestVideoOptionRoutePriorityPrefersQualityThenProvider(t *testing.T) {
+	priorityValues := normalizeVideoOptionModelPriority(nil)
+	priority := make(map[string]int, len(priorityValues))
+	for index, value := range priorityValues {
+		priority[strings.ToLower(value)] = index
+	}
+	grok46 := modeldomain.Route{Provider: account.ProviderBuild, UpstreamModel: "grok-4.6"}
+	grok45 := modeldomain.Route{Provider: account.ProviderBuild, UpstreamModel: "grok-4.5"}
+	unknownConsole := modeldomain.Route{Provider: account.ProviderConsole, UpstreamModel: "future-text"}
+	unknownWeb := modeldomain.Route{Provider: account.ProviderWeb, UpstreamModel: "future-text"}
+	if videoOptionRoutePriority(grok46, priority, len(priority)) >= videoOptionRoutePriority(grok45, priority, len(priority)) {
+		t.Fatal("grok-4.6 must precede grok-4.5")
+	}
+	if videoOptionRoutePriority(unknownConsole, priority, len(priority)) != len(priority) || videoOptionRoutePriority(unknownWeb, priority, len(priority)) != len(priority) {
+		t.Fatal("unknown enabled text models must remain in the fallback set")
+	}
+	if videoOptionProviderPriority(account.ProviderConsole) >= videoOptionProviderPriority(account.ProviderWeb) {
+		t.Fatal("Console fallback must precede Web at equal quality")
+	}
+}

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -960,7 +960,76 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 		writeGatewayError(c, err)
 		return
 	}
+	if hasJSONValue(request.Messages) {
+		h.writeVideoChatAccepted(c, job.ID, model, request.Stream != nil && *request.Stream)
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"request_id": job.ID})
+}
+
+func (h *Handler) writeVideoChatAccepted(c *gin.Context, jobID, model string, stream bool) {
+	created := time.Now().Unix()
+	content := fmt.Sprintf(
+		"视频生成任务已提交。\n任务 ID: %s\n状态查询: %s\n视频地址: %s",
+		jobID,
+		h.videoStatusURL(jobID),
+		h.videoContentURL(jobID),
+	)
+	if !stream {
+		c.JSON(http.StatusOK, gin.H{
+			"id":      jobID,
+			"object":  "chat.completion",
+			"created": created,
+			"model":   model,
+			"choices": []gin.H{{
+				"index":         0,
+				"message":       gin.H{"role": "assistant", "content": content},
+				"finish_reason": "stop",
+			}},
+		})
+		return
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+	writeVideoChatChunk(c.Writer, gin.H{
+		"id":      jobID,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []gin.H{{
+			"index":         0,
+			"delta":         gin.H{"role": "assistant", "content": content},
+			"finish_reason": nil,
+		}},
+	})
+	writeVideoChatChunk(c.Writer, gin.H{
+		"id":      jobID,
+		"object":  "chat.completion.chunk",
+		"created": created,
+		"model":   model,
+		"choices": []gin.H{{
+			"index":         0,
+			"delta":         gin.H{},
+			"finish_reason": "stop",
+		}},
+	})
+	_, _ = c.Writer.WriteString("data: [DONE]\n\n")
+	c.Writer.Flush()
+}
+
+func writeVideoChatChunk(writer gin.ResponseWriter, chunk gin.H) {
+	data, err := json.Marshal(chunk)
+	if err != nil {
+		return
+	}
+	_, _ = writer.WriteString("data: ")
+	_, _ = writer.Write(data)
+	_, _ = writer.WriteString("\n\n")
+	writer.Flush()
 }
 
 func mergeVideoOptionHints(duration int, hasDuration bool, aspectRatio string, hasAspectRatio bool, resolution string, hasResolution bool, hints gateway.VideoOptionHints) (int, bool, string, bool, string, bool) {
@@ -1036,7 +1105,15 @@ func (h *Handler) getVideo(c *gin.Context) {
 }
 
 func (h *Handler) videoContentURL(jobID string) string {
-	path := "/v1/videos/" + url.PathEscape(jobID) + "/content"
+	return h.videoURL(jobID, "/content")
+}
+
+func (h *Handler) videoStatusURL(jobID string) string {
+	return h.videoURL(jobID, "")
+}
+
+func (h *Handler) videoURL(jobID, suffix string) string {
+	path := "/v1/videos/" + url.PathEscape(jobID) + suffix
 	baseURL := h.publicAPIBaseURL
 	if h.publicBaseURL != nil {
 		baseURL = strings.TrimRight(strings.TrimSpace(h.publicBaseURL()), "/")

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -174,20 +174,45 @@ type videoGenerationAudio struct {
 }
 
 type videoGenerationRequest struct {
-	Model           string                 `json:"model"`
-	Prompt          string                 `json:"prompt"`
-	Messages        json.RawMessage        `json:"messages"`
-	Stream          *bool                  `json:"stream"`
-	User            *string                `json:"user"`
-	Duration        json.RawMessage        `json:"duration"`
-	AspectRatio     string                 `json:"aspect_ratio"`
-	Resolution      string                 `json:"resolution"`
-	Image           *videoGenerationImage  `json:"image"`
-	ReferenceImages []videoGenerationImage `json:"reference_images"`
-	ReferenceAudios []videoGenerationAudio `json:"reference_audios"`
-	Video           *videoGenerationImage  `json:"video"`
-	Output          json.RawMessage        `json:"output"`
-	StorageOptions  json.RawMessage        `json:"storage_options"`
+	Model               string                 `json:"model"`
+	Prompt              string                 `json:"prompt"`
+	Messages            json.RawMessage        `json:"messages"`
+	Stream              *bool                  `json:"stream"`
+	Temperature         *float64               `json:"temperature"`
+	TopP                *float64               `json:"top_p"`
+	MaxTokens           *int                   `json:"max_tokens"`
+	MaxCompletionTokens *int                   `json:"max_completion_tokens"`
+	PresencePenalty     *float64               `json:"presence_penalty"`
+	FrequencyPenalty    *float64               `json:"frequency_penalty"`
+	Stop                json.RawMessage        `json:"stop"`
+	Seed                *int64                 `json:"seed"`
+	Logprobs            *bool                  `json:"logprobs"`
+	TopLogprobs         *int                   `json:"top_logprobs"`
+	Tools               json.RawMessage        `json:"tools"`
+	ToolChoice          json.RawMessage        `json:"tool_choice"`
+	ParallelToolCalls   *bool                  `json:"parallel_tool_calls"`
+	ResponseFormat      json.RawMessage        `json:"response_format"`
+	ReasoningEffort     string                 `json:"reasoning_effort"`
+	LogitBias           json.RawMessage        `json:"logit_bias"`
+	Metadata            json.RawMessage        `json:"metadata"`
+	Modalities          json.RawMessage        `json:"modalities"`
+	Count               *int                   `json:"n"`
+	Prediction          json.RawMessage        `json:"prediction"`
+	ServiceTier         string                 `json:"service_tier"`
+	Store               *bool                  `json:"store"`
+	StreamOptions       json.RawMessage        `json:"stream_options"`
+	Verbosity           string                 `json:"verbosity"`
+	WebSearchOptions    json.RawMessage        `json:"web_search_options"`
+	User                *string                `json:"user"`
+	Duration            json.RawMessage        `json:"duration"`
+	AspectRatio         string                 `json:"aspect_ratio"`
+	Resolution          string                 `json:"resolution"`
+	Image               *videoGenerationImage  `json:"image"`
+	ReferenceImages     []videoGenerationImage `json:"reference_images"`
+	ReferenceAudios     []videoGenerationAudio `json:"reference_audios"`
+	Video               *videoGenerationImage  `json:"video"`
+	Output              json.RawMessage        `json:"output"`
+	StorageOptions      json.RawMessage        `json:"storage_options"`
 }
 
 type modelListItem struct {
@@ -751,33 +776,37 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 	}
 
 	duration := 0
+	hasDuration := false
 	aspectRatio := ""
+	hasAspectRatio := false
 	resolution := ""
+	hasResolution := false
 	imageURL := ""
 	referenceURLs := []string{}
 	referenceAudios := []string{}
+	hasReferenceMode := false
 	videoURL := ""
 
 	if operation == gatewayVideoOperationGenerate {
 		var err error
-		duration, err = parseVideoDuration(request.Duration)
+		duration, hasDuration, err = parseOptionalVideoInteger(request.Duration)
 		if err != nil {
-			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", err.Error())
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "duration 必须是整数或整数字符串")
+			return
+		}
+		if hasDuration && (duration < 1 || duration > 15) {
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "duration 必须在 1 到 15 秒之间")
 			return
 		}
 		aspectRatio = strings.TrimSpace(request.AspectRatio)
-		if aspectRatio == "" {
-			aspectRatio = "16:9"
-		}
-		if !validVideoAspectRatio(aspectRatio) {
+		hasAspectRatio = aspectRatio != ""
+		if hasAspectRatio && !validVideoAspectRatio(aspectRatio) {
 			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "aspect_ratio 必须是 1:1、16:9、9:16、4:3、3:4、3:2 或 2:3")
 			return
 		}
 		resolution = strings.ToLower(strings.TrimSpace(request.Resolution))
-		if resolution == "" {
-			resolution = "720p"
-		}
-		if resolution != "480p" && resolution != "720p" && resolution != "1080p" {
+		hasResolution = resolution != ""
+		if hasResolution && resolution != "480p" && resolution != "720p" && resolution != "1080p" {
 			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "resolution 必须是 480p、720p 或 1080p")
 			return
 		}
@@ -817,13 +846,13 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", fmt.Sprintf("reference_images 不能超过 %d 张", mediadomain.MaxInputImages))
 			return
 		}
-		hasReferenceMode := len(referenceURLs) > 0 || len(referenceAudios) > 0
+		hasReferenceMode = len(referenceURLs) > 0 || len(referenceAudios) > 0
 		if hasReferenceMode {
 			if prompt == "" {
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "参考图/参考音频视频必须提供 prompt")
 				return
 			}
-			if resolution == "1080p" {
+			if hasResolution && resolution == "1080p" {
 				writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "参考图视频 resolution 最高 720p")
 				return
 			}
@@ -886,6 +915,32 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 	if !ok {
 		return
 	}
+	if operation == gatewayVideoOperationGenerate {
+		if prompt != "" && (!hasDuration || !hasAspectRatio || !hasResolution) {
+			hints, inferErr := h.gateway.InferVideoOptions(c.Request.Context(), gateway.VideoOptionParseInput{
+				RequestID: requestID, ClientKey: clientKey, Prompt: prompt,
+				NeedDuration: !hasDuration, NeedAspectRatio: !hasAspectRatio, NeedResolution: !hasResolution,
+			})
+			if inferErr == nil {
+				duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution = mergeVideoOptionHints(
+					duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution, hints,
+				)
+			}
+		}
+		if !hasDuration {
+			duration = 8
+		}
+		if !hasAspectRatio {
+			aspectRatio = "16:9"
+		}
+		if !hasResolution {
+			resolution = "720p"
+		}
+		if hasReferenceMode && resolution == "1080p" {
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "参考图视频 resolution 最高 720p")
+			return
+		}
+	}
 	var op provider.VideoOperation
 	switch operation {
 	case gatewayVideoOperationEdit:
@@ -906,6 +961,22 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"request_id": job.ID})
+}
+
+func mergeVideoOptionHints(duration int, hasDuration bool, aspectRatio string, hasAspectRatio bool, resolution string, hasResolution bool, hints gateway.VideoOptionHints) (int, bool, string, bool, string, bool) {
+	if !hasDuration && hints.Duration != nil {
+		duration = *hints.Duration
+		hasDuration = true
+	}
+	if !hasAspectRatio && hints.AspectRatio != nil {
+		aspectRatio = *hints.AspectRatio
+		hasAspectRatio = true
+	}
+	if !hasResolution && hints.Resolution != nil {
+		resolution = *hints.Resolution
+		hasResolution = true
+	}
+	return duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution
 }
 
 func extractVideoPromptFromMessages(raw json.RawMessage) (string, error) {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -176,6 +176,7 @@ type videoGenerationAudio struct {
 type videoGenerationRequest struct {
 	Model           string                 `json:"model"`
 	Prompt          string                 `json:"prompt"`
+	Messages        json.RawMessage        `json:"messages"`
 	User            *string                `json:"user"`
 	Duration        json.RawMessage        `json:"duration"`
 	AspectRatio     string                 `json:"aspect_ratio"`
@@ -719,6 +720,14 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 	}
 	model := strings.TrimSpace(request.Model)
 	prompt := strings.TrimSpace(request.Prompt)
+	if prompt == "" {
+		var err error
+		prompt, err = extractVideoPromptFromMessages(request.Messages)
+		if err != nil {
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", label+" messages 无效: "+err.Error())
+			return
+		}
+	}
 	if model == "" {
 		writeOpenAIError(c, http.StatusBadRequest, "invalid_request", label+"缺少有效 model")
 		return
@@ -896,6 +905,49 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"request_id": job.ID})
+}
+
+func extractVideoPromptFromMessages(raw json.RawMessage) (string, error) {
+	if !hasJSONValue(raw) {
+		return "", nil
+	}
+	var messages []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &messages); err != nil {
+		return "", errors.New("必须是消息数组")
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		if !strings.EqualFold(strings.TrimSpace(messages[i].Role), "user") {
+			continue
+		}
+		return extractVideoMessageText(messages[i].Content), nil
+	}
+	return "", nil
+}
+
+func extractVideoMessageText(raw json.RawMessage) string {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return strings.TrimSpace(text)
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) != nil {
+		return ""
+	}
+	texts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		partType := strings.ToLower(strings.TrimSpace(part.Type))
+		value := strings.TrimSpace(part.Text)
+		if value != "" && (partType == "text" || partType == "input_text") {
+			texts = append(texts, value)
+		}
+	}
+	return strings.Join(texts, "\n")
 }
 
 func (h *Handler) getVideo(c *gin.Context) {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -132,6 +132,7 @@ type messagesRequest struct {
 type imageGenerationRequest struct {
 	Model          string          `json:"model"`
 	Prompt         string          `json:"prompt"`
+	Messages       json.RawMessage `json:"messages"`
 	Count          *int            `json:"n"`
 	PartialImages  *int            `json:"partial_images"`
 	Size           string          `json:"size"`
@@ -408,7 +409,22 @@ func (h *Handler) generateImage(c *gin.Context) {
 		return
 	}
 	var request imageGenerationRequest
-	if decodeSingleJSON(c.Request.Body, &request, false) != nil || strings.TrimSpace(request.Model) == "" || strings.TrimSpace(request.Prompt) == "" {
+	if decodeSingleJSON(c.Request.Body, &request, false) != nil {
+		writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "图片请求缺少有效 model 或 prompt")
+		return
+	}
+	model := strings.TrimSpace(request.Model)
+	prompt := strings.TrimSpace(request.Prompt)
+	chatStyle := hasJSONValue(request.Messages)
+	if prompt == "" {
+		var err error
+		prompt, err = extractVideoPromptFromMessages(request.Messages)
+		if err != nil {
+			writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "图片生成 messages 无效: "+err.Error())
+			return
+		}
+	}
+	if model == "" || prompt == "" {
 		writeOpenAIError(c, http.StatusBadRequest, "invalid_request", "图片请求缺少有效 model 或 prompt")
 		return
 	}
@@ -424,7 +440,7 @@ func (h *Handler) generateImage(c *gin.Context) {
 		}
 		count = *request.Count
 	}
-	if request.Stream && count != 1 {
+	if request.Stream && count != 1 && !chatStyle {
 		writeImageGenerationUserError(c, "unsupported_parameter", "input", "Streaming is only supported with n=1.")
 		return
 	}
@@ -449,17 +465,128 @@ func (h *Handler) generateImage(c *gin.Context) {
 	if !ok {
 		return
 	}
-	result, err := h.gateway.GenerateImage(c.Request.Context(), gateway.ImageGenerationInput{
-		RequestID: requestID, ClientKey: clientKey, PublicModel: request.Model, Prompt: request.Prompt,
+	created := time.Now().Unix()
+	if chatStyle && request.Stream {
+		beginChatCompletionStream(c)
+		writeChatCompletionChunk(c.Writer, requestID, model, created, "图片生成已开始。\n", nil)
+	}
+	responseFormat := request.ResponseFormat
+	streamUpstream := request.Stream
+	if chatStyle {
+		responseFormat = "url"
+		streamUpstream = false
+		partialImages = 0
+	}
+	imageInput := gateway.ImageGenerationInput{
+		RequestID: requestID, ClientKey: clientKey, PublicModel: model, Prompt: prompt,
 		Count: count, Size: request.Size, AspectRatio: request.AspectRatio,
-		Resolution: request.Resolution, Quality: quality, ResponseFormat: request.ResponseFormat,
-		Streaming: request.Stream, PartialImages: partialImages,
-	})
+		Resolution: request.Resolution, Quality: quality, ResponseFormat: responseFormat,
+		Streaming: streamUpstream, PartialImages: partialImages,
+	}
+	result, err := h.generateImageWithChatHeartbeat(c, imageInput, requestID, model, created, chatStyle && request.Stream)
 	if err != nil {
+		if chatStyle && request.Stream {
+			finishChatCompletionStream(c.Writer, requestID, model, created, "图片生成失败，请稍后重试。")
+			return
+		}
 		writeGatewayError(c, err)
 		return
 	}
+	if chatStyle {
+		urls, readErr := readImageChatResult(result)
+		if readErr != nil {
+			if request.Stream {
+				finishChatCompletionStream(c.Writer, requestID, model, created, "图片生成失败，请稍后重试。")
+				return
+			}
+			writeOpenAIError(c, http.StatusBadGateway, "image_generation_failed", "图片生成失败，请稍后重试")
+			return
+		}
+		content := imageChatCompletionContent(urls)
+		if request.Stream {
+			finishChatCompletionStream(c.Writer, requestID, model, created, content)
+			return
+		}
+		writeChatCompletion(c, requestID, model, created, content)
+		return
+	}
 	h.writeResult(c, result, request.Stream, streamProtocolImage)
+}
+
+func (h *Handler) generateImageWithChatHeartbeat(c *gin.Context, input gateway.ImageGenerationInput, id, model string, created int64, heartbeat bool) (*gateway.Result, error) {
+	if !heartbeat {
+		return h.gateway.GenerateImage(c.Request.Context(), input)
+	}
+	type outcome struct {
+		result *gateway.Result
+		err    error
+	}
+	completed := make(chan outcome, 1)
+	go func() {
+		result, err := h.gateway.GenerateImage(c.Request.Context(), input)
+		completed <- outcome{result: result, err: err}
+	}()
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case value := <-completed:
+			return value.result, value.err
+		case <-ticker.C:
+			writeChatCompletionChunk(c.Writer, id, model, created, "图片仍在生成。\n", nil)
+		case <-c.Request.Context().Done():
+			return nil, c.Request.Context().Err()
+		}
+	}
+}
+
+func readImageChatResult(result *gateway.Result) ([]string, error) {
+	usage := gateway.Usage{}
+	responseID := ""
+	errorCode := ""
+	defer result.Body.Close()
+	defer func() { result.Finalize(usage, responseID, errorCode) }()
+	body, err := io.ReadAll(io.LimitReader(result.Body, maxJSONResponseTransferBytes+1))
+	if err != nil || len(body) > maxJSONResponseTransferBytes {
+		errorCode = "image_response_invalid"
+		return nil, errors.New("图片响应读取失败")
+	}
+	metadata := extractMetadata(body)
+	usage, responseID = metadata.Usage, metadata.ResponseID
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		errorCode = "upstream_error"
+		return nil, errors.New("图片上游响应失败")
+	}
+	var payload struct {
+		Data []struct {
+			URL string `json:"url"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		errorCode = "image_response_invalid"
+		return nil, errors.New("图片响应格式无效")
+	}
+	urls := make([]string, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		value := strings.TrimSpace(item.URL)
+		if value != "" {
+			urls = append(urls, value)
+		}
+	}
+	if len(urls) == 0 {
+		errorCode = "image_response_invalid"
+		return nil, errors.New("图片响应没有媒体地址")
+	}
+	return urls, nil
+}
+
+func imageChatCompletionContent(urls []string) string {
+	var content strings.Builder
+	content.WriteString("图片生成完成。")
+	for index, value := range urls {
+		fmt.Fprintf(&content, "\n\n![生成图片 %d](%s)\n[下载原图 %d](%s)", index+1, value, index+1, value)
+	}
+	return content.String()
 }
 
 func (h *Handler) writeMediaResult(c *gin.Context, result *gateway.Result) {
@@ -961,67 +1088,105 @@ func (h *Handler) handleVideoCreate(c *gin.Context, operation, label string) {
 		return
 	}
 	if hasJSONValue(request.Messages) {
-		h.writeVideoChatAccepted(c, job.ID, model, request.Stream != nil && *request.Stream)
+		h.writeVideoChatResult(c, job, clientKey, model, request.Stream != nil && *request.Stream)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"request_id": job.ID})
 }
 
-func (h *Handler) writeVideoChatAccepted(c *gin.Context, jobID, model string, stream bool) {
+func (h *Handler) writeVideoChatResult(c *gin.Context, job mediadomain.Job, clientKey clientkeydomain.Key, model string, stream bool) {
 	created := time.Now().Unix()
-	content := fmt.Sprintf(
-		"视频生成任务已提交。\n任务 ID: %s\n状态查询: %s\n视频地址: %s",
-		jobID,
-		h.videoStatusURL(jobID),
-		h.videoContentURL(jobID),
-	)
-	if !stream {
-		c.JSON(http.StatusOK, gin.H{
-			"id":      jobID,
-			"object":  "chat.completion",
-			"created": created,
-			"model":   model,
-			"choices": []gin.H{{
-				"index":         0,
-				"message":       gin.H{"role": "assistant", "content": content},
-				"finish_reason": "stop",
-			}},
-		})
+	if stream {
+		beginChatCompletionStream(c)
+		writeChatCompletionChunk(c.Writer, job.ID, model, created, "视频生成已开始。\n", nil)
+	}
+	lastProgress := -1
+	lastProgressSentAt := time.Time{}
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		current, err := h.gateway.GetVideo(c.Request.Context(), job.ID, clientKey)
+		if err != nil {
+			h.finishVideoChat(c, job.ID, model, created, stream, "视频生成状态读取失败，请稍后重试。")
+			return
+		}
+		switch current.Status {
+		case mediadomain.StatusCompleted:
+			if current.ResultAssetID == "" {
+				h.finishVideoChat(c, job.ID, model, created, stream, "视频已生成，但媒体归档尚未完成，请稍后重试。")
+				return
+			}
+			mediaURL := h.videoAssetURL(current.ResultAssetID)
+			content := fmt.Sprintf("视频生成完成。\n\n<video controls src=\"%s\"></video>\n\n[下载视频](%s)", mediaURL, mediaURL)
+			h.finishVideoChat(c, job.ID, model, created, stream, content)
+			return
+		case mediadomain.StatusFailed:
+			message := "视频生成失败，请稍后重试。"
+			if strings.TrimSpace(current.ErrorMessage) != "" {
+				message = "视频生成失败：" + strings.TrimSpace(current.ErrorMessage)
+			}
+			h.finishVideoChat(c, job.ID, model, created, stream, message)
+			return
+		default:
+			progress := min(99, max(0, current.Progress))
+			if stream && (progress != lastProgress || time.Since(lastProgressSentAt) >= 15*time.Second) {
+				prefix := "视频生成进度"
+				if progress == lastProgress {
+					prefix = "视频仍在生成"
+				}
+				writeChatCompletionChunk(c.Writer, job.ID, model, created, fmt.Sprintf("%s：%d%%\n", prefix, progress), nil)
+				lastProgress = progress
+				lastProgressSentAt = time.Now()
+			}
+		}
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (h *Handler) finishVideoChat(c *gin.Context, id, model string, created int64, stream bool, content string) {
+	if stream {
+		finishChatCompletionStream(c.Writer, id, model, created, content)
 		return
 	}
+	writeChatCompletion(c, id, model, created, content)
+}
 
+func beginChatCompletionStream(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 	c.Header("X-Accel-Buffering", "no")
 	c.Status(http.StatusOK)
-	writeVideoChatChunk(c.Writer, gin.H{
-		"id":      jobID,
-		"object":  "chat.completion.chunk",
-		"created": created,
-		"model":   model,
-		"choices": []gin.H{{
-			"index":         0,
-			"delta":         gin.H{"role": "assistant", "content": content},
-			"finish_reason": nil,
-		}},
-	})
-	writeVideoChatChunk(c.Writer, gin.H{
-		"id":      jobID,
-		"object":  "chat.completion.chunk",
-		"created": created,
-		"model":   model,
-		"choices": []gin.H{{
-			"index":         0,
-			"delta":         gin.H{},
-			"finish_reason": "stop",
-		}},
-	})
-	_, _ = c.Writer.WriteString("data: [DONE]\n\n")
-	c.Writer.Flush()
 }
 
-func writeVideoChatChunk(writer gin.ResponseWriter, chunk gin.H) {
+func writeChatCompletion(c *gin.Context, id, model string, created int64, content string) {
+	c.JSON(http.StatusOK, gin.H{
+		"id": id, "object": "chat.completion", "created": created, "model": model,
+		"choices": []gin.H{{"index": 0, "message": gin.H{"role": "assistant", "content": content}, "finish_reason": "stop"}},
+	})
+}
+
+func finishChatCompletionStream(writer gin.ResponseWriter, id, model string, created int64, content string) {
+	writeChatCompletionChunk(writer, id, model, created, content, nil)
+	finishReason := "stop"
+	writeChatCompletionChunk(writer, id, model, created, "", &finishReason)
+	_, _ = writer.WriteString("data: [DONE]\n\n")
+	writer.Flush()
+}
+
+func writeChatCompletionChunk(writer gin.ResponseWriter, id, model string, created int64, content string, finishReason *string) {
+	delta := gin.H{}
+	if content != "" {
+		delta = gin.H{"role": "assistant", "content": content}
+	}
+	chunk := gin.H{
+		"id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+		"choices": []gin.H{{"index": 0, "delta": delta, "finish_reason": finishReason}},
+	}
 	data, err := json.Marshal(chunk)
 	if err != nil {
 		return
@@ -1110,6 +1275,18 @@ func (h *Handler) videoContentURL(jobID string) string {
 
 func (h *Handler) videoStatusURL(jobID string) string {
 	return h.videoURL(jobID, "")
+}
+
+func (h *Handler) videoAssetURL(assetID string) string {
+	path := "/v1/media/videos/" + url.PathEscape(assetID) + ".mp4"
+	baseURL := h.publicAPIBaseURL
+	if h.publicBaseURL != nil {
+		baseURL = strings.TrimRight(strings.TrimSpace(h.publicBaseURL()), "/")
+	}
+	if baseURL == "" {
+		return path
+	}
+	return baseURL + path
 }
 
 func (h *Handler) videoURL(jobID, suffix string) string {

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -177,6 +177,7 @@ type videoGenerationRequest struct {
 	Model           string                 `json:"model"`
 	Prompt          string                 `json:"prompt"`
 	Messages        json.RawMessage        `json:"messages"`
+	Stream          *bool                  `json:"stream"`
 	User            *string                `json:"user"`
 	Duration        json.RawMessage        `json:"duration"`
 	AspectRatio     string                 `json:"aspect_ratio"`

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -235,13 +235,14 @@ func TestVideoContentURLFollowsRuntimePublicAPIBase(t *testing.T) {
 	}
 }
 
-func TestWriteVideoChatAcceptedReturnsChatCompletion(t *testing.T) {
+func TestWriteChatCompletionReturnsMediaMessage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
 	handler := NewHandler(nil, nil, 1<<20, "https://api.example.com")
+	content := "视频生成完成。\n\n[下载视频](" + handler.videoAssetURL("vid_request_1") + ")"
 
-	handler.writeVideoChatAccepted(context, "video_request_1", "grok-imagine-video", false)
+	writeChatCompletion(context, "video_request_1", "grok-imagine-video", 123, content)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
@@ -262,25 +263,24 @@ func TestWriteVideoChatAcceptedReturnsChatCompletion(t *testing.T) {
 	if response.Object != "chat.completion" || len(response.Choices) != 1 || response.Choices[0].Message.Role != "assistant" || response.Choices[0].FinishReason != "stop" {
 		t.Fatalf("response=%#v", response)
 	}
-	content := response.Choices[0].Message.Content
+	responseContent := response.Choices[0].Message.Content
 	for _, want := range []string{
-		"video_request_1",
-		"https://api.example.com/v1/videos/video_request_1",
-		"https://api.example.com/v1/videos/video_request_1/content",
+		"https://api.example.com/v1/media/videos/vid_request_1.mp4",
+		"下载视频",
 	} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("content %q does not contain %q", content, want)
+		if !strings.Contains(responseContent, want) {
+			t.Fatalf("content %q does not contain %q", responseContent, want)
 		}
 	}
 }
 
-func TestWriteVideoChatAcceptedReturnsChatCompletionStream(t *testing.T) {
+func TestFinishChatCompletionStreamReturnsMediaMessage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
-	handler := NewHandler(nil, nil, 1<<20, "https://api.example.com")
-
-	handler.writeVideoChatAccepted(context, "video_request_2", "grok-imagine-video", true)
+	beginChatCompletionStream(context)
+	writeChatCompletionChunk(context.Writer, "video_request_2", "grok-imagine-video", 123, "视频生成进度：42%\n", nil)
+	finishChatCompletionStream(context.Writer, "video_request_2", "grok-imagine-video", 123, "视频生成完成。\n\n[下载视频](https://api.example.com/v1/media/videos/vid_request_2.mp4)")
 
 	if recorder.Code != http.StatusOK || !strings.HasPrefix(recorder.Header().Get("Content-Type"), "text/event-stream") {
 		t.Fatalf("status=%d content-type=%q", recorder.Code, recorder.Header().Get("Content-Type"))
@@ -290,12 +290,45 @@ func TestWriteVideoChatAcceptedReturnsChatCompletionStream(t *testing.T) {
 		`"object":"chat.completion.chunk"`,
 		`"role":"assistant"`,
 		`"finish_reason":"stop"`,
-		"https://api.example.com/v1/videos/video_request_2/content",
+		"视频生成进度：42%",
+		"https://api.example.com/v1/media/videos/vid_request_2.mp4",
 		"data: [DONE]\n\n",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("stream %q does not contain %q", body, want)
 		}
+	}
+}
+
+func TestImageChatCompletionContentRendersEveryImage(t *testing.T) {
+	content := imageChatCompletionContent([]string{
+		"https://api.example.com/v1/media/images/img_one",
+		"https://api.example.com/v1/media/images/img_two",
+	})
+	for _, want := range []string{
+		"图片生成完成",
+		"![生成图片 1](https://api.example.com/v1/media/images/img_one)",
+		"![生成图片 2](https://api.example.com/v1/media/images/img_two)",
+		"[下载原图 2](https://api.example.com/v1/media/images/img_two)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("content %q does not contain %q", content, want)
+		}
+	}
+}
+
+func TestReadImageChatResultReturnsPublicURLsAndFinalizes(t *testing.T) {
+	finalized := 0
+	result := &gateway.Result{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"created":123,"data":[{"url":"https://api.example.com/v1/media/images/img_one"}]}`)),
+		Finalize: func(gateway.Usage, string, string) {
+			finalized++
+		},
+	}
+	urls, err := readImageChatResult(result)
+	if err != nil || len(urls) != 1 || urls[0] != "https://api.example.com/v1/media/images/img_one" || finalized != 1 {
+		t.Fatalf("urls=%#v err=%v finalized=%d", urls, err, finalized)
 	}
 }
 

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -235,6 +235,70 @@ func TestVideoContentURLFollowsRuntimePublicAPIBase(t *testing.T) {
 	}
 }
 
+func TestWriteVideoChatAcceptedReturnsChatCompletion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	handler := NewHandler(nil, nil, 1<<20, "https://api.example.com")
+
+	handler.writeVideoChatAccepted(context, "video_request_1", "grok-imagine-video", false)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Object  string `json:"object"`
+		Choices []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Object != "chat.completion" || len(response.Choices) != 1 || response.Choices[0].Message.Role != "assistant" || response.Choices[0].FinishReason != "stop" {
+		t.Fatalf("response=%#v", response)
+	}
+	content := response.Choices[0].Message.Content
+	for _, want := range []string{
+		"video_request_1",
+		"https://api.example.com/v1/videos/video_request_1",
+		"https://api.example.com/v1/videos/video_request_1/content",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("content %q does not contain %q", content, want)
+		}
+	}
+}
+
+func TestWriteVideoChatAcceptedReturnsChatCompletionStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	handler := NewHandler(nil, nil, 1<<20, "https://api.example.com")
+
+	handler.writeVideoChatAccepted(context, "video_request_2", "grok-imagine-video", true)
+
+	if recorder.Code != http.StatusOK || !strings.HasPrefix(recorder.Header().Get("Content-Type"), "text/event-stream") {
+		t.Fatalf("status=%d content-type=%q", recorder.Code, recorder.Header().Get("Content-Type"))
+	}
+	body := recorder.Body.String()
+	for _, want := range []string{
+		`"object":"chat.completion.chunk"`,
+		`"role":"assistant"`,
+		`"finish_reason":"stop"`,
+		"https://api.example.com/v1/videos/video_request_2/content",
+		"data: [DONE]\n\n",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream %q does not contain %q", body, want)
+		}
+	}
+}
+
 func TestGatewayErrorDoesNotExposeInternalDetails(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -127,6 +127,7 @@ func TestVideoGenerationAcceptsChatMessagesAsPrompt(t *testing.T) {
 		{name: "string content", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"animate ocean waves"}]}`},
 		{name: "text content parts", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":[{"type":"text","text":"animate"},{"type":"input_text","text":"ocean waves"}]}]}`},
 		{name: "last user message", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"first"},{"role":"assistant","content":"reply"},{"role":"user","content":"final prompt"}]}`},
+		{name: "chat stream flag", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"animate ocean waves"}],"stream":true}`},
 		{name: "explicit prompt takes precedence", body: `{"model":"grok-imagine-video","prompt":"explicit","messages":{"not":"an array"}}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -147,6 +148,7 @@ func TestVideoGenerationAcceptsChatMessagesAsPrompt(t *testing.T) {
 	}{
 		{name: "invalid messages shape", body: `{"model":"grok-imagine-video","messages":{"role":"user","content":"test"}}`, want: "messages 无效"},
 		{name: "no user text", body: `{"model":"grok-imagine-video","messages":[{"role":"assistant","content":"reply"}]}`, want: "必须提供 prompt"},
+		{name: "invalid stream type", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"test"}],"stream":"true"}`, want: "cannot unmarshal string"},
 		{name: "unknown top level field remains rejected", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"test"}],"unexpected":true}`, want: "unknown field"},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -128,7 +128,9 @@ func TestVideoGenerationAcceptsChatMessagesAsPrompt(t *testing.T) {
 		{name: "text content parts", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":[{"type":"text","text":"animate"},{"type":"input_text","text":"ocean waves"}]}]}`},
 		{name: "last user message", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"first"},{"role":"assistant","content":"reply"},{"role":"user","content":"final prompt"}]}`},
 		{name: "chat stream flag", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"animate ocean waves"}],"stream":true}`},
+		{name: "chat sampling metadata", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"animate ocean waves"}],"stream":true,"temperature":0.7,"top_p":0.9,"max_tokens":256,"presence_penalty":0,"frequency_penalty":0,"stop":["DONE"],"seed":42,"logprobs":false,"top_logprobs":2,"tools":[],"tool_choice":"none","parallel_tool_calls":false,"response_format":{"type":"text"},"reasoning_effort":"medium"}`},
 		{name: "explicit prompt takes precedence", body: `{"model":"grok-imagine-video","prompt":"explicit","messages":{"not":"an array"}}`},
+		{name: "legacy structured parameters", body: `{"model":"grok-imagine-video","prompt":"animate ocean waves","duration":4,"aspect_ratio":"1:1","resolution":"480p"}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodPost, "/v1/videos/generations", strings.NewReader(test.body))
@@ -176,6 +178,27 @@ func TestExtractVideoPromptFromMessagesUsesOnlyLastUserText(t *testing.T) {
 	prompt, err := extractVideoPromptFromMessages(raw)
 	if err != nil || prompt != "new prompt\nsecond line" {
 		t.Fatalf("prompt=%q err=%v", prompt, err)
+	}
+}
+
+func TestMergeVideoOptionHintsNeverOverridesExplicitValues(t *testing.T) {
+	inferredDuration := 12
+	inferredAspectRatio := "9:16"
+	inferredResolution := "1080p"
+	duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution := mergeVideoOptionHints(
+		6, true, "4:3", true, "480p", true,
+		gateway.VideoOptionHints{Duration: &inferredDuration, AspectRatio: &inferredAspectRatio, Resolution: &inferredResolution},
+	)
+	if duration != 6 || !hasDuration || aspectRatio != "4:3" || !hasAspectRatio || resolution != "480p" || !hasResolution {
+		t.Fatalf("explicit values overwritten: %d %t %s %t %s %t", duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution)
+	}
+
+	duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution = mergeVideoOptionHints(
+		0, false, "", false, "", false,
+		gateway.VideoOptionHints{Duration: &inferredDuration, AspectRatio: &inferredAspectRatio, Resolution: &inferredResolution},
+	)
+	if duration != 12 || !hasDuration || aspectRatio != "9:16" || !hasAspectRatio || resolution != "1080p" || !hasResolution {
+		t.Fatalf("missing values not filled: %d %t %s %t %s %t", duration, hasDuration, aspectRatio, hasAspectRatio, resolution, hasResolution)
 	}
 }
 

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -115,6 +115,68 @@ func TestVideoGenerationUsesOfficialXAIEndpointsAndFields(t *testing.T) {
 	}
 }
 
+func TestVideoGenerationAcceptsChatMessagesAsPrompt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	NewHandler(nil, nil, 1<<20).Register(router.Group("/v1"))
+
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "string content", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"animate ocean waves"}]}`},
+		{name: "text content parts", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":[{"type":"text","text":"animate"},{"type":"input_text","text":"ocean waves"}]}]}`},
+		{name: "last user message", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"first"},{"role":"assistant","content":"reply"},{"role":"user","content":"final prompt"}]}`},
+		{name: "explicit prompt takes precedence", body: `{"model":"grok-imagine-video","prompt":"explicit","messages":{"not":"an array"}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/v1/videos/generations", strings.NewReader(test.body))
+			request.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid messages shape", body: `{"model":"grok-imagine-video","messages":{"role":"user","content":"test"}}`, want: "messages 无效"},
+		{name: "no user text", body: `{"model":"grok-imagine-video","messages":[{"role":"assistant","content":"reply"}]}`, want: "必须提供 prompt"},
+		{name: "unknown top level field remains rejected", body: `{"model":"grok-imagine-video","messages":[{"role":"user","content":"test"}],"unexpected":true}`, want: "unknown field"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/v1/videos/generations", strings.NewReader(test.body))
+			request.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), test.want) {
+				t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestExtractVideoPromptFromMessagesUsesOnlyLastUserText(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"role":"user","content":"old prompt"},
+		{"role":"assistant","content":"assistant history"},
+		{"role":"user","content":[
+			{"type":"input_text","text":"new prompt"},
+			{"type":"image_url","image_url":{"url":"https://example.com/input.png"}},
+			{"type":"text","text":"second line"}
+		]}
+	]`)
+	prompt, err := extractVideoPromptFromMessages(raw)
+	if err != nil || prompt != "new prompt\nsecond line" {
+		t.Fatalf("prompt=%q err=%v", prompt, err)
+	}
+}
+
 func TestWriteVideoContentRejectsDeclaredOversizeMedia(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/backend/internal/transport/http/media/handler.go
+++ b/backend/internal/transport/http/media/handler.go
@@ -83,7 +83,8 @@ func (h *Handler) getImage(c *gin.Context) {
 }
 
 func (h *Handler) getVideo(c *gin.Context) {
-	asset, body, err := h.service.OpenVideo(c.Request.Context(), c.Param("assetId"))
+	assetID := strings.TrimSuffix(c.Param("assetId"), ".mp4")
+	asset, body, err := h.service.OpenVideo(c.Request.Context(), assetID)
 	if errors.Is(err, mediaapp.ErrAssetNotFound) {
 		c.Status(http.StatusNotFound)
 		return
@@ -99,7 +100,7 @@ func (h *Handler) getVideo(c *gin.Context) {
 		return
 	}
 	c.Header("Content-Type", asset.MIMEType)
-	c.Header("Content-Disposition", `inline; filename="`+asset.ID+`"`)
+	c.Header("Content-Disposition", `inline; filename="`+asset.ID+`.mp4"`)
 	c.Header("Cache-Control", "public, max-age=31536000, immutable")
 	c.Header("ETag", `"`+asset.SHA256+`"`)
 	c.Header("X-Content-Type-Options", "nosniff")

--- a/backend/internal/transport/http/media/handler_test.go
+++ b/backend/internal/transport/http/media/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,6 +112,11 @@ func TestPublicVideoAssetSupportsGetHeadAndRange(t *testing.T) {
 	router.ServeHTTP(partial, rangeRequest)
 	if partial.Code != http.StatusPartialContent || partial.Body.Len() != 4 || partial.Header().Get("Content-Range") == "" {
 		t.Fatalf("Range status=%d size=%d headers=%#v", partial.Code, partial.Body.Len(), partial.Header())
+	}
+	suffixed := httptest.NewRecorder()
+	router.ServeHTTP(suffixed, httptest.NewRequest(http.MethodGet, path+".mp4", nil))
+	if suffixed.Code != http.StatusOK || suffixed.Body.Len() != len(payload) || !strings.Contains(suffixed.Header().Get("Content-Disposition"), asset.ID+".mp4") {
+		t.Fatalf("suffixed GET status=%d size=%d headers=%#v", suffixed.Code, suffixed.Body.Len(), suffixed.Header())
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept chat-style `messages` on `/v1/videos/generations` and use only the last user text when `prompt` is empty
- tolerate common Chat Completions metadata (`stream`, sampling fields, tools, response metadata) while retaining strict unknown-field rejection
- infer omitted `duration`, `aspect_ratio`, and `resolution` from natural-language prompts in any language
- prefer `grok-4.6`, then `grok-4.5`, then every other enabled text route; preserve the original prompt and fall back to existing defaults on parser failure
- keep explicit structured parameters authoritative and preserve existing generate/edit/extend constraints
- for chat-style video requests, keep the Chat Completions response open, stream status/progress events, and finish with an embeddable `<video>` plus a public MP4 download link
- for chat-style image requests, stream a start/heartbeat response and finish with Markdown previews plus original-image links
- allow public archived video assets to use a `.mp4` suffix while preserving HEAD and Range support
- keep native `prompt` image/video requests on their existing JSON/SSE contracts

## Media response behavior

Chat Completions SSE is a text event stream and cannot switch to a binary attachment after progress events. The final chat message therefore references the archived media through an unauthenticated public asset URL. Clients that support HTML can render the video inline; all other clients retain a regular download link.

The public media endpoint returns the actual `video/mp4` bytes and supports byte ranges, so integrations with a native attachment API can download the URL and re-upload it as a file message.

## Validation

- `go test ./...` from `backend`
- production natural-language request: Spanish `3 seconds / 9:16 / 480p`, HTTP 200, valid MP4
- production structured request: explicit `2 / 1:1 / 480p`, HTTP 200, valid MP4
- production precedence request: text requested 3 seconds, explicit `duration: 4`; persisted `4 / 9:16 / 480p`, HTTP 200, valid MP4
- production chat-style video request: SSE progress through completion, public `.mp4` URL, HTTP 200, `video/mp4`, Range HTTP 206, valid MP4
- public `/healthz` and `/readyz`: HTTP 200

Closes #919