### PR TITLE
perf: optimize large account pool selection and precise health invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Important optional settings:
 
 - `audit.ledgerMode`: `observe` reports ledger faults; `enforce` can pause new inference to protect billing integrity.
 - `routing.accountIsolatedConnections`: partitions outbound TCP/HTTP pools by account for external L4 or connection-hash load balancers. It is off by default because it increases connections, TLS handshakes, memory, and file-descriptor usage.
-- `routing.segmentedSelectorEnabled`: optimizes large account pools while retaining full-planner fallback and atomic guards.
+- `routing.segmentedSelectorEnabled`: enabled by default for pools with at least 3,000 eligible accounts; bounds dynamic concurrency reads while retaining quota/tier priorities, sticky sessions, full-planner fallback, and atomic guards.
 - Build response-header timeout and exact-match 403 invalidation rules are hot-reloadable.
 - **Sync latest version** applies the validated Grok Build client version and User-Agent.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -417,7 +417,7 @@ GROK2API_DATABASE_URL='postgresql://user:password@host:5432/grok2api?sslmode=req
 
 - `audit.ledgerMode`：`observe` 仅报告账本故障；`enforce` 可暂停新推理以保护计费准确性。
 - `routing.accountIsolatedConnections`：为外部 L4 或按连接哈希的负载均衡器按账号拆分出站 TCP/HTTP 连接池。默认关闭，因为会增加连接数、TLS 握手、内存和文件描述符占用。
-- `routing.segmentedSelectorEnabled`：用于大型账号池，同时保留完整选号回退与原子门禁。
+- `routing.segmentedSelectorEnabled`：默认对至少 3000 个可用账号的大号池启用，限制动态并发读取规模，同时保留额度/等级优先级、会话粘性、完整选号回退与原子门禁。
 - Build 响应头超时和精确匹配的 403 失效规则支持热加载。
 - “同步最新版本”可应用已验证的 Grok Build 客户端版本和 User-Agent。
 

--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -28,6 +28,7 @@ type accountLease struct {
 	QuotaProbe          bool
 	QuotaProbeKind      account.QuotaRecoveryKind
 	QuotaMode           string
+	routingCandidate    *account.RoutingCandidate
 	selectorObservation *selectorLeaseObservation
 	release             func()
 }
@@ -51,6 +52,12 @@ const maxRoutingOverlayValues = 250_000
 const concurrencySnapshotTTL = 25 * time.Millisecond
 const maxConcurrencySnapshots = 256
 
+// Health overrides bridge precise request-path mutations until the immutable
+// provider snapshot naturally refreshes. Keep them through the snapshot's
+// normal and stale lifetimes so a transient database error cannot resurrect a
+// cooled account from an older snapshot.
+const routingHealthOverrideTTL = candidateCacheTTL + candidateCacheStaleTTL
+
 const modelAccessDeniedCooldown = 5 * time.Minute
 
 // softNetworkCooldown 网络/超时/5xx 仅短暂隔离本号，避免指数冷却掏空热池。
@@ -73,6 +80,16 @@ type quotaConsumptionKey struct {
 type accountQuotaConsumptionKey struct {
 	accountID uint64
 	mode      string
+}
+
+type routingHealthOverride struct {
+	provider      account.Provider
+	failureCount  int
+	cooldownUntil *time.Time
+	lastError     string
+	updatedAt     time.Time
+	revision      uint64
+	expiresAt     time.Time
 }
 
 type candidateSnapshot struct {
@@ -268,6 +285,7 @@ type Selector struct {
 	configMu               sync.RWMutex
 	candidateMu            sync.Mutex
 	selectionMu            sync.RWMutex
+	healthMu               sync.RWMutex
 	quotaMu                sync.RWMutex
 	staleLogMu             sync.Mutex
 	logger                 *slog.Logger
@@ -275,6 +293,7 @@ type Selector struct {
 	leaseWake              chan struct{}
 	lastSelectedAt         map[uint64]time.Time
 	lastSuccessAt          map[uint64]time.Time
+	healthOverrides        map[uint64]routingHealthOverride
 	quotaConsumed          map[quotaConsumptionKey]int
 	staleFallbackLoggedAt  map[string]time.Time
 	candidates             map[candidateCacheKey]candidateSnapshot
@@ -299,7 +318,7 @@ func NewSelector(accounts repository.AccountRepository, concurrency repository.C
 	if len(capacityWait) > 0 && capacityWait[0] > 0 {
 		wait = capacityWait[0]
 	}
-	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), logger: slog.Default(), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), quotaConsumed: make(map[quotaConsumptionKey]int), staleFallbackLoggedAt: make(map[string]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), routingAccountProvider: make(map[uint64]account.Provider), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
+	return &Selector{accounts: accounts, concurrency: concurrency, sticky: sticky, tierOrders: tierOrders, stickyTTL: stickyTTL, cooldownBase: cooldownBase, cooldownMax: cooldownMax, capacityWait: wait, leaseWake: make(chan struct{}), logger: slog.Default(), lastSelectedAt: make(map[uint64]time.Time), lastSuccessAt: make(map[uint64]time.Time), healthOverrides: make(map[uint64]routingHealthOverride), quotaConsumed: make(map[quotaConsumptionKey]int), staleFallbackLoggedAt: make(map[string]time.Time), candidates: make(map[candidateCacheKey]candidateSnapshot), routingBases: make(map[routingBaseCacheKey]routingBaseSnapshot), routingOverlays: make(map[routingOverlayCacheKey]routingOverlaySnapshot), routingAccountProvider: make(map[uint64]account.Provider), baseProviderVersion: make(map[account.Provider]uint64), overlayProviderVersion: make(map[account.Provider]uint64), concurrencySnapshots: resultcache.New[[32]byte, map[string]int](maxConcurrencySnapshots, concurrencySnapshotTTL)}
 }
 
 // SetLogger wires the application logger into routing degradation diagnostics.
@@ -441,6 +460,7 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 		return nil, err
 	}
 	quotaConsumed := s.quotaConsumptionSnapshot(provider)
+	healthOverrides := s.routingHealthSnapshot(provider, now)
 	// 仅保留候选下标，避免每个请求复制包含凭据、计费和额度结构的完整账号切片。
 	normalCandidates := make([]int, 0, len(values))
 	probeCandidates := make([]int, 0, len(values))
@@ -451,7 +471,7 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 	quotaCandidates := 0
 	var earliestRetry time.Time
 	for index, candidate := range values {
-		value := candidate.Credential
+		value := applyHealthSnapshot(candidate.Credential, healthOverrides)
 		if forcedEgressNodeID != 0 && value.EgressNodeID != forcedEgressNodeID {
 			continue
 		}
@@ -615,11 +635,17 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 		}
 		return nil, &SelectionUnavailableError{Reason: SelectionSaturated, RetryAfter: time.Second}
 	}
-	if stickyKey == "" {
-		activeRequest := s.nextSegmentedActiveRequest(provider, upstreamModel, quotaMode, len(normalCandidates))
-		if activeRequest != nil {
-			return s.acquireSegmentedCandidates(ctx, values, normalCandidates, quotaMode, s.resolveTierOrder(provider, upstreamModel), *activeRequest)
+	activeRequest := s.nextSegmentedActiveRequest(provider, upstreamModel, quotaMode, len(normalCandidates))
+	if activeRequest != nil {
+		lease, acquireErr := s.acquireSegmentedCandidates(ctx, values, normalCandidates, quotaMode, s.resolveTierOrder(provider, upstreamModel), *activeRequest)
+		if acquireErr != nil || lease == nil || stickyKey == "" {
+			return lease, acquireErr
 		}
+		if lease.routingCandidate == nil {
+			lease.Release()
+			return nil, errors.New("分段选号缺少候选上下文")
+		}
+		return s.completeStickyLease(ctx, stickyKey, values, normalCandidates, *lease.routingCandidate, lease, quotaMode)
 	}
 	_, _, _, capacityWait := s.routingConfig()
 	waitDeadline := time.Now().Add(capacityWait)
@@ -644,42 +670,7 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 				capacityMisses++
 				continue
 			}
-			if stickyKey != "" {
-				stickyTTL, _, _, _ := s.routingConfig()
-				boundID, bindErr := s.sticky.Bind(ctx, stickyKey, candidate.Credential.ID, currentTime, currentTime.Add(stickyTTL))
-				if bindErr != nil {
-					lease.Release()
-					return nil, fmt.Errorf("写入会话粘滞状态: %w", bindErr)
-				}
-				if boundID != candidate.Credential.ID {
-					if boundCandidate, eligible := routingCandidateByID(values, normalCandidates, boundID); eligible {
-						boundLease, boundErr := s.acquirePinnedCapacity(ctx, boundCandidate.Credential)
-						if boundErr == nil {
-							lease.Release()
-							boundLease.Billing = boundCandidate.Billing
-							boundLease.QuotaMode = effectiveQuotaMode(boundCandidate, quotaMode)
-							return boundLease, nil
-						}
-						if errors.Is(boundErr, errRoutingCredentialStale) {
-							_ = s.sticky.DeleteByAccount(ctx, boundID)
-							if err := s.sticky.Set(ctx, stickyKey, candidate.Credential.ID, currentTime.Add(stickyTTL)); err != nil {
-								lease.Release()
-								return nil, fmt.Errorf("重建会话粘滞状态: %w", err)
-							}
-						} else if !isSelectionUnavailable(boundErr, SelectionSaturated) {
-							lease.Release()
-							return nil, boundErr
-						}
-						// 已绑定账号满载时保留原绑定，本次请求使用已获取的临时账号。
-					} else if err := s.sticky.Set(ctx, stickyKey, candidate.Credential.ID, currentTime.Add(stickyTTL)); err != nil {
-						lease.Release()
-						return nil, fmt.Errorf("重建会话粘滞状态: %w", err)
-					}
-				}
-			}
-			lease.Billing = candidate.Billing
-			lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
-			return lease, nil
+			return s.completeStickyLease(ctx, stickyKey, values, normalCandidates, candidate, lease, quotaMode)
 		}
 		if staleClaims > 0 && capacityMisses == 0 {
 			return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
@@ -695,6 +686,44 @@ func (s *Selector) acquire(ctx context.Context, provider account.Provider, model
 			return nil, &SelectionUnavailableError{Reason: SelectionSaturated, RetryAfter: time.Second}
 		}
 	}
+}
+
+func (s *Selector) completeStickyLease(ctx context.Context, stickyKey string, values []account.RoutingCandidate, normalCandidates []int, candidate account.RoutingCandidate, lease *accountLease, quotaMode string) (*accountLease, error) {
+	if stickyKey != "" {
+		stickyTTL, _, _, _ := s.routingConfig()
+		now := time.Now().UTC()
+		boundID, err := s.sticky.Bind(ctx, stickyKey, candidate.Credential.ID, now, now.Add(stickyTTL))
+		if err != nil {
+			lease.Release()
+			return nil, fmt.Errorf("写入会话粘滞状态: %w", err)
+		}
+		if boundID != candidate.Credential.ID {
+			if boundCandidate, eligible := routingCandidateByID(values, normalCandidates, boundID); eligible {
+				boundLease, acquireErr := s.acquirePinnedCapacity(ctx, boundCandidate.Credential)
+				if acquireErr == nil {
+					lease.Release()
+					lease = boundLease
+					candidate = boundCandidate
+				} else if errors.Is(acquireErr, errRoutingCredentialStale) {
+					_ = s.sticky.DeleteByAccount(ctx, boundID)
+					if err := s.sticky.Set(ctx, stickyKey, candidate.Credential.ID, now.Add(stickyTTL)); err != nil {
+						lease.Release()
+						return nil, fmt.Errorf("重建会话粘滞状态: %w", err)
+					}
+				} else if !isSelectionUnavailable(acquireErr, SelectionSaturated) {
+					lease.Release()
+					return nil, acquireErr
+				}
+				// 已绑定账号满载时保留原绑定，本次请求使用已获取的临时账号。
+			} else if err := s.sticky.Set(ctx, stickyKey, candidate.Credential.ID, now.Add(stickyTTL)); err != nil {
+				lease.Release()
+				return nil, fmt.Errorf("重建会话粘滞状态: %w", err)
+			}
+		}
+	}
+	lease.Billing = candidate.Billing
+	lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
+	return lease, nil
 }
 
 // stickySessionKey 将调用方粘滞 identity 压缩为固定长度，仅用于账号粘滞索引。
@@ -742,8 +771,9 @@ func (s *Selector) acquirePinned(ctx context.Context, provider account.Provider,
 		return nil, err
 	}
 	quotaConsumed := s.quotaConsumptionSnapshot(provider)
+	healthOverrides := s.routingHealthSnapshot(provider, now)
 	for _, candidate := range values {
-		value := candidate.Credential
+		value := applyHealthSnapshot(candidate.Credential, healthOverrides)
 		if value.ID != accountID {
 			continue
 		}
@@ -869,22 +899,29 @@ func (s *Selector) MarkSuccess(ctx context.Context, credential account.Credentia
 
 func (s *Selector) markSuccess(ctx context.Context, credential account.Credential, quotaProbe bool) {
 	now := time.Now().UTC()
-	persist := credential.FailureCount > 0 || credential.CooldownUntil != nil || credential.LastError != ""
+	healthChanged := credential.FailureCount > 0 || credential.CooldownUntil != nil || credential.LastError != ""
+	touchLastUsed := healthChanged
 	s.selectionMu.Lock()
 	if last := s.lastSuccessAt[credential.ID]; last.IsZero() || now.Sub(last) >= successPersistInterval {
-		persist = true
+		touchLastUsed = true
 	}
-	if persist {
+	if touchLastUsed {
 		s.lastSuccessAt[credential.ID] = now
 	}
 	s.selectionMu.Unlock()
-	if persist {
-		_ = s.accounts.UpdateHealth(ctx, credential.ID, 0, nil, "", true)
+	if healthChanged {
+		if err := s.accounts.UpdateHealth(ctx, credential.ID, credential.Provider, 0, nil, "", true); err == nil {
+			s.ApplyInvalidation(repository.InvalidationEvent{
+				Kind: repository.InvalidationAccountHealthChanged, Provider: credential.Provider, AccountID: credential.ID,
+			})
+		}
+	} else if touchLastUsed {
+		_ = s.accounts.TouchLastUsed(ctx, credential.ID, now)
 	}
 	if quotaProbe {
 		_ = s.accounts.ClearQuotaRecovery(ctx, credential.ID)
 	}
-	if quotaProbe || credential.FailureCount > 0 || credential.CooldownUntil != nil || credential.LastError != "" {
+	if quotaProbe {
 		s.evictCandidate(credential.Provider, credential.ID)
 	}
 }
@@ -1083,8 +1120,14 @@ func (s *Selector) markFailure(ctx context.Context, credential account.Credentia
 		}
 	}
 	until := time.Now().UTC().Add(cooldown)
-	healthErr := s.accounts.UpdateHealth(ctx, credential.ID, effectiveFailureCount, &until, fmt.Sprintf("upstream status %d", status), false)
-	s.invalidateCandidates(credential.Provider)
+	lastError := fmt.Sprintf("upstream status %d", status)
+	healthErr := s.accounts.UpdateHealth(ctx, credential.ID, credential.Provider, effectiveFailureCount, &until, lastError, false)
+	if healthErr == nil {
+		s.ApplyInvalidation(repository.InvalidationEvent{
+			Kind: repository.InvalidationAccountHealthChanged, Provider: credential.Provider, AccountID: credential.ID,
+			FailureCount: effectiveFailureCount, CooldownUntil: &until,
+		})
+	}
 	if status == 401 || status == 402 || status == 403 || status == 429 {
 		_ = s.sticky.DeleteByAccount(ctx, credential.ID)
 	}
@@ -1374,11 +1417,131 @@ func (s *Selector) routingVersionsStable(provider account.Provider, base, overla
 	return base == s.routingBaseVersionLocked(provider) && overlay == s.routingOverlayVersionLocked(provider)
 }
 
+func (s *Selector) applyHealthInvalidation(event repository.InvalidationEvent) {
+	updatedAt := event.PublishedAt.UTC()
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	expiresAt := updatedAt.Add(routingHealthOverrideTTL)
+	if !time.Now().UTC().Before(expiresAt) {
+		return
+	}
+	var cooldownUntil *time.Time
+	if event.CooldownUntil != nil {
+		value := event.CooldownUntil.UTC()
+		cooldownUntil = &value
+	}
+	overrideLastError := ""
+	if event.FailureCount > 0 || cooldownUntil != nil {
+		overrideLastError = "upstream failure"
+	}
+	value := routingHealthOverride{
+		provider: event.Provider, failureCount: max(0, event.FailureCount), cooldownUntil: cooldownUntil,
+		lastError: overrideLastError, updatedAt: updatedAt, revision: event.Revision, expiresAt: expiresAt,
+	}
+	s.healthMu.Lock()
+	current, exists := s.healthOverrides[event.AccountID]
+	if exists {
+		if current.revision > 0 && value.revision > 0 && value.revision < current.revision {
+			s.healthMu.Unlock()
+			return
+		}
+		if (current.revision == 0 || value.revision == 0) && value.updatedAt.Before(current.updatedAt) {
+			s.healthMu.Unlock()
+			return
+		}
+	}
+	s.healthOverrides[event.AccountID] = value
+	s.healthMu.Unlock()
+}
+
+func (s *Selector) applyRoutingHealth(value account.Credential, now time.Time) account.Credential {
+	s.healthMu.RLock()
+	override, exists := s.healthOverrides[value.ID]
+	s.healthMu.RUnlock()
+	if !exists || override.provider != value.Provider {
+		return value
+	}
+	if !now.Before(override.expiresAt) {
+		s.healthMu.Lock()
+		if current, ok := s.healthOverrides[value.ID]; ok && !now.Before(current.expiresAt) {
+			delete(s.healthOverrides, value.ID)
+		}
+		s.healthMu.Unlock()
+		return value
+	}
+	value.FailureCount = override.failureCount
+	value.CooldownUntil = override.cooldownUntil
+	value.LastError = override.lastError
+	return value
+}
+
+func (s *Selector) routingHealthSnapshot(provider account.Provider, now time.Time) map[uint64]routingHealthOverride {
+	var result map[uint64]routingHealthOverride
+	expired := make([]uint64, 0)
+	s.healthMu.RLock()
+	for accountID, value := range s.healthOverrides {
+		if !now.Before(value.expiresAt) {
+			expired = append(expired, accountID)
+			continue
+		}
+		if value.provider == provider {
+			if result == nil {
+				result = make(map[uint64]routingHealthOverride)
+			}
+			result[accountID] = value
+		}
+	}
+	s.healthMu.RUnlock()
+	if len(expired) > 0 {
+		s.healthMu.Lock()
+		for _, accountID := range expired {
+			if value, ok := s.healthOverrides[accountID]; ok && !now.Before(value.expiresAt) {
+				delete(s.healthOverrides, accountID)
+			}
+		}
+		s.healthMu.Unlock()
+	}
+	return result
+}
+
+func applyHealthSnapshot(value account.Credential, overrides map[uint64]routingHealthOverride) account.Credential {
+	if override, ok := overrides[value.ID]; ok && override.provider == value.Provider {
+		value.FailureCount = override.failureCount
+		value.CooldownUntil = override.cooldownUntil
+		value.LastError = override.lastError
+	}
+	return value
+}
+
+func (s *Selector) clearHealthOverrides(provider account.Provider, accountID uint64) {
+	s.healthMu.Lock()
+	defer s.healthMu.Unlock()
+	if accountID != 0 {
+		delete(s.healthOverrides, accountID)
+		return
+	}
+	if provider == "" {
+		clear(s.healthOverrides)
+		return
+	}
+	for id, value := range s.healthOverrides {
+		if value.provider == provider {
+			delete(s.healthOverrides, id)
+		}
+	}
+}
+
 // ApplyInvalidation advances local layer generations before any remote publish.
 func (s *Selector) ApplyInvalidation(event repository.InvalidationEvent) {
 	if !event.Valid() {
 		return
 	}
+	if event.Kind == repository.InvalidationAccountHealthChanged {
+		s.applyHealthInvalidation(event)
+		return
+	}
+	s.clearHealthOverrides(event.Provider, event.AccountID)
 	layer := event.Layer()
 	if layer != repository.InvalidationLayerRoute && layer != repository.InvalidationLayerBase && layer != repository.InvalidationLayerOverlay {
 		return
@@ -1696,6 +1859,11 @@ func (s *Selector) evictCandidate(provider account.Provider, accountID uint64) {
 }
 
 func (s *Selector) claimAccountSlot(ctx context.Context, value account.Credential) (*accountLease, error) {
+	now := time.Now().UTC()
+	value = s.applyRoutingHealth(value, now)
+	if value.CooldownUntil != nil && now.Before(*value.CooldownUntil) {
+		return nil, nil
+	}
 	limit := value.MaxConcurrent
 	if limit <= 0 {
 		limit = account.DefaultMaxConcurrent

--- a/backend/internal/application/gateway/selector_layered_test.go
+++ b/backend/internal/application/gateway/selector_layered_test.go
@@ -35,6 +35,8 @@ type layeredAccountRepository struct {
 	materialErrors map[uint64]error
 	materials      map[uint64]account.CredentialMaterial
 	materialCalls  []uint64
+	healthUpdates  []repository.InvalidationEvent
+	lastUsedAt     map[uint64]time.Time
 }
 
 type temporaryRoutingLoadError struct{ message string }
@@ -94,6 +96,33 @@ func (r *layeredAccountRepository) GetCredentialMaterial(_ context.Context, acco
 	return account.CredentialMaterial{AccountID: accountID, Provider: provider, AuthType: account.AuthTypeOAuth, EncryptedAccessToken: "encrypted"}, nil
 }
 
+func (r *layeredAccountRepository) UpdateHealth(_ context.Context, id uint64, _ account.Provider, failureCount int, cooldownUntil *time.Time, lastError string, _ bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	provider := account.ProviderBuild
+	for _, base := range r.bases {
+		if base.Credential.ID == id {
+			provider = base.Credential.Provider
+			break
+		}
+	}
+	r.healthUpdates = append(r.healthUpdates, repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: provider, AccountID: id,
+		FailureCount: failureCount, CooldownUntil: cooldownUntil,
+	})
+	return nil
+}
+
+func (r *layeredAccountRepository) TouchLastUsed(_ context.Context, id uint64, usedAt time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastUsedAt == nil {
+		r.lastUsedAt = make(map[uint64]time.Time)
+	}
+	r.lastUsedAt[id] = usedAt
+	return nil
+}
+
 func (r *layeredAccountRepository) ListRoutingAccountOverlays(_ context.Context, _ account.Provider, modelRouteID uint64, upstreamModel string) (account.RoutingOverlaySnapshot, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -148,6 +177,76 @@ func TestSelectorLayeredCacheReusesBaseAcrossModels(t *testing.T) {
 	baseCalls, modelACalls = repo.callCounts("model-a")
 	if baseCalls != 2 || modelACalls != 2 {
 		t.Fatalf("overlay invalidation reloaded base=%d overlay=%d", baseCalls, modelACalls)
+	}
+}
+
+func TestSelectorHealthInvalidationDoesNotRebuildProviderSnapshots(t *testing.T) {
+	repo := newLayeredRepositoryFixture()
+	selector := NewSelector(repo, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	now := time.Now().UTC()
+	if _, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false); err != nil {
+		t.Fatal(err)
+	}
+	baseCalls, overlayCalls := repo.callCounts("model-a")
+
+	cooldownUntil := now.Add(time.Minute)
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 1,
+		FailureCount: 1, CooldownUntil: &cooldownUntil, PublishedAt: now,
+	})
+	_, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	var unavailable *SelectionUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionCooling {
+		t.Fatalf("selection error = %v, want cooling", err)
+	}
+	if currentBase, currentOverlay := repo.callCounts("model-a"); currentBase != baseCalls || currentOverlay != overlayCalls {
+		t.Fatalf("health update rebuilt snapshots: base %d->%d overlay %d->%d", baseCalls, currentBase, overlayCalls, currentOverlay)
+	}
+
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 1, PublishedAt: time.Now().UTC(),
+	})
+	if _, err := selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false); err != nil {
+		t.Fatalf("cleared health override did not restore account: %v", err)
+	}
+	if currentBase, currentOverlay := repo.callCounts("model-a"); currentBase != baseCalls || currentOverlay != overlayCalls {
+		t.Fatalf("health recovery rebuilt snapshots: base %d->%d overlay %d->%d", baseCalls, currentBase, overlayCalls, currentOverlay)
+	}
+
+	selector.MarkFailure(context.Background(), repo.bases[0].Credential, 500, 0)
+	_, err = selector.beginSelectionSession(context.Background(), account.ProviderBuild, 0, "model-a", "", "", nil, false)
+	if !errors.As(err, &unavailable) || unavailable.Reason != SelectionCooling {
+		t.Fatalf("mark failure selection error = %v, want cooling", err)
+	}
+	if currentBase, currentOverlay := repo.callCounts("model-a"); currentBase != baseCalls || currentOverlay != overlayCalls {
+		t.Fatalf("mark failure rebuilt snapshots: base %d->%d overlay %d->%d", baseCalls, currentBase, overlayCalls, currentOverlay)
+	}
+}
+
+func TestSelectorHealthInvalidationRejectsOlderAccountRevision(t *testing.T) {
+	selector := NewSelector(nil, nil, nil, nil, time.Hour, time.Second, time.Minute)
+	now := time.Now().UTC()
+	cooldownUntil := now.Add(time.Minute)
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 7,
+		FailureCount: 2, CooldownUntil: &cooldownUntil, Revision: 20, PublishedAt: now,
+	})
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 7,
+		Revision: 19, PublishedAt: now.Add(time.Second),
+	})
+	value := selector.applyRoutingHealth(account.Credential{ID: 7, Provider: account.ProviderBuild}, now)
+	if value.FailureCount != 2 || value.CooldownUntil == nil || !value.CooldownUntil.Equal(cooldownUntil) {
+		t.Fatalf("older recovery replaced newer cooldown: %#v", value)
+	}
+
+	selector.ApplyInvalidation(repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 7,
+		Revision: 21, PublishedAt: now.Add(2 * time.Second),
+	})
+	value = selector.applyRoutingHealth(value, now)
+	if value.FailureCount != 0 || value.CooldownUntil != nil || value.LastError != "" {
+		t.Fatalf("newer recovery was not applied: %#v", value)
 	}
 }
 

--- a/backend/internal/application/gateway/selector_plan.go
+++ b/backend/internal/application/gateway/selector_plan.go
@@ -111,7 +111,7 @@ func (s *Selector) planCandidateIndexes(ctx context.Context, values []account.Ro
 	return s.planCandidateIndexesWithHints(ctx, values, indexes, now, tierOrder, nil, s.preferFreeBuildEnabled())
 }
 
-func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []account.RoutingCandidate, indexes []int, now time.Time, tierOrder []account.WebTier, concurrencyHints []int, preferFreeBuild bool) (*candidatePlan, error) {
+func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []account.RoutingCandidate, indexes []int, now time.Time, tierOrder []account.WebTier, concurrencyHints map[int]int, preferFreeBuild bool) (*candidatePlan, error) {
 	length := len(indexes)
 	if indexes == nil {
 		length = len(values)
@@ -141,7 +141,7 @@ func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []a
 			if indexes != nil {
 				index = indexes[position]
 			}
-			if concurrencyHints[index] != 0 {
+			if _, exists := concurrencyHints[index]; exists {
 				continue
 			}
 			missingIndexes = append(missingIndexes, index)
@@ -153,7 +153,7 @@ func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []a
 				return nil, err
 			}
 			for position, index := range missingIndexes {
-				concurrencyHints[index] = concurrencySnapshot[keys[position]] + 1
+				concurrencyHints[index] = concurrencySnapshot[keys[position]]
 			}
 		}
 		for position := range length {
@@ -161,7 +161,7 @@ func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []a
 			if indexes != nil {
 				index = indexes[position]
 			}
-			inFlight[position] = concurrencyHints[index] - 1
+			inFlight[position] = concurrencyHints[index]
 		}
 	}
 
@@ -210,21 +210,20 @@ func (s *Selector) planCandidateIndexesWithHints(ctx context.Context, values []a
 func (s *Selector) loadConcurrencySnapshot(ctx context.Context, keys []string) (map[string]int, error) {
 	cacheKey := concurrencySnapshotKey(keys)
 	load := func() (map[string]int, error) {
-		values := make(map[string]int, len(keys))
 		if batchReader, ok := s.concurrency.(repository.ConcurrencySnapshotReader); ok {
-			var err error
-			values, err = batchReader.CurrentMany(ctx, keys)
+			values, err := batchReader.CurrentMany(ctx, keys)
 			if err != nil {
 				return nil, fmt.Errorf("批量读取账号并发租约: %w", err)
 			}
-		} else {
-			for _, key := range keys {
-				current, err := s.concurrency.Current(ctx, key)
-				if err != nil {
-					return nil, fmt.Errorf("读取账号并发租约: %w", err)
-				}
-				values[key] = current
+			return values, nil
+		}
+		values := make(map[string]int, len(keys))
+		for _, key := range keys {
+			current, err := s.concurrency.Current(ctx, key)
+			if err != nil {
+				return nil, fmt.Errorf("读取账号并发租约: %w", err)
 			}
+			values[key] = current
 		}
 		return values, nil
 	}

--- a/backend/internal/application/gateway/selector_segmented.go
+++ b/backend/internal/application/gateway/selector_segmented.go
@@ -23,6 +23,8 @@ type segmentedSelectorState struct {
 type segmentedSelectorCohort struct {
 	supportsModel   bool
 	capabilityKnown bool
+	quotaKnown      bool
+	quotaAvailable  bool
 	preferFreeBuild bool
 	tier            int
 	priority        int
@@ -94,6 +96,12 @@ func segmentedSelectorCohortBetter(left, right segmentedSelectorCohort) bool {
 	}
 	if left.capabilityKnown != right.capabilityKnown {
 		return left.capabilityKnown
+	}
+	if left.quotaAvailable != right.quotaAvailable {
+		return left.quotaAvailable
+	}
+	if left.quotaKnown != right.quotaKnown {
+		return left.quotaKnown
 	}
 	if left.preferFreeBuild != right.preferFreeBuild {
 		return left.preferFreeBuild

--- a/backend/internal/application/gateway/selector_segmented_active.go
+++ b/backend/internal/application/gateway/selector_segmented_active.go
@@ -21,6 +21,14 @@ type segmentedSelectorCohortBucket struct {
 	indexes []int
 }
 
+type segmentedCohortSelection struct {
+	count   int
+	start   int
+	take    int
+	seen    int
+	indexes []int
+}
+
 type segmentedClaimResult struct {
 	lease          *accountLease
 	staleClaims    int
@@ -76,13 +84,13 @@ func (s *Selector) acquireSegmentedCandidates(ctx context.Context, values []acco
 				return nil, &SelectionUnavailableError{Reason: SelectionNoAccounts}
 			}
 		} else {
-			concurrencyHints := make([]int, len(values))
-			cohorts := segmentedCandidateCohorts(values, indexes, now, tierOrder, preferFreeBuild)
+			concurrencyHints := make(map[int]int, min(len(indexes), request.windowSize*segmentedWindowsBeforeFullFallback))
+			cohorts := segmentedCandidateCohorts(values, indexes, now, tierOrder, preferFreeBuild, request.cursor, request.windowSize, segmentedWindowsBeforeFullFallback)
 			roundWindows := 0
 			fallbackToFull := false
 			for cohortIndex, bucket := range cohorts {
 				for windowOffset := 0; windowOffset < len(bucket.indexes); windowOffset += request.windowSize {
-					windowIndexes := segmentedCohortWindow(bucket.indexes, request.cursor, windowOffset, request.windowSize)
+					windowIndexes := bucket.indexes[windowOffset:min(windowOffset+request.windowSize, len(bucket.indexes))]
 					windowsScanned++
 					roundWindows++
 					candidatesScanned += len(windowIndexes)
@@ -170,6 +178,8 @@ func (s *Selector) claimSegmentedPlan(ctx context.Context, plan *candidatePlan, 
 		}
 		lease.Billing = candidate.Billing
 		lease.QuotaMode = effectiveQuotaMode(candidate, quotaMode)
+		selected := candidate
+		lease.routingCandidate = &selected
 		lease.selectorObservation = &selectorLeaseObservation{provider: provider, stage: stage}
 		result.lease = lease
 		return result, nil
@@ -177,48 +187,85 @@ func (s *Selector) claimSegmentedPlan(ctx context.Context, plan *candidatePlan, 
 	return result, nil
 }
 
-func segmentedCandidateCohorts(values []account.RoutingCandidate, indexes []int, now time.Time, tierOrder []account.WebTier, preferFreeBuild bool) []segmentedSelectorCohortBucket {
-	buckets := make(map[segmentedSelectorCohort][]int)
-	appendCandidate := func(index int) {
+func segmentedCandidateCohorts(values []account.RoutingCandidate, indexes []int, now time.Time, tierOrder []account.WebTier, preferFreeBuild bool, cursor uint64, windowSize, maxWindows int) []segmentedSelectorCohortBucket {
+	if windowSize <= 0 || maxWindows <= 0 {
+		return nil
+	}
+	cohortFor := func(index int) segmentedSelectorCohort {
 		candidate := values[index]
 		cohort := segmentedSelectorCohort{
 			supportsModel: candidate.SupportsModel, capabilityKnown: candidate.ModelCapabilityKnown,
 			preferFreeBuild: preferFreeBuild && candidate.IsKnownFreeBuild(),
 			tier:            tierOrderRank(tierOrder, candidate.Credential.WebTier), priority: candidate.Credential.Priority,
 		}
+		if candidate.QuotaWindow != nil && candidate.QuotaWindow.Source == account.QuotaSourceUpstream {
+			cohort.quotaKnown = true
+			cohort.quotaAvailable = candidate.QuotaWindow.Remaining > 0
+		}
 		if candidate.Billing != nil {
 			cohort.billingFresh = now.Sub(candidate.Billing.SyncedAt) <= 30*time.Minute
 		}
-		buckets[cohort] = append(buckets[cohort], index)
+		return cohort
 	}
+	counts := make(map[segmentedSelectorCohort]int)
+	countCandidate := func(index int) { counts[cohortFor(index)]++ }
 	if indexes == nil {
 		for index := range values {
-			appendCandidate(index)
+			countCandidate(index)
 		}
 	} else {
 		for _, index := range indexes {
-			appendCandidate(index)
+			countCandidate(index)
 		}
 	}
-	result := make([]segmentedSelectorCohortBucket, 0, len(buckets))
-	for cohort, cohortIndexes := range buckets {
-		result = append(result, segmentedSelectorCohortBucket{cohort: cohort, indexes: cohortIndexes})
+	ordered := make([]segmentedSelectorCohort, 0, len(counts))
+	for cohort := range counts {
+		ordered = append(ordered, cohort)
 	}
-	sort.Slice(result, func(left, right int) bool {
-		return segmentedSelectorCohortBetter(result[left].cohort, result[right].cohort)
+	sort.Slice(ordered, func(left, right int) bool {
+		return segmentedSelectorCohortBetter(ordered[left], ordered[right])
 	})
-	return result
-}
 
-func segmentedCohortWindow(indexes []int, cursor uint64, offset, windowSize int) []int {
-	if len(indexes) == 0 || offset >= len(indexes) || windowSize <= 0 {
-		return nil
+	remainingWindows := maxWindows
+	selections := make(map[segmentedSelectorCohort]*segmentedCohortSelection)
+	result := make([]segmentedSelectorCohortBucket, 0, min(len(ordered), maxWindows))
+	for _, cohort := range ordered {
+		if remainingWindows == 0 {
+			break
+		}
+		count := counts[cohort]
+		take := min(count, remainingWindows*windowSize)
+		windows := (take + windowSize - 1) / windowSize
+		remainingWindows -= windows
+		selection := &segmentedCohortSelection{
+			count: count, start: int(cursor % uint64(count)), take: take, indexes: make([]int, take),
+		}
+		selections[cohort] = selection
+		result = append(result, segmentedSelectorCohortBucket{cohort: cohort, indexes: selection.indexes})
 	}
-	count := min(windowSize, len(indexes)-offset)
-	start := int(cursor % uint64(len(indexes)))
-	result := make([]int, count)
-	for position := range count {
-		result[position] = indexes[(start+offset+position)%len(indexes)]
+	fillCandidate := func(index int) {
+		selection := selections[cohortFor(index)]
+		if selection == nil {
+			return
+		}
+		position := selection.seen
+		selection.seen++
+		relative := position - selection.start
+		if relative < 0 {
+			relative += selection.count
+		}
+		if relative < selection.take {
+			selection.indexes[relative] = index
+		}
+	}
+	if indexes == nil {
+		for index := range values {
+			fillCandidate(index)
+		}
+	} else {
+		for _, index := range indexes {
+			fillCandidate(index)
+		}
 	}
 	return result
 }

--- a/backend/internal/application/gateway/selector_segmented_active_test.go
+++ b/backend/internal/application/gateway/selector_segmented_active_test.go
@@ -29,6 +29,23 @@ func BenchmarkSelectorSegmentedCandidatePlanning(b *testing.B) {
 	}
 }
 
+func TestSegmentedCandidateCohortsRetainOnlyBoundedRotatingWindows(t *testing.T) {
+	const candidateCount = 10_000
+	values := make([]account.RoutingCandidate, candidateCount)
+	for index := range values {
+		values[index] = account.RoutingCandidate{Credential: account.Credential{
+			ID: uint64(index + 1), Provider: account.ProviderBuild, Priority: account.DefaultPriority,
+		}}
+	}
+	buckets := segmentedCandidateCohorts(values, nil, time.Now().UTC(), nil, false, 9980, 64, segmentedWindowsBeforeFullFallback)
+	if len(buckets) != 1 || len(buckets[0].indexes) != 256 {
+		t.Fatalf("bounded cohorts = %#v", buckets)
+	}
+	if buckets[0].indexes[0] != 9980 || buckets[0].indexes[19] != 9999 || buckets[0].indexes[20] != 0 || buckets[0].indexes[255] != 235 {
+		t.Fatalf("rotating indexes = first:%d before-wrap:%d after-wrap:%d last:%d", buckets[0].indexes[0], buckets[0].indexes[19], buckets[0].indexes[20], buckets[0].indexes[255])
+	}
+}
+
 func benchmarkSegmentedSelector(b *testing.B, candidateCount int, enabled, forceFullFallback bool) {
 	b.Helper()
 	limiter := newSegmentedSelectiveLimiter()
@@ -187,15 +204,20 @@ func TestSegmentedActiveCohortOrderingMatchesFullPlannerHardOrder(t *testing.T) 
 	cohorts := make([]segmentedSelectorCohort, 0, 64)
 	for _, supportsModel := range []bool{false, true} {
 		for _, capabilityKnown := range []bool{false, true} {
-			for _, preferFreeBuild := range []bool{false, true} {
-				for _, tier := range []int{0, 2} {
-					for _, priority := range []int{1, 10} {
-						for _, billingFresh := range []bool{false, true} {
-							cohorts = append(cohorts, segmentedSelectorCohort{
-								supportsModel: supportsModel, capabilityKnown: capabilityKnown,
-								preferFreeBuild: preferFreeBuild, tier: tier, priority: priority,
-								billingFresh: billingFresh,
-							})
+			for _, quotaKnown := range []bool{false, true} {
+				for _, quotaAvailable := range []bool{false, true} {
+					for _, preferFreeBuild := range []bool{false, true} {
+						for _, tier := range []int{0, 2} {
+							for _, priority := range []int{1, 10} {
+								for _, billingFresh := range []bool{false, true} {
+									cohorts = append(cohorts, segmentedSelectorCohort{
+										supportsModel: supportsModel, capabilityKnown: capabilityKnown,
+										quotaKnown: quotaKnown, quotaAvailable: quotaAvailable,
+										preferFreeBuild: preferFreeBuild, tier: tier, priority: priority,
+										billingFresh: billingFresh,
+									})
+								}
+							}
 						}
 					}
 				}
@@ -212,8 +234,8 @@ func TestSegmentedActiveCohortOrderingMatchesFullPlannerHardOrder(t *testing.T) 
 				{Credential: account.Credential{ID: 2, Priority: right.priority}, SupportsModel: right.supportsModel, ModelCapabilityKnown: right.capabilityKnown},
 			}
 			scores := []candidateScore{
-				{index: 0, tier: left.tier, preferFreeBuild: left.preferFreeBuild, billingFresh: left.billingFresh},
-				{index: 1, tier: right.tier, preferFreeBuild: right.preferFreeBuild, billingFresh: right.billingFresh},
+				{index: 0, tier: left.tier, quotaKnown: left.quotaKnown, quotaAvailable: left.quotaAvailable, preferFreeBuild: left.preferFreeBuild, billingFresh: left.billingFresh},
+				{index: 1, tier: right.tier, quotaKnown: right.quotaKnown, quotaAvailable: right.quotaAvailable, preferFreeBuild: right.preferFreeBuild, billingFresh: right.billingFresh},
 			}
 			if got, want := segmentedSelectorCohortBetter(left, right), candidateScoreBetter(values, scores[0], scores[1]); got != want {
 				t.Fatalf("cohort order mismatch at %d/%d: got %t want %t", leftIndex, rightIndex, got, want)
@@ -320,6 +342,34 @@ func TestSegmentedActiveFallsBackToFullPlannerAfterBoundedWindows(t *testing.T) 
 	}
 }
 
+func TestSegmentedActiveBindsAndReusesStickyAccount(t *testing.T) {
+	limiter := newSegmentedSelectiveLimiter()
+	selector := newSegmentedActiveTestSelector(100, limiter, nil)
+	selector.UpdateSegmentedSelector(true, 100, 8)
+
+	first, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model", "", "sticky-session", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectedID := first.Credential.ID
+	first.Release()
+	if sizes := limiter.BatchSizes(); fmt.Sprint(sizes) != "[8]" {
+		t.Fatalf("initial sticky selection did not use bounded window: %v", sizes)
+	}
+
+	second, err := selector.Acquire(context.Background(), account.ProviderBuild, 0, "model", "", "sticky-session", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Release()
+	if second.Credential.ID != selectedID {
+		t.Fatalf("sticky account = %d, want %d", second.Credential.ID, selectedID)
+	}
+	if sizes := limiter.BatchSizes(); fmt.Sprint(sizes) != "[8]" {
+		t.Fatalf("sticky reuse rebuilt concurrency plan: %v", sizes)
+	}
+}
+
 func TestSegmentedActiveWaitsAndRescansAfterCapacityReturns(t *testing.T) {
 	limiter := newSegmentedSelectiveLimiter()
 	for id := uint64(1); id <= 100; id++ {
@@ -406,17 +456,15 @@ func TestSegmentedActiveUsesFullPlannerAfterExhaustingSmallPool(t *testing.T) {
 	}
 }
 
-func TestSegmentedActiveSkipsStickyPinnedAndSmallPools(t *testing.T) {
+func TestSegmentedActiveSkipsPinnedAndSmallPools(t *testing.T) {
 	tests := []struct {
-		name     string
-		count    int
-		affinity string
-		pinned   bool
-		enabled  bool
+		name    string
+		count   int
+		pinned  bool
+		enabled bool
 	}{
 		{name: "disabled", count: 100},
 		{name: "small pool", count: 99, enabled: true},
-		{name: "sticky", count: 100, affinity: "session", enabled: true},
 		{name: "pinned", count: 100, pinned: true, enabled: true},
 	}
 	for _, test := range tests {
@@ -429,7 +477,7 @@ func TestSegmentedActiveSkipsStickyPinnedAndSmallPools(t *testing.T) {
 			if test.pinned {
 				lease, err = selector.AcquirePinned(context.Background(), account.ProviderBuild, 1, 0, "model", "", true)
 			} else {
-				lease, err = selector.Acquire(context.Background(), account.ProviderBuild, 0, "model", "", test.affinity, nil, false)
+				lease, err = selector.Acquire(context.Background(), account.ProviderBuild, 0, "model", "", "", nil, false)
 			}
 			if err != nil {
 				t.Fatal(err)

--- a/backend/internal/application/gateway/selector_session.go
+++ b/backend/internal/application/gateway/selector_session.go
@@ -46,6 +46,7 @@ func (s *Selector) beginSelectionSessionForKey(ctx context.Context, provider acc
 		return nil, err
 	}
 	quotaConsumed := s.quotaConsumptionSnapshot(provider)
+	healthOverrides := s.routingHealthSnapshot(provider, now)
 
 	session = &selectionSession{
 		selector:        s,
@@ -66,7 +67,7 @@ func (s *Selector) beginSelectionSessionForKey(ctx context.Context, provider acc
 	var earliestRetry time.Time
 
 	for index, candidate := range values {
-		value := candidate.Credential
+		value := applyHealthSnapshot(candidate.Credential, healthOverrides)
 		if !accountScopeAllowsCandidate(provider, accountScope, candidate) {
 			continue
 		}
@@ -252,12 +253,18 @@ func (session *selectionSession) acquireNormal(ctx context.Context, excluded map
 			}
 		}
 	}
-	if session.stickyKey == "" {
-		indexes := session.unexcludedNormalIndexes(excluded)
-		activeRequest := session.selector.nextSegmentedActiveRequest(session.provider, session.upstreamModel, session.quotaMode, len(indexes))
-		if activeRequest != nil {
-			return session.selector.acquireSegmentedCandidates(ctx, session.values, indexes, session.quotaMode, session.selector.resolveTierOrder(session.provider, session.upstreamModel), *activeRequest)
+	indexes := session.unexcludedNormalIndexes(excluded)
+	activeRequest := session.selector.nextSegmentedActiveRequest(session.provider, session.upstreamModel, session.quotaMode, len(indexes))
+	if activeRequest != nil {
+		lease, err := session.selector.acquireSegmentedCandidates(ctx, session.values, indexes, session.quotaMode, session.selector.resolveTierOrder(session.provider, session.upstreamModel), *activeRequest)
+		if err != nil || lease == nil || session.stickyKey == "" {
+			return lease, err
 		}
+		if lease.routingCandidate == nil {
+			lease.Release()
+			return nil, errors.New("分段选号缺少候选上下文")
+		}
+		return session.completeNormalLease(ctx, lease, *lease.routingCandidate, excluded)
 	}
 
 	deadline := time.Now().Add(capacityWait)
@@ -353,6 +360,9 @@ func (session *selectionSession) hasUnexcludedNormal(excluded map[uint64]bool) b
 }
 
 func (session *selectionSession) unexcludedNormalIndexes(excluded map[uint64]bool) []int {
+	if len(excluded) == 0 && len(session.staleCandidates) == 0 {
+		return session.normalCandidates
+	}
 	indexes := make([]int, 0, len(session.normalCandidates))
 	for _, index := range session.normalCandidates {
 		if !session.candidateExcluded(excluded, session.values[index].Credential.ID) {

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -362,7 +362,7 @@ func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 	adapter.resetAttempts()
 	expiredCooldown := time.Now().UTC().Add(-time.Minute)
 	for _, accountID := range []uint64{first.ID, second.ID} {
-		if err := accountRepo.UpdateHealth(ctx, accountID, 3, &expiredCooldown, "previous upstream failures", false); err != nil {
+		if err := accountRepo.UpdateHealth(ctx, accountID, account.ProviderBuild, 3, &expiredCooldown, "previous upstream failures", false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -473,7 +473,7 @@ type blockingHealthAccountRepository struct {
 	once    sync.Once
 }
 
-func (r *blockingHealthAccountRepository) UpdateHealth(ctx context.Context, id uint64, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error {
+func (r *blockingHealthAccountRepository) UpdateHealth(ctx context.Context, id uint64, provider account.Provider, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error {
 	if !success {
 		r.once.Do(func() { close(r.started) })
 		select {
@@ -482,7 +482,7 @@ func (r *blockingHealthAccountRepository) UpdateHealth(ctx context.Context, id u
 			return ctx.Err()
 		}
 	}
-	return r.AccountRepository.UpdateHealth(ctx, id, failureCount, cooldownUntil, lastError, success)
+	return r.AccountRepository.UpdateHealth(ctx, id, provider, failureCount, cooldownUntil, lastError, success)
 }
 
 func TestRoutingAttemptPolicy(t *testing.T) {

--- a/backend/internal/application/invalidation/service.go
+++ b/backend/internal/application/invalidation/service.go
@@ -101,6 +101,7 @@ func (s *Service) RunPublisher(ctx context.Context) error {
 type invalidationKey struct {
 	layer       repository.InvalidationLayer
 	provider    string
+	accountID   uint64
 	clientKeyID uint64
 }
 
@@ -108,6 +109,10 @@ func eventKey(event repository.InvalidationEvent) invalidationKey {
 	key := invalidationKey{layer: event.Layer(), provider: string(event.Provider)}
 	if key.layer == repository.InvalidationLayerClientKey {
 		key.clientKeyID = event.ClientKeyID
+	} else if event.Kind == repository.InvalidationAccountHealthChanged {
+		// Health events are intentionally account-scoped. Coalescing different
+		// accounts would silently drop cooldown updates on multi-replica setups.
+		key.accountID = event.AccountID
 	}
 	return key
 }

--- a/backend/internal/application/invalidation/service_test.go
+++ b/backend/internal/application/invalidation/service_test.go
@@ -106,3 +106,11 @@ func TestEventKeyKeepsClientKeyInvalidationsDistinct(t *testing.T) {
 		t.Fatalf("client-key invalidation keys were coalesced: first=%#v second=%#v global=%#v", first, second, global)
 	}
 }
+
+func TestEventKeyKeepsAccountHealthInvalidationsDistinct(t *testing.T) {
+	first := eventKey(repository.InvalidationEvent{Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 1})
+	second := eventKey(repository.InvalidationEvent{Kind: repository.InvalidationAccountHealthChanged, Provider: account.ProviderBuild, AccountID: 2})
+	if first == second {
+		t.Fatalf("account health invalidations were coalesced: first=%#v second=%#v", first, second)
+	}
+}

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -831,7 +831,7 @@ func defaultConfig() Config {
 			MarkBuildChatDeniedAsReauth: false,
 			PreferFreeBuild:             false,
 			AccountIsolatedConnections:  false,
-			SegmentedSelectorEnabled:    false,
+			SegmentedSelectorEnabled:    true,
 			SegmentedMinCandidates:      3000,
 			SegmentedWindowSize:         64,
 			ReasoningReplayEnabled:      true,

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -151,7 +151,7 @@ bootstrapAdmin:
 	if cfg.Routing.PreferFreeBuild {
 		t.Fatal("preferFreeBuild should retain its false default when omitted from YAML")
 	}
-	if cfg.Routing.SegmentedSelectorEnabled || cfg.Routing.SegmentedMinCandidates != 3000 || cfg.Routing.SegmentedWindowSize != 64 {
+	if !cfg.Routing.SegmentedSelectorEnabled || cfg.Routing.SegmentedMinCandidates != 3000 || cfg.Routing.SegmentedWindowSize != 64 {
 		t.Fatalf("segmented selector defaults = %#v", cfg.Routing)
 	}
 	if cfg.Accounts.AutoCleanReauthEnabled || cfg.Accounts.AutoCleanIncludeDisabled {

--- a/backend/internal/infra/persistence/relational/account_repository.go
+++ b/backend/internal/infra/persistence/relational/account_repository.go
@@ -685,7 +685,7 @@ func (r *AccountRepository) ListRoutingAccountOverlays(ctx context.Context, prov
 	var states []accountModelSyncStateModel
 	if err := r.db.db.WithContext(ctx).
 		Table("account_model_sync_states AS state").
-		Select("state.*").
+		Select("state.account_id").
 		Joins("JOIN provider_accounts AS account ON account.id = state.account_id").
 		Where("account.provider = ? AND account.enabled = TRUE AND state.last_success_at IS NOT NULL", provider).
 		Find(&states).Error; err != nil {
@@ -700,7 +700,7 @@ func (r *AccountRepository) ListRoutingAccountOverlays(ctx context.Context, prov
 	var capabilities []accountModelCapabilityModel
 	if err := r.db.db.WithContext(ctx).
 		Table("account_model_capabilities AS capability").
-		Select("capability.*").
+		Select("capability.account_id").
 		Joins("JOIN provider_accounts AS account ON account.id = capability.account_id").
 		Where("account.provider = ? AND account.enabled = TRUE AND capability.upstream_model = ?", provider, upstreamModel).
 		Find(&capabilities).Error; err != nil {
@@ -715,7 +715,7 @@ func (r *AccountRepository) ListRoutingAccountOverlays(ctx context.Context, prov
 	var blockRows []accountModelQuotaBlockModel
 	if err := r.db.db.WithContext(ctx).
 		Table("account_model_quota_blocks AS block").
-		Select("block.*").
+		Select("block.account_id", "block.upstream_model", "block.reason", "block.cooldown_until", "block.updated_at").
 		Joins("JOIN provider_accounts AS account ON account.id = block.account_id").
 		Where("account.provider = ? AND account.enabled = TRUE AND block.upstream_model = ? AND block.cooldown_until > ?", provider, upstreamModel, time.Now().UTC()).
 		Find(&blockRows).Error; err != nil {
@@ -2068,17 +2068,43 @@ func (r *AccountRepository) MarkBuildAPIFallback(ctx context.Context, id uint64,
 	return nil
 }
 
-func (r *AccountRepository) UpdateHealth(ctx context.Context, id uint64, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error {
-	updates := map[string]any{"failure_count": failureCount, "cooldown_until": cooldownUntil, "last_error": truncate(lastError, 512)}
+func (r *AccountRepository) UpdateHealth(ctx context.Context, id uint64, provider account.Provider, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error {
+	if id == 0 || !provider.IsValid() {
+		return repository.ErrNotFound
+	}
+	failureCount = max(0, failureCount)
+	lastError = truncate(lastError, 512)
+	updates := map[string]any{"failure_count": failureCount, "cooldown_until": cooldownUntil, "last_error": lastError}
 	if success {
 		now := time.Now().UTC()
 		updates["last_used_at"] = &now
 	}
-	err := r.db.db.WithContext(ctx).Model(&accountModel{}).Where("id = ?", id).Updates(updates).Error
-	if err == nil && !success {
-		r.notifyInvalidation(ctx, repository.InvalidationEvent{Kind: repository.InvalidationAccountStateChanged, AccountID: id})
+	result := r.db.db.WithContext(ctx).Model(&accountModel{}).Where("id = ? AND provider = ?", id, provider).Updates(updates)
+	if result.Error != nil {
+		return mapError(result.Error)
 	}
-	return err
+	if result.RowsAffected == 0 {
+		return repository.ErrNotFound
+	}
+	r.notifyInvalidation(ctx, repository.InvalidationEvent{
+		Kind: repository.InvalidationAccountHealthChanged, Provider: provider, AccountID: id,
+		FailureCount: failureCount, CooldownUntil: cooldownUntil,
+	})
+	return nil
+}
+
+func (r *AccountRepository) TouchLastUsed(ctx context.Context, id uint64, usedAt time.Time) error {
+	if id == 0 || usedAt.IsZero() {
+		return repository.ErrNotFound
+	}
+	result := r.db.db.WithContext(ctx).Model(&accountModel{}).Where("id = ?", id).Update("last_used_at", usedAt.UTC())
+	if result.Error != nil {
+		return mapError(result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return repository.ErrNotFound
+	}
+	return nil
 }
 
 func (r *AccountRepository) UpsertModelQuotaBlock(ctx context.Context, value account.ModelQuotaBlock) error {
@@ -2218,11 +2244,11 @@ func (r *AccountRepository) ClaimQuotaProbe(ctx context.Context, accountID uint6
 }
 
 func (r *AccountRepository) ClearQuotaRecovery(ctx context.Context, accountID uint64) error {
-	err := r.db.db.WithContext(ctx).Delete(&quotaRecoveryModel{}, "account_id = ?", accountID).Error
-	if err == nil {
+	result := r.db.db.WithContext(ctx).Delete(&quotaRecoveryModel{}, "account_id = ?", accountID)
+	if result.Error == nil && result.RowsAffected > 0 {
 		r.notifyInvalidation(ctx, repository.InvalidationEvent{Kind: repository.InvalidationAccountRecoveryChanged, AccountID: accountID})
 	}
-	return err
+	return result.Error
 }
 
 func (r *AccountRepository) ResetQuotaState(ctx context.Context, provider account.Provider, accountIDs []uint64) error {

--- a/backend/internal/infra/persistence/relational/invalidation_test.go
+++ b/backend/internal/infra/persistence/relational/invalidation_test.go
@@ -89,6 +89,53 @@ func TestRoutingMutationsNotifyAfterCommit(t *testing.T) {
 	}
 }
 
+func TestAccountHealthMutationPublishesPreciseInvalidation(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenSQLite(ctx, filepath.Join(t.TempDir(), "health-invalidation.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "health", SourceKey: "health", EncryptedAccessToken: "encrypted",
+		Enabled: true, AuthStatus: account.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []repository.InvalidationEvent
+	accounts.SetInvalidationObserver(func(_ context.Context, event repository.InvalidationEvent) {
+		events = append(events, event)
+	})
+	cooldownUntil := time.Now().UTC().Add(time.Minute)
+	if err := accounts.UpdateHealth(ctx, credential.ID, account.ProviderWeb, 2, &cooldownUntil, "wrong provider", false); err != repository.ErrNotFound {
+		t.Fatalf("mismatched provider error = %v, want not found", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("mismatched provider emitted invalidation: %#v", events)
+	}
+	if err := accounts.UpdateHealth(ctx, credential.ID, credential.Provider, 2, &cooldownUntil, "upstream status 429", false); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("health events = %#v", events)
+	}
+	event := events[0]
+	if event.Kind != repository.InvalidationAccountHealthChanged || event.Provider != account.ProviderBuild || event.AccountID != credential.ID || event.FailureCount != 2 || event.CooldownUntil == nil || !event.CooldownUntil.Equal(cooldownUntil) {
+		t.Fatalf("health event = %#v", event)
+	}
+	if err := accounts.TouchLastUsed(ctx, credential.ID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("last-used touch emitted routing invalidation: %#v", events[1:])
+	}
+}
+
 func TestClientKeyMutationsNotifyAfterCommit(t *testing.T) {
 	ctx := context.Background()
 	database, err := OpenSQLite(ctx, filepath.Join(t.TempDir(), "client-key-invalidation.db"))

--- a/backend/internal/infra/persistence/relational/repository_test.go
+++ b/backend/internal/infra/persistence/relational/repository_test.go
@@ -41,7 +41,7 @@ func TestSchemaAndRepositoryConstraints(t *testing.T) {
 	if err := accountRepo.UpdateObservedModel(context.Background(), created.ID, "grok-observed", observedAt); err != nil {
 		t.Fatal(err)
 	}
-	if err := accountRepo.UpdateHealth(context.Background(), created.ID, 0, nil, "", true); err != nil {
+	if err := accountRepo.UpdateHealth(context.Background(), created.ID, created.Provider, 0, nil, "", true); err != nil {
 		t.Fatal(err)
 	}
 	value.Name = "updated"
@@ -314,7 +314,7 @@ func TestAccountRepositorySummarizesOperationalStates(t *testing.T) {
 	create(account.ProviderBuild, "build-active")
 	cooldown := create(account.ProviderBuild, "build-cooldown")
 	cooldownUntil := now.Add(time.Hour)
-	if err := repo.UpdateHealth(ctx, cooldown.ID, 1, &cooldownUntil, "cooldown", false); err != nil {
+	if err := repo.UpdateHealth(ctx, cooldown.ID, cooldown.Provider, 1, &cooldownUntil, "cooldown", false); err != nil {
 		t.Fatal(err)
 	}
 	disabled := create(account.ProviderBuild, "build-disabled")

--- a/backend/internal/infra/runtime/memory/store.go
+++ b/backend/internal/infra/runtime/memory/store.go
@@ -136,7 +136,9 @@ func (l *ConcurrencyLimiter) Current(_ context.Context, key string) (int, error)
 }
 
 func (l *ConcurrencyLimiter) CurrentMany(_ context.Context, keys []string) (map[string]int, error) {
-	values := make(map[string]int, len(keys))
+	// Most accounts have no active lease. Keep the sparse result contract used
+	// by the planner instead of allocating one map entry for every candidate.
+	values := make(map[string]int)
 	if len(keys) == 0 {
 		return values, nil
 	}
@@ -177,7 +179,9 @@ func (l *ConcurrencyLimiter) CurrentMany(_ context.Context, keys []string) (map[
 		shard.mu.Lock()
 		for _, keyIndex := range grouped[offsets[shardIndex]:offsets[shardIndex+1]] {
 			key := keys[keyIndex]
-			values[key] = shard.counts[key]
+			if count := shard.counts[key]; count > 0 {
+				values[key] = count
+			}
 		}
 		shard.mu.Unlock()
 	}

--- a/backend/internal/infra/runtime/redis/store.go
+++ b/backend/internal/infra/runtime/redis/store.go
@@ -586,22 +586,24 @@ func (s *Store) Current(ctx context.Context, key string) (int, error) {
 }
 
 func (s *Store) CurrentMany(ctx context.Context, keys []string) (map[string]int, error) {
-	values := make(map[string]int, len(keys))
+	values := make(map[string]int)
 	if len(keys) == 0 {
 		return values, nil
 	}
 	now := "(" + strconv.FormatInt(time.Now().UTC().UnixMilli(), 10)
 	pipe := s.client.Pipeline()
-	counts := make(map[string]*redisclient.IntCmd, len(keys))
-	for _, key := range keys {
+	counts := make([]*redisclient.IntCmd, len(keys))
+	for index, key := range keys {
 		redisKey := s.key("concurrency", key)
-		counts[key] = pipe.ZCount(ctx, redisKey, now, "+inf")
+		counts[index] = pipe.ZCount(ctx, redisKey, now, "+inf")
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return nil, err
 	}
-	for key, count := range counts {
-		values[key] = int(count.Val())
+	for index, count := range counts {
+		if value := int(count.Val()); value > 0 {
+			values[keys[index]] = value
+		}
 	}
 	return values, nil
 }

--- a/backend/internal/repository/account.go
+++ b/backend/internal/repository/account.go
@@ -147,7 +147,10 @@ type AccountRepository interface {
 	NextCredentialRefreshDueAt(ctx context.Context) (*time.Time, error)
 	UpdateCredentialRefreshFailure(ctx context.Context, id uint64, failure CredentialRefreshFailure) error
 	UpdateObservedModel(ctx context.Context, id uint64, model string, observedAt time.Time) error
-	UpdateHealth(ctx context.Context, id uint64, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error
+	UpdateHealth(ctx context.Context, id uint64, provider account.Provider, failureCount int, cooldownUntil *time.Time, lastError string, success bool) error
+	// TouchLastUsed persists request activity without changing routing health or
+	// invalidating candidate snapshots.
+	TouchLastUsed(ctx context.Context, id uint64, usedAt time.Time) error
 	// MarkBuildAPIFallback 幂等写入 Build 账号的 XAI 推理回退标记；非 Build 账号返回错误。
 	MarkBuildAPIFallback(ctx context.Context, id uint64, enabled bool) error
 	// MarkWebNSFWEnabled 幂等记录 Web 账号首次确认 NSFW 已开启的时间。

--- a/backend/internal/repository/runtime.go
+++ b/backend/internal/repository/runtime.go
@@ -26,6 +26,7 @@ type ConcurrencyLimiter interface {
 }
 
 // ConcurrencySnapshotReader 批量读取并发租约快照；调度器会优先使用它减少远程运行态往返。
+// 返回值允许省略计数为零的键，读取方必须将缺失项视为零。
 type ConcurrencySnapshotReader interface {
 	CurrentMany(ctx context.Context, keys []string) (map[string]int, error)
 }
@@ -89,9 +90,13 @@ type SettingsChangeBus interface {
 type InvalidationKind string
 
 const (
-	InvalidationRouteChanged             InvalidationKind = "route_changed"
-	InvalidationModelBindingChanged      InvalidationKind = "model_binding_changed"
-	InvalidationAccountStateChanged      InvalidationKind = "account_state_changed"
+	InvalidationRouteChanged        InvalidationKind = "route_changed"
+	InvalidationModelBindingChanged InvalidationKind = "model_binding_changed"
+	InvalidationAccountStateChanged InvalidationKind = "account_state_changed"
+	// InvalidationAccountHealthChanged carries the exact request-path health
+	// mutation for one account. Unlike an arbitrary account state change, it can
+	// be applied as a small runtime overlay without rebuilding the provider pool.
+	InvalidationAccountHealthChanged     InvalidationKind = "account_health_changed"
 	InvalidationAccountCredentialChanged InvalidationKind = "account_credential_changed"
 	InvalidationAccountCapabilityChanged InvalidationKind = "account_capability_changed"
 	InvalidationAccountBillingChanged    InvalidationKind = "account_billing_changed"
@@ -116,6 +121,8 @@ type InvalidationEvent struct {
 	AccountID      uint64           `json:"accountId,omitempty"`
 	ClientKeyID    uint64           `json:"clientKeyId,omitempty"`
 	UpstreamModel  string           `json:"upstreamModel,omitempty"`
+	FailureCount   int              `json:"failureCount,omitempty"`
+	CooldownUntil  *time.Time       `json:"cooldownUntil,omitempty"`
 	Revision       uint64           `json:"revision,omitempty"`
 	SourceInstance string           `json:"sourceInstance,omitempty"`
 	PublishedAt    time.Time        `json:"publishedAt,omitempty"`
@@ -127,7 +134,7 @@ func (e InvalidationEvent) Layer() InvalidationLayer {
 		return InvalidationLayerRoute
 	case InvalidationModelBindingChanged, InvalidationAccountCapabilityChanged, InvalidationAccountModelQuotaChanged:
 		return InvalidationLayerOverlay
-	case InvalidationAccountStateChanged, InvalidationAccountCredentialChanged, InvalidationAccountBillingChanged, InvalidationAccountQuotaChanged, InvalidationAccountRecoveryChanged:
+	case InvalidationAccountStateChanged, InvalidationAccountHealthChanged, InvalidationAccountCredentialChanged, InvalidationAccountBillingChanged, InvalidationAccountQuotaChanged, InvalidationAccountRecoveryChanged:
 		return InvalidationLayerBase
 	case InvalidationClientKeyChanged:
 		return InvalidationLayerClientKey
@@ -143,6 +150,9 @@ func (e InvalidationEvent) Valid() bool {
 	}
 	if layer == InvalidationLayerClientKey {
 		return e.Provider == "" && e.AccountID == 0 && e.UpstreamModel == ""
+	}
+	if e.Kind == InvalidationAccountHealthChanged {
+		return e.AccountID != 0 && (e.Provider == account.ProviderBuild || e.Provider == account.ProviderWeb || e.Provider == account.ProviderConsole)
 	}
 	switch e.Provider {
 	case "", account.ProviderBuild, account.ProviderWeb, account.ProviderConsole:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,8 +91,8 @@ routing:
   reasoningReplayMaxEntries: 10240
   # [按需修改] 按账号隔离上游连接池，适合外部 L4/连接哈希负载均衡；会增加连接数、TLS 握手和文件描述符占用。
   accountIsolatedConnections: false
-  # [通常不要修改] 大账号池分段选号默认关闭；启用后仍保留完整池回退和原子并发门禁。
-  segmentedSelectorEnabled: false
+  # [通常不要修改] 大账号池默认使用有界分段选号；保留完整池回退、额度优先级和原子并发门禁。
+  segmentedSelectorEnabled: true
   segmentedSelectorMinCandidates: 3000
   segmentedSelectorWindowSize: 64
 

--- a/frontend/src/features/settings/settings-api.ts
+++ b/frontend/src/features/settings/settings-api.ts
@@ -142,7 +142,7 @@ const defaultAccountsConfig = (): SettingsConfigDTO["accounts"] => ({
 });
 function withSettingsDefaults(snapshot: SettingsSnapshotDTO): SettingsSnapshotDTO {
   const accounts = snapshot.config.accounts ?? defaultAccountsConfig();
-  const segmentedSelector = snapshot.config.routing.segmentedSelector ?? { enabled: false, minCandidates: 3000, windowSize: 64 };
+  const segmentedSelector = snapshot.config.routing.segmentedSelector ?? { enabled: true, minCandidates: 3000, windowSize: 64 };
   return {
     ...snapshot,
     config: {
@@ -164,7 +164,7 @@ function withSettingsDefaults(snapshot: SettingsSnapshotDTO): SettingsSnapshotDT
         markBuildChatDeniedAsReauth: snapshot.config.routing.markBuildChatDeniedAsReauth ?? false,
         accountIsolatedConnections: snapshot.config.routing.accountIsolatedConnections ?? false,
         segmentedSelector: {
-          enabled: segmentedSelector.enabled ?? false,
+          enabled: segmentedSelector.enabled ?? true,
           minCandidates: segmentedSelector.minCandidates || 3000,
           windowSize: segmentedSelector.windowSize || 64,
         },

--- a/frontend/src/shared/i18n/index.ts
+++ b/frontend/src/shared/i18n/index.ts
@@ -995,7 +995,7 @@ const resources = {
         codesInvalid: "请填写 1–32 个有效错误码，仅支持字母、数字、点、下划线、冒号和连字符。",
         codesPlaceholder: "permission-denied",
       },
-      settingsRoutingSegmented: { enabled: "启用分段选号", enabledHelp: "仅对达到阈值且没有会话粘性的账号池生效；连续四个窗口满载后自动回退完整池选号。", minCandidates: "启用账号数阈值", minCandidatesHelp: "可用候选账号达到该数量后启用分段选号。", windowSize: "选号窗口大小", windowSizeHelp: "每个分段窗口检查的候选账号数量。" },
+      settingsRoutingSegmented: { enabled: "启用分段选号", enabledHelp: "对达到阈值的账号池生效，兼容会话粘性；连续四个窗口满载后自动回退完整池选号。", minCandidates: "启用账号数阈值", minCandidatesHelp: "可用候选账号达到该数量后启用分段选号。", windowSize: "选号窗口大小", windowSizeHelp: "每个分段窗口检查的候选账号数量。" },
       settingsRoutingAttempts: {
         help: "有限模式控制单次请求的路由尝试轮次：初次选择计 1 次，切号或出口重试各增加 1 次，范围为 1–65535；无限制模式会在账号级可切换失败时遍历当前可用账号。",
         unlimited: "无限制",
@@ -1643,7 +1643,7 @@ const resources = {
 
       settingsBuildTransport: { responseHeaderTimeout: "Response header timeout", responseHeaderTimeoutHelp: "Maximum time to wait for the first Grok Build response headers after the request body is sent.", streamIdleTimeout: "Stream idle timeout", streamIdleTimeoutHelp: "Maximum wait for new data on an open streaming response before aborting. Covers upstream connections that succeed but go silent mid-stream." },
       settingsBuildForbidden: { markInvalid: "Invalidate matching error codes", markInvalidHelp: "When enabled, a Grok Build 403 with a matching error code marks the account invalid and removes it from scheduling.", codes: "Invalidation error codes", codesHelp: "Enter one code per line. Codes match the complete code or error.code value case-insensitively, up to 32 entries.", codesInvalid: "Enter 1–32 valid codes using letters, numbers, dots, underscores, colons, or hyphens.", codesPlaceholder: "permission-denied" },
-      settingsRoutingSegmented: { enabled: "Enable segmented selection", enabledHelp: "Applies only above the threshold without session affinity and falls back to full-pool selection after four saturated windows.", minCandidates: "Account threshold", minCandidatesHelp: "Enables segmented selection when the eligible account pool reaches this size.", windowSize: "Selection window", windowSizeHelp: "Number of candidate accounts inspected in each segmented window." },
+      settingsRoutingSegmented: { enabled: "Enable segmented selection", enabledHelp: "Applies above the threshold, supports session affinity, and falls back to full-pool selection after four saturated windows.", minCandidates: "Account threshold", minCandidatesHelp: "Enables segmented selection when the eligible account pool reaches this size.", windowSize: "Selection window", windowSizeHelp: "Number of candidate accounts inspected in each segmented window." },
       settingsRoutingAttempts: {
         help: "A finite value limits routing-attempt rounds: initial selection counts as one, and account failover or egress retry adds another. Range: 1–65535. Unlimited mode can traverse all currently eligible accounts after account-scoped failures.",
         unlimited: "Unlimited",


### PR DESCRIPTION
## 概述

优化大账号池下的账号选择、并发状态读取与缓存失效路径，降低选号阶段的 CPU、内存及 Redis 压力，同时保持模型能力、额度、账号等级、优先级、粘性会话和故障转移语义不变。

## 主要改动

- 大号池达到 3000 个可用候选时，默认启用有界分段选号。
- 每次优先检查 64 个候选，连续 4 个窗口不可用后回退完整账号池。
- 分段选号支持粘性会话，首次绑定不再强制构建全池计划。
- 补齐上游额度已知/可用、模型能力、账号等级和优先级排序，避免性能优化改变原有路由顺序。
- 将账号失败与恢复改为账号级健康状态失效事件，不再因单个账号冷却而清空整个 Provider 候选缓存。
- 多实例失效事件按账号独立合并，避免不同账号的冷却状态被覆盖。
- 将 `last_used_at` 更新从健康状态写入中拆分，普通成功请求不再触发路由缓存重建。
- 内存与 Redis 并发快照改为稀疏结果，只保存存在活动租约的账号。
- 缩减路由 Overlay SQL 查询字段，避免大号池读取无用列。
- 保留完整池回退和最终原子并发门禁，不通过延长缓存时间掩盖性能问题。

## 配置兼容性

```yaml
routing:
  segmentedSelectorEnabled: true
  segmentedSelectorMinCandidates: 3000
  segmentedSelectorWindowSize: 64
```

- 新部署默认启用。
- 小于 3000 个候选的账号池行为不变。
- 已持久化并明确关闭该功能的部署仍保持关闭，不会被自动覆盖。
- 未修改 SQLite 同步级别、连接缓存大小或数据库 Schema。

## 性能验证

本地 Apple M4 Pro、10,000 个候选账号微基准：

| 路径 | 耗时 | 内存 | 分配次数 |
|---|---:|---:|---:|
| 完整池选号 | 约 2.13 ms | 约 1.67 MB | 19,951 |
| 分段选号 | 约 1.51 ms | 约 0.20 MB | 159 |

正常分段路径下，首轮动态并发状态读取从 10,000 个账号缩小至 64 个；极端满载时仍会自动回退完整池，保证可用性。

## 验证

- `go test ./... -count=1`
- 关键路由、失效、运行时和关系数据库包通过 `go test -race`
- `go vet ./...`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

未在真实生产 PostgreSQL + Redis 大池中复现原报告的具体首字时间，因此性能数据仅代表本地选号微基准，不将其表述为生产端到端结果。