### PR TITLE
fix: deprioritize accounts created within 30-minute warmup window

### DIFF
--- a/backend/internal/application/gateway/selector_plan.go
+++ b/backend/internal/application/gateway/selector_plan.go
@@ -18,6 +18,7 @@ type candidateScore struct {
 	quotaKnown      bool
 	quotaAvailable  bool
 	billingFresh    bool
+	recentlyCreated bool
 	inFlight        int
 	remaining       float64
 	lastSelected    time.Time
@@ -84,6 +85,11 @@ func candidateScoreBetter(values []account.RoutingCandidate, leftScore, rightSco
 	}
 	if left.Priority != right.Priority {
 		return left.Priority > right.Priority
+	}
+	// Fresh imports otherwise win on billing freshness, remaining quota, and a
+	// zero lastSelectedAt. Keep them behind warmed-up peers until snapshots settle.
+	if leftScore.recentlyCreated != rightScore.recentlyCreated {
+		return !leftScore.recentlyCreated
 	}
 	if leftScore.billingFresh != rightScore.billingFresh {
 		return leftScore.billingFresh
@@ -185,6 +191,7 @@ func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []a
 		score := candidateScore{
 			index: index, tier: tierOrderRank(tierOrder, candidate.Credential.WebTier),
 			preferFreeBuild: preferFreeBuild && candidate.IsKnownFreeBuild(),
+			recentlyCreated: accountCreatedWithinWarmup(candidate.Credential.CreatedAt, now),
 			inFlight:        inFlight[position], lastSelected: s.lastSelectedAt[candidate.Credential.ID],
 		}
 		// 只有真实上游快照能够证明账号具备该模式额度。历史默认值和

--- a/backend/internal/application/gateway/selector_segmented.go
+++ b/backend/internal/application/gateway/selector_segmented.go
@@ -27,6 +27,7 @@ type segmentedSelectorCohort struct {
 	tier            int
 	priority        int
 	billingFresh    bool
+	recentlyCreated bool
 }
 
 type selectorLeaseObservation struct {
@@ -103,6 +104,9 @@ func segmentedSelectorCohortBetter(left, right segmentedSelectorCohort) bool {
 	}
 	if left.priority != right.priority {
 		return left.priority > right.priority
+	}
+	if left.recentlyCreated != right.recentlyCreated {
+		return !left.recentlyCreated
 	}
 	if left.billingFresh != right.billingFresh {
 		return left.billingFresh

--- a/backend/internal/application/gateway/selector_segmented_active.go
+++ b/backend/internal/application/gateway/selector_segmented_active.go
@@ -185,6 +185,7 @@ func segmentedCandidateCohorts(values []account.RoutingCandidate, indexes []int,
 			supportsModel: candidate.SupportsModel, capabilityKnown: candidate.ModelCapabilityKnown,
 			preferFreeBuild: preferFreeBuild && candidate.IsKnownFreeBuild(),
 			tier:            tierOrderRank(tierOrder, candidate.Credential.WebTier), priority: candidate.Credential.Priority,
+			recentlyCreated: accountCreatedWithinWarmup(candidate.Credential.CreatedAt, now),
 		}
 		if candidate.Billing != nil {
 			cohort.billingFresh = now.Sub(candidate.Billing.SyncedAt) <= 30*time.Minute

--- a/backend/internal/application/gateway/selector_segmented_active_test.go
+++ b/backend/internal/application/gateway/selector_segmented_active_test.go
@@ -191,11 +191,13 @@ func TestSegmentedActiveCohortOrderingMatchesFullPlannerHardOrder(t *testing.T) 
 				for _, tier := range []int{0, 2} {
 					for _, priority := range []int{1, 10} {
 						for _, billingFresh := range []bool{false, true} {
-							cohorts = append(cohorts, segmentedSelectorCohort{
-								supportsModel: supportsModel, capabilityKnown: capabilityKnown,
-								preferFreeBuild: preferFreeBuild, tier: tier, priority: priority,
-								billingFresh: billingFresh,
-							})
+							for _, recentlyCreated := range []bool{false, true} {
+								cohorts = append(cohorts, segmentedSelectorCohort{
+									supportsModel: supportsModel, capabilityKnown: capabilityKnown,
+									preferFreeBuild: preferFreeBuild, tier: tier, priority: priority,
+									billingFresh: billingFresh, recentlyCreated: recentlyCreated,
+								})
+							}
 						}
 					}
 				}
@@ -212,8 +214,8 @@ func TestSegmentedActiveCohortOrderingMatchesFullPlannerHardOrder(t *testing.T) 
 				{Credential: account.Credential{ID: 2, Priority: right.priority}, SupportsModel: right.supportsModel, ModelCapabilityKnown: right.capabilityKnown},
 			}
 			scores := []candidateScore{
-				{index: 0, tier: left.tier, preferFreeBuild: left.preferFreeBuild, billingFresh: left.billingFresh},
-				{index: 1, tier: right.tier, preferFreeBuild: right.preferFreeBuild, billingFresh: right.billingFresh},
+				{index: 0, tier: left.tier, preferFreeBuild: left.preferFreeBuild, billingFresh: left.billingFresh, recentlyCreated: left.recentlyCreated},
+				{index: 1, tier: right.tier, preferFreeBuild: right.preferFreeBuild, billingFresh: right.billingFresh, recentlyCreated: right.recentlyCreated},
 			}
 			if got, want := segmentedSelectorCohortBetter(left, right), candidateScoreBetter(values, scores[0], scores[1]); got != want {
 				t.Fatalf("cohort order mismatch at %d/%d: got %t want %t", leftIndex, rightIndex, got, want)

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -975,6 +975,71 @@ func TestCandidatePlanPreservesSelectorOrdering(t *testing.T) {
 	}
 }
 
+func TestCandidatePlanDeprioritizesAccountsCreatedWithinWarmupWindow(t *testing.T) {
+	now := time.Now().UTC()
+	selector := NewSelector(nil, memory.NewConcurrencyLimiter(), nil, nil, time.Hour, time.Second, time.Minute)
+	values := []account.RoutingCandidate{
+		{
+			Credential: account.Credential{ID: 2, Priority: 1, CreatedAt: now.Add(-time.Minute)},
+			Billing:    &account.Billing{AccountID: 2, MonthlyLimit: 100, SyncedAt: now},
+		},
+		{
+			Credential: account.Credential{ID: 1, Priority: 1, CreatedAt: now.Add(-time.Hour)},
+			Billing:    &account.Billing{AccountID: 1, MonthlyLimit: 10, Used: 5, SyncedAt: now.Add(-time.Hour)},
+		},
+	}
+	plan, err := selector.planCandidates(context.Background(), values, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, ok := plan.Next()
+	if !ok || first.Credential.ID != 1 {
+		t.Fatalf("first candidate = %#v, want warmed-up account 1", first)
+	}
+}
+
+func TestCandidatePlanKeepsKnownQuotaAheadOfRecentlyCreatedAccounts(t *testing.T) {
+	now := time.Now().UTC()
+	selector := NewSelector(nil, memory.NewConcurrencyLimiter(), nil, nil, time.Hour, time.Second, time.Minute)
+	values := []account.RoutingCandidate{
+		{Credential: account.Credential{ID: 1, Priority: 1, CreatedAt: now.Add(-time.Hour)}},
+		{
+			Credential:  account.Credential{ID: 2, Priority: 1, CreatedAt: now.Add(-time.Minute)},
+			QuotaWindow: &account.QuotaWindow{AccountID: 2, Mode: "console_image", Remaining: 2, Total: 5, Source: account.QuotaSourceUpstream},
+		},
+	}
+	plan, err := selector.planCandidates(context.Background(), values, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, ok := plan.Next()
+	if !ok || first.Credential.ID != 2 {
+		t.Fatalf("first candidate = %#v, want recently created account with known quota", first)
+	}
+}
+
+func TestAccountCreatedWithinWarmup(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		want      bool
+	}{
+		{name: "zero created at is warmed up", want: false},
+		{name: "created one minute ago is warming up", createdAt: now.Add(-time.Minute), want: true},
+		{name: "created exactly at warmup window is warmed up", createdAt: now.Add(-accountCreationWarmup), want: false},
+		{name: "created before warmup window is warmed up", createdAt: now.Add(-accountCreationWarmup - time.Second), want: false},
+		{name: "future created at is treated as warming up", createdAt: now.Add(time.Minute), want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := accountCreatedWithinWarmup(test.createdAt, now); got != test.want {
+				t.Fatalf("accountCreatedWithinWarmup() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCandidatePlanPrefersKnownRemainingQuota(t *testing.T) {
 	values := []account.RoutingCandidate{
 		{Credential: account.Credential{ID: 1, Priority: 100}},

--- a/backend/internal/application/gateway/selector_warmup.go
+++ b/backend/internal/application/gateway/selector_warmup.go
@@ -1,0 +1,11 @@
+package gateway
+
+import "time"
+
+// accountCreationWarmup keeps newly imported accounts out of the front of the
+// queue while their billing, quota, and model capability snapshots settle.
+const accountCreationWarmup = 30 * time.Minute
+
+func accountCreatedWithinWarmup(createdAt, now time.Time) bool {
+	return !createdAt.IsZero() && now.Sub(createdAt) < accountCreationWarmup
+}


### PR DESCRIPTION
## What changed

Newly created accounts are now ranked behind already warmed-up peers for the first 30 minutes after `CreatedAt`.

The rule sits after model support, known quota, free-build preference, tier, and explicit `priority`. It does not exclude new accounts, and a new account with a confirmed upstream remaining window can still outrank an older account whose quota is unknown.

The same signal is applied in both the full planner and the segmented selector cohort order.

## Why

Live scheduling was sending traffic to just-imported accounts first. That was not a `createdAt desc` sort. New accounts win the later tie-breakers because they have:

- billing synced within 30 minutes
- full remaining quota
- a zero `lastSelectedAt`

Those accounts still need time for billing, quota, and model capability snapshots to settle. Putting them behind warmed-up peers avoids burning a fresh import immediately.

## Validation

`go test ./internal/application/gateway -run 'TestCandidatePlan|TestAccountCreatedWithinWarmup|TestSegmentedActiveCohortOrderingMatchesFullPlannerHardOrder'` passed.