### PR TITLE
feat: align with grok-build 1.0.4 request protocol

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -28,7 +28,7 @@ const (
 	ClearanceModeOnDemand         = "on_demand"
 	DefaultStatsigSignerURL       = "https://grok.wodf.de/sign"
 	DefaultFlareSolverrURL        = "http://flaresolverr:8191"
-	RecommendedBuildClientVersion = "0.2.119"
+	RecommendedBuildClientVersion = "1.0.4"
 	RecommendedBuildUserAgent     = "grok-shell/" + RecommendedBuildClientVersion + " (linux; x86_64)"
 
 	maxServerBodyBytes     = 256 << 20
@@ -211,10 +211,10 @@ type LocalMediaConfig struct {
 }
 
 type RoutingConfig struct {
-	StickyTTL       Duration `yaml:"stickyTTL"`
-	CooldownBase    Duration `yaml:"cooldownBase"`
-	CooldownMax     Duration `yaml:"cooldownMax"`
-	CapacityWait    Duration `yaml:"capacityWait"`
+	StickyTTL        Duration `yaml:"stickyTTL"`
+	CooldownBase     Duration `yaml:"cooldownBase"`
+	CooldownMax      Duration `yaml:"cooldownMax"`
+	CapacityWait     Duration `yaml:"capacityWait"`
 	MaxAttempts      int      `yaml:"maxAttempts"`
 	VideoMaxAttempts int      `yaml:"videoMaxAttempts"`
 	PreferFreeBuild  bool     `yaml:"preferFreeBuild"`

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -239,13 +239,13 @@ func TestBuildResponseHeaderTimeoutIsRuntimeOnly(t *testing.T) {
 
 func TestDefaultGrokBuildClientVersionMatchesLocalBaseline(t *testing.T) {
 	build := defaultConfig().Provider.Build
-	if RecommendedBuildClientVersion != "0.2.119" {
+	if RecommendedBuildClientVersion != "1.0.4" {
 		t.Fatalf("recommended clientVersion = %q", RecommendedBuildClientVersion)
 	}
 	if build.ClientVersion != RecommendedBuildClientVersion {
 		t.Fatalf("clientVersion = %q", build.ClientVersion)
 	}
-	if RecommendedBuildUserAgent != "grok-shell/0.2.119 (linux; x86_64)" {
+	if RecommendedBuildUserAgent != "grok-shell/1.0.4 (linux; x86_64)" {
 		t.Fatalf("recommended userAgent = %q", RecommendedBuildUserAgent)
 	}
 	if build.UserAgent != RecommendedBuildUserAgent {

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -253,7 +253,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 			}
 			return invalidResponsesResponse(err), nil
 		}
-		body, err = normalizeBuildRequest(body, request.Model)
+		body, err = normalizeBuildRequest(body, request.Model, request.Operation)
 		if err != nil {
 			if request.Operation == conversation.OperationChat || request.Operation == conversation.OperationMessages {
 				return invalidConversationResponse(request.Operation, err), nil

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1109,6 +1110,40 @@ func TestForwardResponseInjectsPromptCacheKeyAfterChatConversion(t *testing.T) {
 	usage := payload["usage"].(map[string]any)
 	if payload["object"] != "chat.completion" || usage["prompt_tokens"] != float64(11) || usage["cost_in_usd_ticks"] != float64(7000) || usage["context_details"].(map[string]any)["input_tokens"] != float64(10) {
 		t.Fatalf("chat response = %#v", payload)
+	}
+}
+
+func TestForwardResponseRejectsInvalidChatWebSearchBeforeUpstream(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1"}, cipher)
+	upstreamCalled := false
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		upstreamCalled = true
+		return nil, errors.New("unexpected upstream call")
+	})
+
+	response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+		Credential: account.Credential{Provider: account.ProviderBuild, AuthType: account.AuthTypeOAuth, EncryptedAccessToken: encrypted},
+		Method:     http.MethodPost, Path: "/responses", Model: "grok-4.6", NormalizeBody: true,
+		Operation: conversation.OperationChat,
+		Body: []byte(`{
+			"model":"public","messages":[{"role":"user","content":"search"}],
+			"tools":[{"type":"web_search","filters":{"allowed_domains":["allow.example"],"excluded_domains":["deny.example"]}}]
+		}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if upstreamCalled || response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("upstreamCalled=%v status=%d", upstreamCalled, response.StatusCode)
 	}
 }
 

--- a/backend/internal/infra/provider/cli/normalize.go
+++ b/backend/internal/infra/provider/cli/normalize.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	modeldomain "github.com/chenyme/grok2api/backend/internal/domain/model"
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 )
 
 // normalizeResponsesRequest 改写路由字段和兼容别名，并为上游不支持的新工具协议建立请求级映射。
@@ -16,7 +17,7 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 		return nil, nil, fmt.Errorf("解析 Responses 请求: %w", err)
 	}
 	payload["model"] = mustJSON(model)
-	if _, err := normalizeBuildRequestPayload(payload, model); err != nil {
+	if _, err := normalizeBuildRequestPayload(payload, model, conversation.OperationResponses); err != nil {
 		return nil, nil, err
 	}
 	if responseFormat, exists := payload["response_format"]; exists {
@@ -57,12 +58,12 @@ func normalizeResponsesRequest(body []byte, model string) ([]byte, *responsesToo
 
 // normalizeBuildRequest applies the stable compatibility boundary shared by Responses,
 // Chat Completions, and Anthropic Messages before the request reaches Grok Build.
-func normalizeBuildRequest(body []byte, model string) ([]byte, error) {
+func normalizeBuildRequest(body []byte, model, operation string) ([]byte, error) {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return nil, fmt.Errorf("解析 Build 请求: %w", err)
 	}
-	changed, err := normalizeBuildRequestPayload(payload, model)
+	changed, err := normalizeBuildRequestPayload(payload, model, operation)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func normalizeBuildRequest(body []byte, model string) ([]byte, error) {
 	return json.Marshal(payload)
 }
 
-func normalizeBuildRequestPayload(payload map[string]json.RawMessage, model string) (bool, error) {
+func normalizeBuildRequestPayload(payload map[string]json.RawMessage, model, operation string) (bool, error) {
 	changed := false
 	// client_metadata is a Codex transport envelope and may contain local paths,
 	// repository remotes, and installation/session identifiers. It is consumed by
@@ -83,6 +84,27 @@ func normalizeBuildRequestPayload(payload map[string]json.RawMessage, model stri
 	}
 	if normalizeBuildReasoningEffortPayload(payload, model) {
 		changed = true
+	}
+	// grok-build 1.0.4 always requests a concise reasoning summary from its
+	// Responses backend, even when it uses the model's default effort. Chat
+	// Completions has no separate summary parameter, so make that Build-specific
+	// compatibility contract explicit without changing native Responses,
+	// Console, or Web semantics.
+	if operation == conversation.OperationChat {
+		var reasoning map[string]json.RawMessage
+		if raw := payload["reasoning"]; !isEmptyJSON(raw) {
+			if err := json.Unmarshal(raw, &reasoning); err != nil {
+				return false, fmt.Errorf("解析 Build reasoning: %w", err)
+			}
+		}
+		if reasoning == nil {
+			reasoning = make(map[string]json.RawMessage)
+		}
+		if isEmptyJSON(reasoning["summary"]) {
+			reasoning["summary"] = mustJSON("concise")
+			payload["reasoning"] = mustJSON(reasoning)
+			changed = true
+		}
 	}
 	defaultsChanged, err := applyBuildResponseDefaults(payload)
 	if err != nil {

--- a/backend/internal/infra/provider/cli/normalize_test.go
+++ b/backend/internal/infra/provider/cli/normalize_test.go
@@ -65,7 +65,7 @@ func TestNormalizeBuildReasoningEffort(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			body := []byte(`{"reasoning":{"effort":"` + test.effort + `"},"input":"hello"}`)
-			normalized, err := normalizeBuildRequest(body, test.model)
+			normalized, err := normalizeBuildRequest(body, test.model, conversation.OperationResponses)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -81,13 +81,55 @@ func TestNormalizeBuildReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestNormalizeBuildChatRequestsVisibleReasoningSummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		operation   string
+		body        string
+		wantSummary string
+		wantEffort  string
+		wantObject  bool
+	}{
+		{name: "Chat model default", operation: conversation.OperationChat, body: `{"input":"hello"}`, wantSummary: "concise", wantObject: true},
+		{name: "Chat explicit effort", operation: conversation.OperationChat, body: `{"input":"hello","reasoning":{"effort":"high"}}`, wantSummary: "concise", wantEffort: "high", wantObject: true},
+		{name: "Chat explicit summary", operation: conversation.OperationChat, body: `{"input":"hello","reasoning":{"effort":"high","summary":"detailed"}}`, wantSummary: "detailed", wantEffort: "high", wantObject: true},
+		{name: "native Responses remains caller controlled", operation: conversation.OperationResponses, body: `{"input":"hello"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			normalized, err := normalizeBuildRequest([]byte(test.body), "grok-4.6", test.operation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(normalized, &payload); err != nil {
+				t.Fatal(err)
+			}
+			reasoning, ok := payload["reasoning"].(map[string]any)
+			if ok != test.wantObject {
+				t.Fatalf("reasoning = %#v, want object %v", payload["reasoning"], test.wantObject)
+			}
+			if !ok {
+				return
+			}
+			if reasoning["summary"] != test.wantSummary {
+				t.Fatalf("summary = %#v, want %q", reasoning["summary"], test.wantSummary)
+			}
+			if effort, _ := reasoning["effort"].(string); effort != test.wantEffort {
+				t.Fatalf("effort = %q, want %q", effort, test.wantEffort)
+			}
+		})
+	}
+}
+
 func TestNormalizeBuildMaxAcrossCompatibilityProtocols(t *testing.T) {
 	tests := []struct {
-		name string
-		body []byte
+		name      string
+		body      []byte
+		operation string
 	}{
-		{name: "responses", body: []byte(`{"reasoning":{"effort":"max"},"input":"hello"}`)},
-		{name: "chat completions", body: func() []byte {
+		{name: "responses", operation: conversation.OperationResponses, body: []byte(`{"reasoning":{"effort":"max"},"input":"hello"}`)},
+		{name: "chat completions", operation: conversation.OperationChat, body: func() []byte {
 			converted, _, err := conversation.ConvertRequestWithOptions(
 				[]byte(`{"model":"public","messages":[{"role":"user","content":"hello"}],"reasoning_effort":"max"}`),
 				"grok-4.6",
@@ -98,7 +140,7 @@ func TestNormalizeBuildMaxAcrossCompatibilityProtocols(t *testing.T) {
 			}
 			return converted
 		}()},
-		{name: "anthropic messages", body: func() []byte {
+		{name: "anthropic messages", operation: conversation.OperationMessages, body: func() []byte {
 			converted, _, err := conversation.ConvertRequestWithOptions(
 				[]byte(`{"model":"public","max_tokens":64,"messages":[{"role":"user","content":"hello"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`),
 				"grok-4.6",
@@ -113,7 +155,7 @@ func TestNormalizeBuildMaxAcrossCompatibilityProtocols(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			normalized, err := normalizeBuildRequest(test.body, "grok-4.6")
+			normalized, err := normalizeBuildRequest(test.body, "grok-4.6", test.operation)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -131,11 +173,12 @@ func TestNormalizeBuildMaxAcrossCompatibilityProtocols(t *testing.T) {
 
 func TestNormalizeBuildComposerStripsReasoningEffort(t *testing.T) {
 	tests := []struct {
-		name string
-		body []byte
+		name      string
+		body      []byte
+		operation string
 	}{
-		{name: "responses", body: []byte(`{"reasoning":{"effort":"high","summary":"auto"},"input":"hello"}`)},
-		{name: "chat conversion", body: func() []byte {
+		{name: "responses", operation: conversation.OperationResponses, body: []byte(`{"reasoning":{"effort":"high","summary":"auto"},"input":"hello"}`)},
+		{name: "chat conversion", operation: conversation.OperationChat, body: func() []byte {
 			converted, _, err := conversation.ConvertRequestWithOptions(
 				[]byte(`{"model":"public","messages":[{"role":"user","content":"hello"}],"reasoning_effort":"high"}`),
 				modeldomain.GrokComposer25Fast,
@@ -146,7 +189,7 @@ func TestNormalizeBuildComposerStripsReasoningEffort(t *testing.T) {
 			}
 			return converted
 		}()},
-		{name: "messages conversion", body: func() []byte {
+		{name: "messages conversion", operation: conversation.OperationMessages, body: func() []byte {
 			converted, _, err := conversation.ConvertRequestWithOptions(
 				[]byte(`{"model":"public","max_tokens":64,"messages":[{"role":"user","content":"hello"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`),
 				modeldomain.GrokComposer25Fast,
@@ -160,7 +203,7 @@ func TestNormalizeBuildComposerStripsReasoningEffort(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			normalized, err := normalizeBuildRequest(test.body, modeldomain.GrokComposer25Fast)
+			normalized, err := normalizeBuildRequest(test.body, modeldomain.GrokComposer25Fast, test.operation)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -176,7 +219,7 @@ func TestNormalizeBuildComposerStripsReasoningEffort(t *testing.T) {
 		})
 	}
 
-	stripped, err := normalizeBuildRequest([]byte(`{"reasoning":{"effort":"medium"},"input":"hello"}`), modeldomain.GrokComposer25Fast)
+	stripped, err := normalizeBuildRequest([]byte(`{"reasoning":{"effort":"medium"},"input":"hello"}`), modeldomain.GrokComposer25Fast, conversation.OperationResponses)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +237,7 @@ func TestNormalizeBuildRequestAppliesSafeDefaultsAndStripsCodexEnvelope(t *testi
 		"client_metadata":{"cwd":"/private/workspace","git_remote":"ssh://private/repo"},
 		"include":["web_search_call.action.sources"]
 	}`)
-	normalized, err := normalizeBuildRequest(body, "grok-4.5")
+	normalized, err := normalizeBuildRequest(body, "grok-4.5", conversation.OperationResponses)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +259,7 @@ func TestNormalizeBuildRequestAppliesSafeDefaultsAndStripsCodexEnvelope(t *testi
 
 func TestNormalizeBuildRequestPreservesExplicitStoreAndEncryptedInclude(t *testing.T) {
 	body := []byte(`{"input":"hello","store":true,"include":["reasoning.encrypted_content"],"stream_tool_calls":true}`)
-	normalized, err := normalizeBuildRequest(body, "grok-4.5")
+	normalized, err := normalizeBuildRequest(body, "grok-4.5", conversation.OperationResponses)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +273,7 @@ func TestNormalizeBuildRequestPreservesExplicitStoreAndEncryptedInclude(t *testi
 }
 
 func TestNormalizeBuildRequestDoesNotInventStreamToolCalls(t *testing.T) {
-	normalized, err := normalizeBuildRequest([]byte(`{"input":"hello"}`), "grok-4.5")
+	normalized, err := normalizeBuildRequest([]byte(`{"input":"hello"}`), "grok-4.5", conversation.OperationResponses)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/infra/provider/cli/responses_advanced_test.go
+++ b/backend/internal/infra/provider/cli/responses_advanced_test.go
@@ -188,12 +188,18 @@ func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 		t.Fatalf("compatibility warnings = %q", compatibility.warningHeader())
 	}
 
-	for _, supported := range []string{
-		`"filters":{"allowed_domains":["example.com"]}`,
-		`"allowed_domains":["example.com"]`,
+	for _, supported := range []struct {
+		fragment string
+		field    string
+		warning  string
+	}{
+		{fragment: `"filters":{"allowed_domains":["example.com"]}`, field: "allowed_domains"},
+		{fragment: `"allowed_domains":["example.com"]`, field: "allowed_domains", warning: "web_search_allowed_domains_normalized"},
+		{fragment: `"filters":{"excluded_domains":["example.com"]}`, field: "excluded_domains"},
+		{fragment: `"excluded_domains":["example.com"]`, field: "excluded_domains", warning: "web_search_excluded_domains_normalized"},
 	} {
 		normalized, compatibility, err = normalizeResponsesRequest([]byte(`{
-			"model":"public","input":"search","tools":[{"type":"web_search",`+supported+`}]
+			"model":"public","input":"search","tools":[{"type":"web_search",`+supported.fragment+`}]
 		}`), "grok-4.5")
 		if err != nil {
 			t.Fatal(err)
@@ -203,13 +209,54 @@ func TestResponsesWebSearchAliasesAndOptions(t *testing.T) {
 			t.Fatal(err)
 		}
 		tool = request["tools"].([]any)[0].(map[string]any)
-		domains := tool["filters"].(map[string]any)["allowed_domains"].([]any)
+		domains := tool["filters"].(map[string]any)[supported.field].([]any)
 		if len(domains) != 1 || domains[0] != "example.com" {
-			t.Fatalf("allowed_domains 未保留: %#v", tool)
+			t.Fatalf("%s 未保留: %#v", supported.field, tool)
 		}
-		if strings.Contains(supported, `"allowed_domains"`) && !strings.Contains(supported, `"filters"`) && (compatibility == nil || !strings.Contains(compatibility.warningHeader(), "web_search_allowed_domains_normalized")) {
-			t.Fatalf("top-level allowed_domains warning = %#v", compatibility)
+		if supported.warning != "" && (compatibility == nil || !strings.Contains(compatibility.warningHeader(), supported.warning)) {
+			t.Fatalf("top-level %s warning = %#v", supported.field, compatibility)
 		}
+	}
+
+	for _, invalid := range []string{
+		`"filters":{"allowed_domains":["a.example","b.example","c.example","d.example","e.example","f.example"]}`,
+		`"filters":{"excluded_domains":["a.example","b.example","c.example","d.example","e.example","f.example"]}`,
+		`"filters":{"allowed_domains":["allow.example"],"excluded_domains":["deny.example"]}`,
+	} {
+		if _, _, err = normalizeResponsesRequest([]byte(`{
+			"model":"public","input":"search","tools":[{"type":"web_search",`+invalid+`}]
+		}`), "grok-4.5"); err == nil {
+			t.Fatalf("invalid web_search filters accepted: %s", invalid)
+		}
+	}
+
+	normalized, _, err = normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"search","tools":[{"type":"web_search","filters":{"excluded_domains":["a.example","b.example","c.example","d.example","e.example"]}}]
+	}`), "grok-4.6")
+	if err != nil {
+		t.Fatalf("five excluded domains must remain valid: %v", err)
+	}
+	request = nil
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	domains := request["tools"].([]any)[0].(map[string]any)["filters"].(map[string]any)["excluded_domains"].([]any)
+	if len(domains) != maxWebSearchDomains {
+		t.Fatalf("excluded_domains count = %d", len(domains))
+	}
+
+	normalized, _, err = normalizeResponsesRequest([]byte(`{
+		"model":"public","input":"search","tools":[{"type":"web_search","filters":{"allowed_domains":null,"excluded_domains":[]}}]
+	}`), "grok-4.6")
+	if err != nil {
+		t.Fatalf("null/empty domain filters must remain unbounded: %v", err)
+	}
+	request = nil
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	if tool = request["tools"].([]any)[0].(map[string]any); len(tool) != 1 || tool["type"] != "web_search" {
+		t.Fatalf("empty domain filters were not omitted: %#v", tool)
 	}
 
 	for _, restricted := range []string{

--- a/backend/internal/infra/provider/cli/responses_tool_types.go
+++ b/backend/internal/infra/provider/cli/responses_tool_types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/chenyme/grok2api/backend/internal/infra/provider/conversation"
 )
 
 var nativeHostedToolChoiceTypes = map[string]string{
@@ -33,6 +35,8 @@ var webSearchCompatibilityFields = map[string]struct{}{
 	"max_search_results":   {},
 	"safe_search":          {},
 }
+
+const maxWebSearchDomains = conversation.MaxWebSearchDomains
 
 // normalizeNativeTool preserves native Build tools and removes Tool Search-only fields.
 func (c *responsesToolCompatibility) normalizeNativeTool(tool map[string]any, _ string) ([]any, error) {
@@ -84,7 +88,7 @@ func (c *responsesToolCompatibility) normalizeXSearchTool(tool map[string]any, p
 	return c.normalizeNativeTool(converted, param)
 }
 
-// normalizeWebSearchTool preserves Build's allowed_domains constraint and safely
+// normalizeWebSearchTool preserves Build's allowed/excluded domain constraints and safely
 // reduces newer controls that cannot be represented with equivalent semantics.
 func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any, kind, param string) ([]any, error) {
 	if external, exists := tool["external_web_access"]; exists {
@@ -129,6 +133,11 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 			c.addWarning("web_search_allowed_domains_normalized")
 			continue
 		}
+		if key == "excluded_domains" {
+			c.changed = true
+			c.addWarning("web_search_excluded_domains_normalized")
+			continue
+		}
 		if _, compatible := webSearchCompatibilityFields[key]; !compatible {
 			c.changed = true
 			c.addWarning("web_search_unknown_controls_ignored")
@@ -151,57 +160,83 @@ func (c *responsesToolCompatibility) normalizeWebSearchTool(tool map[string]any,
 }
 
 func (c *responsesToolCompatibility) normalizeWebSearchFilters(tool map[string]any, param string) (map[string]any, error) {
-	var nestedDomains []any
+	nested := make(map[string][]any, 2)
 	if rawFilters, exists := tool["filters"]; exists && rawFilters != nil {
 		filters, ok := rawFilters.(map[string]any)
 		if !ok {
 			return nil, &responsesRequestError{Message: "web_search filters 必须是对象", Param: param + ".filters", Code: "invalid_parameter"}
 		}
 		for key := range filters {
-			if key != "allowed_domains" {
+			if key != "allowed_domains" && key != "excluded_domains" {
 				c.changed = true
 				c.addWarning("web_search_filters_downgraded")
 			}
 		}
-		if rawDomains, exists := filters["allowed_domains"]; exists {
-			values, err := normalizeAllowedDomains(rawDomains, param+".filters.allowed_domains")
+		for _, field := range []string{"allowed_domains", "excluded_domains"} {
+			rawDomains, exists := filters[field]
+			if !exists {
+				continue
+			}
+			values, err := normalizeWebSearchDomains(rawDomains, field, param+".filters."+field)
 			if err != nil {
 				return nil, err
 			}
-			nestedDomains = values
+			nested[field] = values
 		}
 	}
 
-	var topLevelDomains []any
-	if rawDomains, exists := tool["allowed_domains"]; exists {
-		values, err := normalizeAllowedDomains(rawDomains, param+".allowed_domains")
-		if err != nil {
-			return nil, err
+	topLevel := make(map[string][]any, 2)
+	for _, field := range []string{"allowed_domains", "excluded_domains"} {
+		if rawDomains, exists := tool[field]; exists {
+			values, err := normalizeWebSearchDomains(rawDomains, field, param+"."+field)
+			if err != nil {
+				return nil, err
+			}
+			topLevel[field] = values
 		}
-		topLevelDomains = values
 	}
-	if len(nestedDomains) > 0 && len(topLevelDomains) > 0 && !sameStringValues(nestedDomains, topLevelDomains) {
-		return nil, &responsesRequestError{Message: "web_search allowed_domains 声明冲突", Param: param + ".allowed_domains", Code: "invalid_parameter"}
+
+	result := make(map[string]any, 2)
+	for _, field := range []string{"allowed_domains", "excluded_domains"} {
+		nestedDomains := nested[field]
+		topLevelDomains := topLevel[field]
+		if len(nestedDomains) > 0 && len(topLevelDomains) > 0 && !sameStringValues(nestedDomains, topLevelDomains) {
+			return nil, &responsesRequestError{Message: "web_search " + field + " 声明冲突", Param: param + "." + field, Code: "invalid_parameter"}
+		}
+		domains := nestedDomains
+		if len(domains) == 0 {
+			domains = topLevelDomains
+		}
+		if len(domains) > 0 {
+			result[field] = cloneJSONValue(domains)
+		}
 	}
-	domains := nestedDomains
-	if len(domains) == 0 {
-		domains = topLevelDomains
+	if _, hasAllowed := result["allowed_domains"]; hasAllowed {
+		if _, hasExcluded := result["excluded_domains"]; hasExcluded {
+			return nil, &responsesRequestError{Message: "web_search 不能同时设置 allowed_domains 和 excluded_domains", Param: param + ".filters", Code: "invalid_parameter"}
+		}
 	}
-	if len(domains) == 0 {
+	if len(result) == 0 {
 		return nil, nil
 	}
-	return map[string]any{"allowed_domains": cloneJSONValue(domains)}, nil
+	return result, nil
 }
 
-func normalizeAllowedDomains(value any, param string) ([]any, error) {
+func normalizeWebSearchDomains(value any, field, param string) ([]any, error) {
+	if value == nil {
+		return nil, nil
+	}
 	values, ok := value.([]any)
 	if !ok {
-		return nil, &responsesRequestError{Message: "allowed_domains 必须是字符串数组", Param: param, Code: "invalid_parameter"}
+		return nil, &responsesRequestError{Message: field + " 必须是字符串数组", Param: param, Code: "invalid_parameter"}
+	}
+	if len(values) > maxWebSearchDomains {
+		return nil, &responsesRequestError{Message: fmt.Sprintf("%s 不能超过 %d 个域名", field, maxWebSearchDomains), Param: param, Code: "invalid_parameter"}
 	}
 	for index, value := range values {
 		domain, ok := value.(string)
 		if !ok || strings.TrimSpace(domain) == "" {
-			return nil, &responsesRequestError{Message: "allowed_domains 必须包含有效域名", Param: fmt.Sprintf("%s[%d]", param, index), Code: "invalid_parameter"}
+			return nil, &responsesRequestError{Message: field + " 必须包含有效域名", Param: fmt.Sprintf("%s[%d]", param, index), Code: "invalid_parameter"}
 		}
 	}
 	return values, nil

--- a/backend/internal/infra/provider/conversation/chat_request.go
+++ b/backend/internal/infra/provider/conversation/chat_request.go
@@ -275,13 +275,9 @@ func convertChatTools(raw json.RawMessage) ([]any, error) {
 			object, _ := value.(map[string]any)
 			switch typeName {
 			case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
-				converted := map[string]any{"type": "web_search"}
-				if filters, ok := object["filters"].(map[string]any); ok {
-					if domains, exists := filters["allowed_domains"]; exists {
-						converted["filters"] = map[string]any{"allowed_domains": domains}
-					}
-				} else if domains, exists := object["allowed_domains"]; exists {
-					converted["filters"] = map[string]any{"allowed_domains": domains}
+				converted, err := convertChatWebSearchTool(object)
+				if err != nil {
+					return nil, err
 				}
 				result = append(result, converted)
 			default:
@@ -297,6 +293,89 @@ func convertChatTools(raw json.RawMessage) ([]any, error) {
 		result = append(result, function)
 	}
 	return result, nil
+}
+
+func convertChatWebSearchTool(tool map[string]any) (map[string]any, error) {
+	nested := make(map[string][]any, 2)
+	if rawFilters, exists := tool["filters"]; exists && rawFilters != nil {
+		filters, ok := rawFilters.(map[string]any)
+		if !ok {
+			return nil, errors.New("web_search filters 必须是对象")
+		}
+		for _, field := range []string{"allowed_domains", "excluded_domains"} {
+			if value, exists := filters[field]; exists {
+				domains, err := normalizeChatWebSearchDomains(value, field)
+				if err != nil {
+					return nil, err
+				}
+				nested[field] = domains
+			}
+		}
+	}
+
+	resultFilters := make(map[string]any, 2)
+	for _, field := range []string{"allowed_domains", "excluded_domains"} {
+		var topLevel []any
+		if value, exists := tool[field]; exists {
+			domains, err := normalizeChatWebSearchDomains(value, field)
+			if err != nil {
+				return nil, err
+			}
+			topLevel = domains
+		}
+		domains := nested[field]
+		if len(domains) > 0 && len(topLevel) > 0 && !sameChatWebSearchDomains(domains, topLevel) {
+			return nil, fmt.Errorf("web_search %s 声明冲突", field)
+		}
+		if len(domains) == 0 {
+			domains = topLevel
+		}
+		if len(domains) > 0 {
+			resultFilters[field] = domains
+		}
+	}
+	if _, hasAllowed := resultFilters["allowed_domains"]; hasAllowed {
+		if _, hasExcluded := resultFilters["excluded_domains"]; hasExcluded {
+			return nil, errors.New("web_search 不能同时设置 allowed_domains 和 excluded_domains")
+		}
+	}
+	converted := map[string]any{"type": "web_search"}
+	if len(resultFilters) > 0 {
+		converted["filters"] = resultFilters
+	}
+	return converted, nil
+}
+
+func normalizeChatWebSearchDomains(value any, field string) ([]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	domains, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("web_search %s 必须是字符串数组", field)
+	}
+	if len(domains) > MaxWebSearchDomains {
+		return nil, fmt.Errorf("web_search %s 不能超过 %d 个域名", field, MaxWebSearchDomains)
+	}
+	for index, value := range domains {
+		domain, ok := value.(string)
+		if !ok || strings.TrimSpace(domain) == "" {
+			return nil, fmt.Errorf("web_search %s[%d] 必须是非空字符串", field, index)
+		}
+	}
+	return domains, nil
+}
+
+func sameChatWebSearchDomains(left, right []any) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func containsToolType(tools []any, kind string) bool {

--- a/backend/internal/infra/provider/conversation/conversation_test.go
+++ b/backend/internal/infra/provider/conversation/conversation_test.go
@@ -53,6 +53,61 @@ func TestConvertChatRequestToResponses(t *testing.T) {
 	}
 }
 
+func TestConvertChatPreservesWebSearchExcludedDomains(t *testing.T) {
+	converted, err := ConvertRequest([]byte(`{
+		"model":"public-chat","messages":[{"role":"user","content":"search"}],
+		"tools":[{"type":"web_search","filters":{"excluded_domains":["blocked.example"]}}]
+	}`), "grok-4.6", OperationChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(converted, &payload); err != nil {
+		t.Fatal(err)
+	}
+	tool := payload["tools"].([]any)[0].(map[string]any)
+	domains := tool["filters"].(map[string]any)["excluded_domains"].([]any)
+	if len(domains) != 1 || domains[0] != "blocked.example" {
+		t.Fatalf("excluded_domains = %#v", tool)
+	}
+}
+
+func TestConvertChatValidatesWebSearchDomainFilters(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		tool    string
+		wantErr bool
+	}{
+		{name: "identical nested and top level", tool: `{"type":"web_search","filters":{"allowed_domains":["same.example"]},"allowed_domains":["same.example"]}`},
+		{name: "conflicting duplicate", tool: `{"type":"web_search","filters":{"allowed_domains":["nested.example"]},"allowed_domains":["top.example"]}`, wantErr: true},
+		{name: "allow and exclude", tool: `{"type":"web_search","filters":{"allowed_domains":["allow.example"],"excluded_domains":["deny.example"]}}`, wantErr: true},
+		{name: "six domains", tool: `{"type":"web_search","excluded_domains":["a.example","b.example","c.example","d.example","e.example","f.example"]}`, wantErr: true},
+		{name: "invalid filters type", tool: `{"type":"web_search","filters":"invalid"}`, wantErr: true},
+		{name: "empty filters omitted", tool: `{"type":"web_search","filters":{"allowed_domains":null,"excluded_domains":[]}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			converted, err := ConvertRequest([]byte(`{
+				"model":"public-chat","messages":[{"role":"user","content":"search"}],
+				"tools":[`+test.tool+`]
+			}`), "grok-4.6", OperationChat)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("conversion error = %v, wantErr %v", err, test.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(converted, &payload); err != nil {
+				t.Fatal(err)
+			}
+			tool := payload["tools"].([]any)[0].(map[string]any)
+			if test.name == "empty filters omitted" && len(tool) != 1 {
+				t.Fatalf("empty filters were not omitted: %#v", tool)
+			}
+		})
+	}
+}
+
 func TestConvertChatToolImageResultToMultimodalFunctionOutput(t *testing.T) {
 	body := []byte(`{
 		"model":"public-chat",
@@ -511,6 +566,28 @@ func TestConvertAnthropicWebSearchControls(t *testing.T) {
 	tool = payload["tools"].([]any)[0].(map[string]any)
 	if len(tool) != 1 || tool["type"] != "web_search" {
 		t.Fatalf("downgraded tool = %#v", tool)
+	}
+
+	converted, _, err = ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"messages":[{"role":"user","content":"search"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","blocked_domains":["blocked.example"]}]
+	}`), "grok-4.6", OperationMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload = nil
+	_ = json.Unmarshal(converted, &payload)
+	tool = payload["tools"].([]any)[0].(map[string]any)
+	domains = tool["filters"].(map[string]any)["excluded_domains"].([]any)
+	if len(domains) != 1 || domains[0] != "blocked.example" {
+		t.Fatalf("blocked_domains conversion = %#v", tool)
+	}
+
+	if _, _, err = ConvertRequestWithOptions([]byte(`{
+		"model":"public","max_tokens":64,"messages":[{"role":"user","content":"search"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search","allowed_domains":["allow.example"],"blocked_domains":["blocked.example"]}]
+	}`), "grok-4.6", OperationMessages); err == nil {
+		t.Fatal("allowed_domains + blocked_domains must be rejected")
 	}
 }
 

--- a/backend/internal/infra/provider/conversation/messages_request.go
+++ b/backend/internal/infra/provider/conversation/messages_request.go
@@ -686,7 +686,7 @@ func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (
 		switch key {
 		case "type", "name", "cache_control":
 			continue
-		case "allowed_domains":
+		case "allowed_domains", "blocked_domains", "excluded_domains":
 			var value any
 			if json.Unmarshal(raw, &value) != nil {
 				return nil, fmt.Errorf("tools[%d].%s 无效", index, key)
@@ -695,17 +695,38 @@ func convertAnthropicWebSearchTool(tool map[string]json.RawMessage, index int) (
 			if !ok {
 				return nil, fmt.Errorf("tools[%d].%s 必须是字符串数组", index, key)
 			}
-			if len(domains) > 5 {
-				return nil, fmt.Errorf("tools[%d].%s 不能超过 5 个域名", index, key)
+			if len(domains) > MaxWebSearchDomains {
+				return nil, fmt.Errorf("tools[%d].%s 不能超过 %d 个域名", index, key, MaxWebSearchDomains)
 			}
 			for domainIndex, domain := range domains {
 				if text, ok := domain.(string); !ok || strings.TrimSpace(text) == "" {
 					return nil, fmt.Errorf("tools[%d].%s[%d] 必须是非空字符串", index, key, domainIndex)
 				}
 			}
-			converted["filters"] = map[string]any{"allowed_domains": value}
-		case "max_uses", "blocked_domains", "user_location", "search_context_size":
-			// The Build web-search wire contract supports only allowed_domains. Do not forward other optional Anthropic controls,
+			field := key
+			if field == "blocked_domains" {
+				field = "excluded_domains"
+			}
+			filters, _ := converted["filters"].(map[string]any)
+			if filters == nil {
+				filters = make(map[string]any, 2)
+			}
+			if len(domains) > 0 {
+				if _, exists := filters[field]; exists {
+					return nil, fmt.Errorf("tools[%d].%s 与同义域名过滤字段重复", index, key)
+				}
+				other := "allowed_domains"
+				if field == other {
+					other = "excluded_domains"
+				}
+				if existing, ok := filters[other].([]any); ok && len(existing) > 0 {
+					return nil, fmt.Errorf("tools[%d] 不能同时设置 allowed_domains 和 blocked_domains/excluded_domains", index)
+				}
+				filters[field] = value
+				converted["filters"] = filters
+			}
+		case "max_uses", "user_location", "search_context_size":
+			// These Anthropic controls have no equivalent in the Build web-search wire contract,
 			// preventing unknown parameters from causing the upstream to reject the request.
 			continue
 		default:

--- a/backend/internal/infra/provider/conversation/server_web_search.go
+++ b/backend/internal/infra/provider/conversation/server_web_search.go
@@ -26,7 +26,11 @@ type webSearchCall struct {
 	Code   string
 }
 
-const maxWebSearchCalls = 32
+const (
+	maxWebSearchCalls = 32
+	// MaxWebSearchDomains mirrors the Grok Build Web Search limit for each allow/exclude list.
+	MaxWebSearchDomains = 5
+)
 
 func unavailableWebSearchCall(query string) webSearchCall {
 	fallback := map[string]string{"type": "web_search", "query": query, "error": "unavailable"}

--- a/backend/internal/transport/http/settings/security_test.go
+++ b/backend/internal/transport/http/settings/security_test.go
@@ -47,9 +47,9 @@ func TestSettingsResponseIncludesBuildTokenAuth(t *testing.T) {
 
 func TestSettingsResponseIncludesRecommendedBuildBaseline(t *testing.T) {
 	response := newSettingsResponse(settingsapp.Snapshot{RecommendedProviderBuild: settingsapp.ProviderBuildRecommendation{
-		ClientVersion: "0.2.119", UserAgent: "grok-shell/0.2.119 (linux; x86_64)",
+		ClientVersion: "1.0.4", UserAgent: "grok-shell/1.0.4 (linux; x86_64)",
 	}})
-	if response.RecommendedProviderBuild.ClientVersion != "0.2.119" || response.RecommendedProviderBuild.UserAgent == "" {
+	if response.RecommendedProviderBuild.ClientVersion != "1.0.4" || response.RecommendedProviderBuild.UserAgent == "" {
 		t.Fatalf("recommended build = %#v", response.RecommendedProviderBuild)
 	}
 }


### PR DESCRIPTION
## 概述

对照 xAI 官方 grok-build 1.0.4 源码，更新 Grok Build 推荐客户端标识，并补齐 Web Search 域名过滤和 Chat 可见推理摘要的协议兼容。

本次改动保持 Grok2API 对 Responses、Chat Completions 与 Anthropic Messages 的兼容边界，不盲目复制官方客户端行为，也不影响 Console、Web Provider。

## 主要改动

### 1. 更新 Grok Build 推荐客户端版本

将推荐客户端基线从 `0.2.119` 更新为 `1.0.4`：

```text
clientVersion: 1.0.4
User-Agent: grok-shell/1.0.4 (linux; x86_64)
```

同步更新：

- 内置默认配置
- 后台运行设置中的推荐值
- 配置与设置接口测试

该变更只更新推荐基线，不会强制覆盖数据库中已经保存的运行设置。现有部署可在后台确认并同步推荐值，避免升级代码时意外修改已灰度验证的客户端标识。

### 2. 补齐 Web Search 排除域名支持

对齐 grok-build 1.0.4 的 Web Search 请求结构，完整支持：

```json
{
  "type": "web_search",
  "filters": {
    "allowed_domains": ["example.com"]
  }
}
```

或：

```json
{
  "type": "web_search",
  "filters": {
    "excluded_domains": ["blocked.example"]
  }
}
```

覆盖三种下游协议：

- Responses API
- Chat Completions
- Anthropic Messages

兼容行为包括：

- 支持 `filters.allowed_domains`
- 支持 `filters.excluded_domains`
- 兼容顶层 `allowed_domains` / `excluded_domains` 并归一化到 `filters`
- Anthropic `blocked_domains` 映射为 Build `excluded_domains`
- 每个域名列表最多允许 5 项
- 拒绝空字符串和非字符串元素
- 拒绝同时设置允许列表与排除列表
- 拒绝顶层与嵌套字段存在冲突的重复声明
- `null` 或空数组视为未设置，不生成无效过滤对象
- 无法等价转换的其他搜索参数继续沿用现有降级策略

无效请求会在本地返回明确的参数错误，不会发送到上游产生无效调用、账号轮换或健康状态污染。

### 3. 保证 Build Chat 返回可见推理摘要

真实排查确认，原实现没有丢失 `reasoning_effort`：

```text
Chat reasoning_effort
        ↓
Responses reasoning.effort
        ↓
Grok Build
```

上游返回的推理事件也能够被正确收集并转换：

- Responses：`response.reasoning_summary_text.delta`
- Chat Completions：`choices[].delta.reasoning_content`
- Anthropic Messages：`thinking_delta` / `signature_delta`

实际协议缺口是：Chat Completions 没有单独的 reasoning summary 参数，原实现只转发 `effort`，可见推理摘要依赖上游的隐式默认行为。

官方 grok-build 1.0.4 会在请求 Responses 后端时显式携带：

```json
{
  "reasoning": {
    "summary": "concise"
  }
}
```

本次在 Build 请求归一化边界补齐该行为：

- Build Chat 默认添加 `reasoning.summary = "concise"`
- 显式 `reasoning_effort` 继续映射到 `reasoning.effort`
- 未传 effort 时保留模型自身的默认推理强度
- 调用方已有明确 summary 时不覆盖
- 原生 Responses 继续由调用方控制 summary
- Anthropic Messages 继续使用现有 thinking 转换
- Console 与 Web Provider 不受影响

该逻辑按请求协议类型在 Build Adapter 内执行，没有将 Build 专属默认值放入三端共享转换层。

## 保持不变的兼容逻辑

以下项目经过复核，本次未改变：

- `grok-4.5` 不支持的 `xhigh` / `max` 继续安全降级
- `grok-4.6` 已验证的 `xhigh` 能力继续保留
- Composer 继续移除不支持的 `reasoning.effort`
- `store` 缺省时继续使用安全的 `false`
- `reasoning.encrypted_content` 继续自动加入 include，支持无状态推理回放
- 不主动注入 `stream_tool_calls`
- 不根据单账号 `/models` 元数据覆盖全局模型目录
- 不修改模型路由、账号能力和计费逻辑

## 真实请求验证

通过本地 Grok2API 完整链路请求真实 Grok Build 上游，不以 reasoning token 计数作为判断依据，而是直接检查响应字段及非空内容。

### Responses API

流式响应真实包含：

```text
response.reasoning_summary_part.added
response.reasoning_summary_text.delta
response.reasoning_summary_text.done
response.reasoning_summary_part.done
```

非流式响应包含独立的 reasoning output item：

```json
{
  "type": "reasoning",
  "summary": [
    {
      "type": "summary_text",
      "text": "..."
    }
  ]
}
```

### Chat Completions

显式设置：

```json
{
  "reasoning_effort": "high"
}
```

真实结果：

```text
HTTP 200
reasoning_content events: 16
reasoning_content 非空
```

不传 `reasoning_effort`、使用模型默认值：

```text
HTTP 200
reasoning_content events: 16
reasoning_content 非空
```

非流式响应真实包含：

```json
{
  "message": {
    "reasoning_content": "..."
  }
}
```

### Anthropic Messages

启用 thinking 后，流式响应真实包含：

```text
thinking_delta
signature_delta
```

非流式响应真实包含：

```json
{
  "content": [
    {
      "type": "thinking",
      "thinking": "...",
      "signature": "..."
    }
  ]
}
```

## 自动化验证

已通过：

```bash
go test \
  ./internal/infra/provider/conversation \
  ./internal/infra/provider/cli \
  ./internal/application/gateway \
  ./internal/transport/http/inference \
  -count=1
```

```bash
go vet \
  ./internal/infra/provider/conversation \
  ./internal/infra/provider/cli \
  ./internal/application/gateway \
  ./internal/transport/http/inference
```

```bash
git diff --check
```

新增或扩展的测试覆盖：

- Build Chat 默认 concise summary
- 显式 reasoning effort 保留
- 显式 summary 不被覆盖
- 原生 Responses 不被注入额外 summary
- `allowed_domains` / `excluded_domains` 三协议转换
- Anthropic `blocked_domains` 映射
- 域名数量上限
- allow/exclude 互斥
- 顶层与嵌套冲突
- 空过滤器省略
- 无效请求不会调用上游

## 兼容性

- API：向后兼容
- 数据库：无 Schema 变更
- 配置文件：无新增必填项
- 账号与路由：无行为变化
- Console/Web：无影响
- 原生 Responses：保留调用方参数控制
- 已保存的 Build 运行设置：不会被强制覆盖