### PR TITLE
docs: document requestRetry, compact session drift, and sticky nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Web can be weakly linked one-to-one with matching Build and Console accounts. Li
 
 ### Codex, Claude Code, and prompt caching
 
-Responses and Messages support streaming, tools, reasoning, multi-turn sessions, and compaction. Stable client session signals are preserved for Grok Build prompt-cache affinity. Cache hits still require a compatible upstream account and an unchanged prompt prefix.
+Responses and Messages support streaming, tools, reasoning, multi-turn sessions, and compaction. Stable client session signals are preserved for Grok Build prompt-cache affinity. Cache hits still require a compatible upstream account and an unchanged prompt prefix. A still-decryptable compaction summary from this gateway instance is expanded even if the session or PromptCacheKey remaps; foreign or undecodable blobs remain a compatibility boundary.
 
 Responses and Chat Completions report OpenAI-style total input. Messages reports Anthropic-style uncached input and cache reads separately. Audits retain total and cached input for billing reconciliation.
 
@@ -350,6 +350,7 @@ Egress nodes are scoped to Build, Web, Console, or Web assets. The admin console
 - Proxy-pool mode without global cooldown after one connection failure
 - Immediate recovery probes after fixed-proxy transport failures, with per-node coalescing and bounded waiting for fast retry
 - Optional [Egress Quality Guard](./tools/egress-quality-guard/README.md) for active per-node model probes, guarded quarantine, and recovery; enable it with the built-in `quality-guard` Compose profile
+- Give each sticky session its own fixed node (`proxyPool=false`). Do not merge several stickies into one node, or the guard can only quarantine the whole group
 
 Hysteria and TUIC are not supported yet. FlareSolverr accepts only HTTP/SOCKS proxy URLs, so automatic clearance refresh cannot use a tunnel share URL directly.
 
@@ -361,7 +362,16 @@ identity automatically:
 qualityGuard:
   enabled: true
   model: "grok-4.5"
+  # Optional: withhold thinking-model streams that have no reasoning.
+  requestRetry:
+    enabled: false
+    maxAttempts: 6
+    holdTimeout: 3s
+    minOutputTokens: 32
+    onExhausted: fail_closed # fail_open | fail_closed
 ```
+
+`requestRetry` runs on the gateway request path and is independent of the sidecar. It is off by default. When enabled, a thinking-model stream with enough visible output and no reasoning is **not delivered**; another account is tried. If every attempt still has no reasoning, `onExhausted` either returns `503 quality_degraded` or delivers the last body. Image, video, tool, stored-response, and ForcedEgress probe requests are unchanged.
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -291,7 +291,7 @@ Web 可与对应的 Build、Console 建立一对一弱关联。关联只共享�
 
 ### Codex、Claude Code 与 Prompt Cache
 
-Responses 与 Messages 支持流式、工具、推理、多轮会话和 compact。客户端会话信号会保持稳定，用于 Grok Build Prompt Cache 亲和；实际命中仍要求上游账号兼容且请求前缀未变化。
+Responses 与 Messages 支持流式、工具、推理、多轮会话和 compact。客户端会话信号会保持稳定，用于 Grok Build Prompt Cache 亲和；实际命中仍要求上游账号兼容且请求前缀未变化。同一网关实例内，仍可解密的 compact 摘要在 session / PromptCacheKey 漂移后也会展开；无法解密的外源 blob 仍视为兼容边界。
 
 Responses 与 Chat Completions 按 OpenAI 语义报告输入总量；Messages 按 Anthropic 语义分开报告未缓存输入和缓存读取。审计保留输入总量与缓存部分，用于计费对账。
 
@@ -348,6 +348,7 @@ curl http://127.0.0.1:8000/v1/responses \
 - 代理池模式，单次连接失败不会触发全局冷却
 - 固定代理传输失败后立即复测；同节点复测自动合并，后续绑定请求限时等待并在恢复后快速重试
 - 可选的[出口质量守护程序](./tools/egress-quality-guard/README.zh-CN.md)，支持逐节点模型探测、防误杀隔离和自动恢复；通过内置的 `quality-guard` Compose profile 按需启用
+- 固定 sticky 会话应各自建成独立节点（`proxyPool=false`）。不要把多条 sticky 合成一个节点，否则质量守护只能整组摘流，无法定位坏会话
 
 Hysteria 与 TUIC 暂未支持。FlareSolverr 仅接受 HTTP/SOCKS 代理地址，因此自动刷新 Clearance 暂不能直接使用隧道分享链接。
 
@@ -357,7 +358,16 @@ Hysteria 与 TUIC 暂未支持。FlareSolverr 仅接受 HTTP/SOCKS 代理地址�
 qualityGuard:
   enabled: true
   model: "grok-4.5"
+  # 可选：思考模型缺 reasoning 时先扣住响应，换号再打，不把降智正文发给用户。
+  requestRetry:
+    enabled: false
+    maxAttempts: 6
+    holdTimeout: 3s
+    minOutputTokens: 32
+    onExhausted: fail_closed # fail_open | fail_closed
 ```
+
+`requestRetry` 在网关请求路径上生效，与 sidecar 探测/隔离相互独立。默认关闭。开启后，可见输出达到 `minOutputTokens` 且全程无 reasoning 时**不发给用户**，排除该账号再试；全部仍无推理则按 `onExhausted` 返回 `503 quality_degraded` 或放出最后一枪。不处理图/视频/工具、stored response 钉账号和 ForcedEgress 探针。
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/tools/egress-quality-guard/README.md
+++ b/tools/egress-quality-guard/README.md
@@ -190,6 +190,10 @@ The sidecar talks to grok2api at `GROK2API_BASE_URL`, which defaults to
 renamed or published on host networking, for example
 `GROK2API_BASE_URL=http://127.0.0.1:8000`.
 
+Missing-thinking **request-path withhold/retry** (`qualityGuard.requestRetry`)
+runs inside the grok2api gateway, not this sidecar. See `config.example.yaml`
+and the root README.
+
 Verify the managed nodes, model, and minimum healthy-node count before leaving
 the sidecar running. Never commit the state volume or
 production logs.

--- a/tools/egress-quality-guard/README.zh-CN.md
+++ b/tools/egress-quality-guard/README.zh-CN.md
@@ -132,6 +132,8 @@ docker compose --profile quality-guard up -d --build
 
 sidecar 通过 `GROK2API_BASE_URL` 访问主程序，Compose 网络默认是 `http://grok2api:8000`。主服务改名或使用 host 网络时需要覆盖，例如 `GROK2API_BASE_URL=http://127.0.0.1:8000`。
 
+缺 thinking 的**请求路径扣住/换号**（`qualityGuard.requestRetry`）在 grok2api 网关内完成，不经过 sidecar。配置见根目录 `config.example.yaml` 与主 README。
+
 先确认受管节点、模型和最低健康节点数正确，再允许 sidecar 长期运行。不要提交状态卷或生产日志。只停止守护程序可执行
 `docker compose --profile quality-guard stop egress-quality-guard`，不会影响主 API。
 


### PR DESCRIPTION
## Summary

Document three behaviors that are already on `main` but easy to miss in the root README:

- `qualityGuard.requestRetry`: gateway-side withhold/retry when a thinking model returns enough visible output with no reasoning (`503 quality_degraded` when `fail_closed`).
- Compact summaries stay usable after session / PromptCacheKey drift on the same gateway instance.
- Recommend one fixed egress node per sticky session (`proxyPool=false`).

The sidecar README already covers `GROK2API_BASE_URL`. This PR only notes that requestRetry is **in-process**, not sidecar.

## Scope

Docs only: `README.md`, `README.zh-CN.md`, `tools/egress-quality-guard/README.md`, `tools/egress-quality-guard/README.zh-CN.md`.