### PR TITLE
fix: 质量守护与面板速度在 /v1/responses 下的虚高问题

### DIFF
--- a/backend/internal/application/gateway/quality_probe.go
+++ b/backend/internal/application/gateway/quality_probe.go
@@ -32,6 +32,7 @@ type qualityProbeChatEvent struct {
 			Content          string `json:"content"`
 			Reasoning        string `json:"reasoning"`
 			ReasoningContent string `json:"reasoning_content"`
+			ThinkingContent  string `json:"thinking_content"`
 		} `json:"delta"`
 	} `json:"choices"`
 	Usage *struct {
@@ -133,7 +134,7 @@ func (s *Service) ProbeEgressQuality(ctx context.Context, nodeID uint64, input e
 		}
 		for _, choice := range event.Choices {
 			delta := choice.Delta
-			generated := delta.Content != "" || delta.Reasoning != "" || delta.ReasoningContent != ""
+			generated := qualityProbeHasGeneratedDelta(delta.Content, delta.Reasoning, delta.ReasoningContent, delta.ThinkingContent)
 			if generated && firstGeneratedAt.IsZero() {
 				firstGeneratedAt = time.Now()
 				if result.MarkFirstToken != nil {
@@ -206,4 +207,8 @@ func qualityProbeOutputTokensPerSecond(outputTokens, durationMS, firstTokenMS in
 		return 0
 	}
 	return float64(outputTokens) * 1000 / float64(generationMS)
+}
+
+func qualityProbeHasGeneratedDelta(content, reasoning, reasoningContent, thinkingContent string) bool {
+	return content != "" || reasoning != "" || reasoningContent != "" || thinkingContent != ""
 }

--- a/backend/internal/application/gateway/quality_probe_test.go
+++ b/backend/internal/application/gateway/quality_probe_test.go
@@ -39,3 +39,15 @@ func TestQualityProbeOutputTokensPerSecondIncludesReasoningTokens(t *testing.T) 
 		t.Fatalf("output TPS = %v, want 10500", got)
 	}
 }
+
+func TestQualityProbeCountsThinkingContentAsFirstToken(t *testing.T) {
+	if qualityProbeHasGeneratedDelta("", "", "", "") {
+		t.Fatal("empty deltas must not mark first token")
+	}
+	if !qualityProbeHasGeneratedDelta("", "", "", "hmm") {
+		t.Fatal("thinking_content must mark first token so thinking time stays in the generation window")
+	}
+	if !qualityProbeHasGeneratedDelta("", "", "hmm", "") {
+		t.Fatal("reasoning_content must still mark first token")
+	}
+}

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1436,13 +1436,23 @@ func containsGeneratedDelta(data []byte, protocol streamProtocol) bool {
 		var event struct {
 			Type  string `json:"type"`
 			Delta string `json:"delta"`
+			Item  struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			} `json:"item"`
 		}
-		if json.Unmarshal(data, &event) != nil || event.Delta == "" {
+		if json.Unmarshal(data, &event) != nil {
 			return false
 		}
 		switch event.Type {
 		case "response.output_text.delta", "response.reasoning_summary_text.delta", "response.reasoning_text.delta", "response.refusal.delta", "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
-			return true
+			return event.Delta != ""
+		case "response.output_item.added":
+			// Native Responses can stream an identified reasoning item with no
+			// text delta when only encrypted_content is requested. That item is
+			// still generation start; waiting for output_text kicks thinking
+			// time out of the TPS denominator.
+			return event.Item.Type == "reasoning" && event.Item.ID != ""
 		}
 	case streamProtocolChat:
 		var event struct {
@@ -1451,6 +1461,7 @@ func containsGeneratedDelta(data []byte, protocol streamProtocol) bool {
 					Content          string `json:"content"`
 					Reasoning        string `json:"reasoning"`
 					ReasoningContent string `json:"reasoning_content"`
+					ThinkingContent  string `json:"thinking_content"`
 					Refusal          string `json:"refusal"`
 					ToolCalls        []struct {
 						Function struct {
@@ -1465,7 +1476,7 @@ func containsGeneratedDelta(data []byte, protocol streamProtocol) bool {
 		}
 		for _, choice := range event.Choices {
 			delta := choice.Delta
-			if delta.Content != "" || delta.Reasoning != "" || delta.ReasoningContent != "" || delta.Refusal != "" {
+			if delta.Content != "" || delta.Reasoning != "" || delta.ReasoningContent != "" || delta.ThinkingContent != "" || delta.Refusal != "" {
 				return true
 			}
 			for _, call := range delta.ToolCalls {

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -836,9 +836,19 @@ func TestStreamInspectorMarksFirstGeneratedTokenOnce(t *testing.T) {
 			delta:   `data: {"type":"response.custom_tool_call_input.delta","output_index":1,"item_id":"ctc_1","delta":"{}"}` + "\n\n",
 		},
 		{
+			name: "responses encrypted reasoning item", protocol: streamProtocolResponses,
+			prelude: `data: {"type":"response.created","response":{"id":"resp_1"}}` + "\n\n",
+			delta:   `data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning","status":"in_progress"}}` + "\n\n",
+		},
+		{
 			name: "chat reasoning", protocol: streamProtocolChat,
 			prelude: `data: {"choices":[{"delta":{"role":"assistant"}}]}` + "\n\n",
 			delta:   `data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}` + "\n\n",
+		},
+		{
+			name: "chat thinking_content", protocol: streamProtocolChat,
+			prelude: `data: {"choices":[{"delta":{"role":"assistant"}}]}` + "\n\n",
+			delta:   `data: {"choices":[{"delta":{"thinking_content":"thinking"}}]}` + "\n\n",
 		},
 		{
 			name: "anthropic tool input", protocol: streamProtocolAnthropic,


### PR DESCRIPTION
# 让首字落在真正开始生成的那一刻：修复 /v1/responses 下面板/质量守护 Token/s 虚高

质量守护和审计面板的速度口径是 `outputTokens / (durationMs - firstTokenMs)`：分子有意包含 reasoning token，分母只扣「首字」等待。问题就出在「首字」——`/v1/responses` 原生流里模型先思考，思考期间上游只发 `response.output_item.added`（`item.type=reasoning`），没有任何文字 delta。旧代码只在 `delta` 非空的事件上打首字，于是要一直等到第一条 `output_text` 才落点。

后果：思考时间整段滑进 TTFT（被踢出分母），分子里的思考 token 一份没少，Token/s 比真实生成速度快。修复只有一处：带 id 的 `output_item.added` + `item.type=reasoning` 视为生成开始。`done` 不算——它出现在思考结束时，拿来当首字等于白改。质量探测走 Chat（强制 concise summary），不受影响。

## 复现流程（修复前）

**前置条件**

- 本仓库后端已启动，`qualityGuard` 启用或可直接查「请求审计」页
- 一个可调度的 Grok Build 账号，模型 grok-4.6 或 grok-4.5

**步骤**

1. 用原生 Responses + 流式发请求，**不要**带 `reasoning.summary`（服务端仍会自动注入 `include: ["reasoning.encrypted_content"]`）：

```bash
curl -sN "$BASE/v1/responses" \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "grok-4.6",
    "stream": true,
    "reasoning": {"effort": "high"},
    "input": "Prove that there are infinitely many primes. Think carefully."
  }'
```

2. 观察 SSE 事件顺序。修复前你会看到：

```
response.output_item.added      ← item.type = "reasoning"，带 id，没有 delta
（长时间空白，只有 keepalive，无任何 *_text.delta）
response.output_item.done       ← 挂上 encrypted_content（思考结束）
response.output_text.delta      ← 第一条可见文字，首字在这里才被打点
response.completed              ← usage 里 output_tokens 含 reasoning_tokens
```

3. 打开管理端「请求审计」找到这条记录（`/v1/responses`、streaming=true、statusCode=200）。核对四个字段：

| 字段 | 修复前的值 | 说明 |
|---|---|---|
| `firstTokenMs` | ≈ 整个思考等待 + 首个答案字 | 思考时间被算进 TTFT |
| `durationMs - firstTokenMs` | 只剩答案生成窗口 | 分母被人为缩小 |
| `outputTokens` | 含 `reasoningTokens` | 分子照旧含思考 token |
| `outputTokensPerSecond` | 明显高于答案阶段真实速度 | 虚高结果 |

4. 对照组：同一账号走 `/v1/chat/completions`。Chat 路径会强制 `reasoning.summary = "concise"`，思考以 `delta.reasoning_content` 流出，首字打点早得多，面板 Token/s 更接近真实。两条路径对比即可确认差异来自首字打点，而非账号/节点本身。

5. 单元复现：把 `handler.go` 中 `containsGeneratedDelta` 的修改回退（恢复 `event.Delta != ""` 早退），运行：

```bash
cd backend
go test ./internal/transport/http/inference -run 'TestStreamInspectorMarksFirstGeneratedTokenOnce' -count=1
```

新增用例 `responses_encrypted_reasoning_item` 会失败——它模拟的就是 2 里的流：只有 `output_item.added`(reasoning)，没有文字 delta，但首字必须在这里打点。

## 验证

```bash
cd backend
go test ./internal/transport/http/inference ./internal/application/gateway -count=1 -timeout 90s \
  -run 'TestStreamInspectorMarksFirstGeneratedTokenOnce|TestCopyStreamMarksFirstTokenAfterFlush|TestQualityProbe'
```

---

# Make first token land where generation actually starts: fix inflated Token/s on /v1/responses

Quality Guard and the audit panel compute speed as `outputTokens / (durationMs - firstTokenMs)`: the numerator intentionally includes reasoning tokens, the denominator only subtracts the "first token" wait. The catch is the first-token point itself. On native `/v1/responses` the model thinks first, and while it thinks the stream only carries `response.output_item.added` (`item.type=reasoning`) — no text deltas at all. The old detector stamped first token only on events with a non-empty `delta`, so it waited all the way to the first `output_text`.

Result: the whole thinking period slid into TTFT (out of the denominator) while reasoning tokens stayed in the numerator, so Token/s read higher than real generation. The fix is one line: an identified `output_item.added` with `item.type=reasoning` counts as generation start. `done` deliberately does not — it arrives when thinking finishes, so marking it there would keep the inflation. Quality probes go through Chat (concise summary forced), so they are unaffected.

## Repro (before the fix)

**Prereqs**

- Backend running; Quality Guard enabled or Request Audits page reachable
- A schedulable Grok Build account with grok-4.6 or grok-4.5

**Steps**

1. Send a native Responses streaming request **without** `reasoning.summary` (the server still injects `include: ["reasoning.encrypted_content"]`):

```bash
curl -sN "$BASE/v1/responses" \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "grok-4.6",
    "stream": true,
    "reasoning": {"effort": "high"},
    "input": "Prove that there are infinitely many primes. Think carefully."
  }'
```

2. Watch the SSE order. Before the fix:

```
response.output_item.added      ← item.type = "reasoning", has id, no delta
(long gap; keepalives only, no *_text.delta)
response.output_item.done       ← carries encrypted_content (thinking finished)
response.output_text.delta      ← first visible text; first token stamped here
response.completed              ← usage output_tokens includes reasoning_tokens
```

3. Open Request Audits and find this record (`/v1/responses`, streaming=true, statusCode=200). Check four fields:

| field | before the fix | note |
|---|---|---|
| `firstTokenMs` | ≈ full thinking wait + first answer char | thinking folded into TTFT |
| `durationMs - firstTokenMs` | only the answer window | denominator shrank |
| `outputTokens` | includes `reasoningTokens` | numerator unchanged |
| `outputTokensPerSecond` | clearly above the answer-phase rate | the inflation |

4. Control: same account via `/v1/chat/completions`. Chat forces `reasoning.summary = "concise"`, thinking streams out as `delta.reasoning_content`, first token is much earlier, and panel Token/s is realistic. The two-path comparison isolates the cause to first-token timing, not the account or node.

5. Unit repro: revert the `containsGeneratedDelta` change in `handler.go` (restore the `event.Delta != ""` early return), then:

```bash
cd backend
go test ./internal/transport/http/inference -run 'TestStreamInspectorMarksFirstGeneratedTokenOnce' -count=1
```

The new `responses_encrypted_reasoning_item` case fails — it simulates the step-2 stream: only `output_item.added`(reasoning), no text delta, yet first token must be stamped there.

## Verify

```bash
cd backend
go test ./internal/transport/http/inference ./internal/application/gateway -count=1 -timeout 90s \
  -run 'TestStreamInspectorMarksFirstGeneratedTokenOnce|TestCopyStreamMarksFirstTokenAfterFlush|TestQualityProbe'
```