### PR TITLE
fix: avoid duplicate view_image tool definitions

### DIFF
--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -470,6 +470,75 @@ func TestNormalizeRequestForwardsXSearchTimeRangeAndImageSearch(t *testing.T) {
 	})
 }
 
+func TestNormalizeRequestAvoidsClientViewImageToolCollision(t *testing.T) {
+	spec, ok := Resolve("grok-4.5")
+	if !ok {
+		t.Fatal("grok-4.5 missing")
+	}
+	tests := []struct {
+		name      string
+		operation string
+		body      string
+	}{
+		{
+			name:      "responses",
+			operation: conversation.OperationResponses,
+			body: `{"model":"grok-4.5","input":"Reply only OK. Do not call tools.","tools":[
+				{"type":"function","name":"view_image","description":"View a local image","strict":false,"parameters":{"type":"object"}},
+				{"type":"web_search","enable_image_understanding":true}],"tool_choice":"auto"}`,
+		},
+		{
+			name:      "chat completions",
+			operation: conversation.OperationChat,
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"Reply only OK."}],"tools":[
+				{"type":"function","function":{"name":"view_image","description":"View a local image","strict":false,"parameters":{"type":"object"}}},
+				{"type":"web_search"}],"tool_choice":"auto"}`,
+		},
+		{
+			name:      "anthropic messages",
+			operation: conversation.OperationMessages,
+			body: `{"model":"grok-4.5","max_tokens":64,"messages":[{"role":"user","content":"Reply only OK."}],"tools":[
+				{"name":"view_image","description":"View a local image","input_schema":{"type":"object"}},
+				{"type":"web_search_20250305","name":"web_search"}],"tool_choice":{"type":"auto"}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(test.body)
+			var err error
+			if test.operation != conversation.OperationResponses {
+				body, err = conversation.ConvertRequest(body, spec.UpstreamModel, test.operation)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			body, err = normalizeRequest(body, spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatal(err)
+			}
+			tools, _ := payload["tools"].([]any)
+			if len(tools) != 2 {
+				t.Fatalf("tools = %#v", tools)
+			}
+			function, _ := tools[0].(map[string]any)
+			if toolIdentity(function) != "function:view_image" || function["parameters"] == nil {
+				t.Fatalf("client view_image must be retained: %#v", function)
+			}
+			webSearch, _ := tools[1].(map[string]any)
+			if webSearch["type"] != "web_search" || webSearch["enable_image_understanding"] != false {
+				t.Fatalf("server view_image must be disabled: %#v", webSearch)
+			}
+			if payload["tool_choice"] != "auto" {
+				t.Fatalf("tool_choice = %#v", payload["tool_choice"])
+			}
+		})
+	}
+}
+
 func TestNormalizeRequestDoesNotInjectToolsForConsoleCatalog(t *testing.T) {
 	for _, spec := range catalog {
 		t.Run(spec.PublicID, func(t *testing.T) {

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -254,6 +254,7 @@ func normalizeConsoleTools(payload map[string]any) bool {
 		delete(payload, "tool_choice")
 		return false
 	}
+	hasClientViewImage := hasConsoleFunctionTool(tools, "view_image")
 	result := make([]any, 0, len(tools))
 	retainedClientTools := false
 	for _, rawTool := range tools {
@@ -264,8 +265,12 @@ func normalizeConsoleTools(payload map[string]any) bool {
 		typeName, _ := tool["type"].(string)
 		switch strings.ToLower(strings.TrimSpace(typeName)) {
 		case "web_search", "web_search_preview", "web_search_preview_2025_03_11", "web_search_2025_08_26":
-			clean := map[string]any{"type": "web_search", "enable_image_understanding": true}
-			if enabled, ok := tool["enable_image_understanding"].(bool); ok {
+			// xAI equips web_search with a server-side tool also named view_image
+			// when image understanding is enabled. Prefer the client's function of
+			// that name so Codex can still inspect local files without mgw rejecting
+			// the request as a duplicate tool definition.
+			clean := map[string]any{"type": "web_search", "enable_image_understanding": !hasClientViewImage}
+			if enabled, ok := tool["enable_image_understanding"].(bool); ok && !hasClientViewImage {
 				clean["enable_image_understanding"] = enabled
 			}
 			// Forward the image-search toggle (enable_image_search) so clients
@@ -330,6 +335,21 @@ func normalizeConsoleTools(payload map[string]any) bool {
 	}
 	payload["tools"] = result
 	return retainedClientTools
+}
+
+func hasConsoleFunctionTool(tools []any, target string) bool {
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		typeName, _ := tool["type"].(string)
+		name, _ := tool["name"].(string)
+		if strings.EqualFold(strings.TrimSpace(typeName), "function") && strings.EqualFold(strings.TrimSpace(name), target) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeConsoleToolChoice(payload map[string]any, retainedClientTools bool) {


### PR DESCRIPTION
Closes #879.

## Summary

- Detect client-defined `view_image` functions in Console requests.
- When `web_search` is also present, disable its server-side image-understanding tool to avoid creating a second `view_image`.
- Preserve the client-defined `view_image` so clients such as Codex CLI can continue handling local image inspection.
- Keep the existing `web_search` image-understanding behavior when no client-defined `view_image` is present.
- Cover Responses, Chat Completions, and Anthropic Messages request shapes.

## Root cause

Grok Console exposes a server-side tool named `view_image` when `web_search.enable_image_understanding` is enabled.

When a client such as Codex CLI also declares its own `view_image` function, the normalized upstream request contains two tools with the same name. Console rejects the request before generation with:

```json
{
  "code": "invalid-argument",
  "error": "Duplicate tool names: view_image"
}