### PR TITLE
fix(build): normalize inline GIF image inputs

### DIFF
--- a/backend/internal/infra/provider/cli/build_images.go
+++ b/backend/internal/infra/provider/cli/build_images.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image/gif"
+	"image/png"
+	"strings"
+
+	mediadomain "github.com/chenyme/grok2api/backend/internal/domain/media"
+)
+
+const (
+	buildGIFMaxPixels    = 64_000_000
+	buildGIFMaxWalkDepth = 64
+)
+
+var (
+	gif87aMagic = []byte("GIF87a")
+	gif89aMagic = []byte("GIF89a")
+)
+
+// normalizeBuildInputGIFs converts inline GIF inputs to a PNG of their first
+// frame because Grok Build only accepts static JPG, PNG, WebP, and ICO images.
+// Detection uses decoded magic bytes so mislabeled data URIs are covered too.
+func normalizeBuildInputGIFs(payload map[string]json.RawMessage) (bool, error) {
+	raw, exists := payload["input"]
+	if !exists || isEmptyJSON(raw) {
+		return false, nil
+	}
+	normalized, changed, err := normalizeBuildGIFNode(raw, "input", 0)
+	if err != nil {
+		return false, err
+	}
+	if changed {
+		payload["input"] = normalized
+	}
+	return changed, nil
+}
+
+func normalizeBuildGIFNode(raw json.RawMessage, param string, depth int) (json.RawMessage, bool, error) {
+	if depth >= buildGIFMaxWalkDepth {
+		return raw, false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return raw, false, nil
+	}
+	switch trimmed[0] {
+	case '[':
+		var items []json.RawMessage
+		if err := json.Unmarshal(raw, &items); err != nil {
+			return nil, false, fmt.Errorf("解析 %s: %w", param, err)
+		}
+		changed := false
+		for index, item := range items {
+			normalized, itemChanged, err := normalizeBuildGIFNode(item, fmt.Sprintf("%s[%d]", param, index), depth+1)
+			if err != nil {
+				return nil, false, err
+			}
+			if itemChanged {
+				items[index] = normalized
+				changed = true
+			}
+		}
+		if !changed {
+			return raw, false, nil
+		}
+		normalized, err := json.Marshal(items)
+		return normalized, true, err
+	case '{':
+		var value map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, false, fmt.Errorf("解析 %s: %w", param, err)
+		}
+		changed := false
+		var blockType string
+		_ = json.Unmarshal(value["type"], &blockType)
+		if blockType == "input_image" {
+			var imageURL string
+			if err := json.Unmarshal(value["image_url"], &imageURL); err == nil && imageURL != "" {
+				normalized, imageChanged, err := normalizeBuildGIFDataURI(imageURL, param+".image_url")
+				if err != nil {
+					return nil, false, err
+				}
+				if imageChanged {
+					value["image_url"] = mustJSON(normalized)
+					changed = true
+				}
+			}
+		}
+		for _, key := range []string{"content", "output"} {
+			child, exists := value[key]
+			if !exists || isEmptyJSON(child) {
+				continue
+			}
+			normalized, childChanged, err := normalizeBuildGIFNode(child, param+"."+key, depth+1)
+			if err != nil {
+				return nil, false, err
+			}
+			if childChanged {
+				value[key] = normalized
+				changed = true
+			}
+		}
+		if !changed {
+			return raw, false, nil
+		}
+		normalized, err := json.Marshal(value)
+		return normalized, true, err
+	default:
+		return raw, false, nil
+	}
+}
+
+func normalizeBuildGIFDataURI(value, param string) (string, bool, error) {
+	header, encoded, ok := strings.Cut(value, ",")
+	if !ok || !strings.HasPrefix(strings.ToLower(header), "data:") || !strings.Contains(strings.ToLower(header), ";base64") {
+		return value, false, nil
+	}
+	compact := strings.Map(func(character rune) rune {
+		if character == ' ' || character == '\t' || character == '\r' || character == '\n' {
+			return -1
+		}
+		return character
+	}, encoded)
+	if len(compact) < 8 {
+		return value, false, nil
+	}
+	prefix, err := base64.StdEncoding.DecodeString(compact[:8])
+	if err != nil || !hasGIFMagic(prefix) {
+		return value, false, nil
+	}
+	if base64.StdEncoding.DecodedLen(len(compact)) > mediadomain.MaxInputAssetBytes {
+		return "", false, invalidBuildGIF(param, fmt.Sprintf("图片超过 %d MiB", mediadomain.MaxInputAssetBytes>>20))
+	}
+	raw, err := decodeBuildBase64(compact)
+	if err != nil {
+		return "", false, invalidBuildGIF(param, "Base64 无效")
+	}
+	if len(raw) > mediadomain.MaxInputAssetBytes {
+		return "", false, invalidBuildGIF(param, fmt.Sprintf("图片超过 %d MiB", mediadomain.MaxInputAssetBytes>>20))
+	}
+	config, err := gif.DecodeConfig(bytes.NewReader(raw))
+	if err != nil || config.Width <= 0 || config.Height <= 0 {
+		return "", false, invalidBuildGIF(param, "GIF 数据损坏")
+	}
+	if int64(config.Width)*int64(config.Height) > buildGIFMaxPixels {
+		return "", false, invalidBuildGIF(param, fmt.Sprintf("GIF 像素超过 %d MP", buildGIFMaxPixels/1_000_000))
+	}
+	firstFrame, err := gif.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return "", false, invalidBuildGIF(param, "GIF 数据损坏")
+	}
+	var output bytes.Buffer
+	if err := png.Encode(&output, firstFrame); err != nil {
+		return "", false, invalidBuildGIF(param, "首帧 PNG 编码失败")
+	}
+	if output.Len() > mediadomain.MaxInputAssetBytes {
+		return "", false, invalidBuildGIF(param, fmt.Sprintf("首帧 PNG 超过 %d MiB", mediadomain.MaxInputAssetBytes>>20))
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(output.Bytes()), true, nil
+}
+
+func decodeBuildBase64(value string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(value)
+	if err == nil {
+		return decoded, nil
+	}
+	return base64.RawStdEncoding.DecodeString(value)
+}
+
+func hasGIFMagic(value []byte) bool {
+	return bytes.HasPrefix(value, gif87aMagic) || bytes.HasPrefix(value, gif89aMagic)
+}
+
+func invalidBuildGIF(param, message string) error {
+	return &responsesRequestError{Message: "Grok Build GIF 输入无效：" + message, Param: param, Code: "invalid_image"}
+}

--- a/backend/internal/infra/provider/cli/build_images_test.go
+++ b/backend/internal/infra/provider/cli/build_images_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/png"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBuildInputGIFsConvertsFirstFrame(t *testing.T) {
+	gifData := testAnimatedGIF(t)
+	tests := []struct {
+		name       string
+		mediaType  string
+		input      string
+		imageParam string
+	}{
+		{
+			name:       "declared gif in message content",
+			mediaType:  "image/gif",
+			input:      `[{"role":"user","content":[{"type":"input_image","image_url":"%s"}]}]`,
+			imageParam: "content",
+		},
+		{
+			name:       "gif magic mislabeled as png in tool output",
+			mediaType:  "image/png",
+			input:      `[{"type":"function_call_output","call_id":"call_1","output":[{"type":"input_image","image_url":"%s"}]}]`,
+			imageParam: "output",
+		},
+		{
+			name:       "unpadded gif base64",
+			mediaType:  "image/gif",
+			input:      `[{"role":"user","content":[{"type":"input_image","image_url":"%s"}]}]`,
+			imageParam: "content",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString(gifData)
+			if test.name == "unpadded gif base64" {
+				encoded = strings.TrimRight(encoded, "=")
+			}
+			dataURI := "data:" + test.mediaType + ";base64," + encoded
+			body := []byte(`{"input":` + strings.Replace(test.input, "%s", dataURI, 1) + `}`)
+			normalized, err := normalizeBuildRequest(body, "grok-4.6")
+			if err != nil {
+				t.Fatal(err)
+			}
+			imageURL := findTestImageURL(t, normalized, test.imageParam)
+			if !strings.HasPrefix(imageURL, "data:image/png;base64,") {
+				t.Fatalf("image_url = %.64q", imageURL)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(imageURL, "data:image/png;base64,"))
+			if err != nil || !bytes.HasPrefix(decoded, []byte("\x89PNG\r\n\x1a\n")) {
+				t.Fatalf("transcoded data is not PNG: %v", err)
+			}
+			frame, err := png.Decode(bytes.NewReader(decoded))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := color.NRGBAModel.Convert(frame.At(0, 0)).(color.NRGBA); got.R != 255 || got.G != 0 || got.B != 0 || got.A != 255 {
+				t.Fatalf("first-frame pixel = %#v, want opaque red", got)
+			}
+		})
+	}
+}
+
+func TestNormalizeBuildInputGIFsPreservesNonGIFDataURI(t *testing.T) {
+	value := "data:image/png;base64,iVBORw0KGgo="
+	body := []byte(`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"` + value + `"}]}]}`)
+	normalized, err := normalizeBuildRequest(body, "grok-4.6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findTestImageURL(t, normalized, "content"); got != value {
+		t.Fatalf("image_url = %q, want unchanged %q", got, value)
+	}
+}
+
+func TestNormalizeBuildInputGIFsRejectsDamagedGIF(t *testing.T) {
+	value := "data:image/png;base64," + base64.StdEncoding.EncodeToString([]byte("GIF89a damaged"))
+	body := []byte(`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"` + value + `"}]}]}`)
+	_, err := normalizeBuildRequest(body, "grok-4.6")
+	if err == nil {
+		t.Fatal("damaged GIF was accepted")
+	}
+	requestError, ok := err.(*responsesRequestError)
+	if !ok || requestError.Code != "invalid_image" || requestError.Param != "input[0].content[0].image_url" {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func testAnimatedGIF(t *testing.T) []byte {
+	t.Helper()
+	palette := color.Palette{color.NRGBA{R: 255, A: 255}, color.NRGBA{B: 255, A: 255}}
+	first := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+	second := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+	for index := range second.Pix {
+		second.Pix[index] = 1
+	}
+	var output bytes.Buffer
+	if err := gif.EncodeAll(&output, &gif.GIF{Image: []*image.Paletted{first, second}, Delay: []int{10, 10}}); err != nil {
+		t.Fatal(err)
+	}
+	return output.Bytes()
+}
+
+func findTestImageURL(t *testing.T, body []byte, containerKey string) string {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	items := payload["input"].([]any)
+	blocks := items[0].(map[string]any)[containerKey].([]any)
+	return blocks[0].(map[string]any)["image_url"].(string)
+}

--- a/backend/internal/infra/provider/cli/normalize.go
+++ b/backend/internal/infra/provider/cli/normalize.go
@@ -84,6 +84,13 @@ func normalizeBuildRequestPayload(payload map[string]json.RawMessage, model stri
 	if normalizeBuildReasoningEffortPayload(payload, model) {
 		changed = true
 	}
+	imagesChanged, err := normalizeBuildInputGIFs(payload)
+	if err != nil {
+		return false, err
+	}
+	if imagesChanged {
+		changed = true
+	}
 	defaultsChanged, err := applyBuildResponseDefaults(payload)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Problem

Grok Build rejects inline GIF image inputs with:

```text
Downloaded response does not contain a valid JPG, PNG, WebP, or ICO image
```

The same failure occurs when a client labels the data URI as `image/png` while the decoded bytes are actually GIF data.

## Root cause

The shared Build request compatibility boundary forwards `input_image.image_url` data URIs unchanged. Grok Build accepts static image formats, so an inline GIF reaches the upstream downloader without normalization.

## Changes

- inspect inline image data by decoded `GIF87a` / `GIF89a` magic bytes instead of trusting the declared MIME type
- convert the first GIF frame to PNG before forwarding the Build request
- cover message content and structured function-call output images across Responses, Chat Completions, and Anthropic Messages
- preserve non-GIF data URIs unchanged
- reject damaged or oversized GIF inputs with a structured `invalid_image` error
- bound decoded input size, pixel count, and JSON traversal depth

Remote HTTP image URLs remain unchanged. Animated GIFs intentionally degrade to their first frame because the Build endpoint only accepts static image formats.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- regression tests cover declared GIF input, GIF bytes mislabeled as PNG, unpadded Base64, non-GIF preservation, first-frame output, and damaged GIF rejection
- live verification: an animated GIF mislabeled as `image/png` completed successfully through `grok-4.6` with HTTP 200
