### PR TITLE
fix(web): Web video generation — gzip-only encoding, 72-byte statsig fallback, 6s duration clamp

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -935,7 +935,14 @@ func validStatsigID(value string) bool {
 	if err != nil {
 		decoded, err = base64.StdEncoding.DecodeString(value)
 	}
-	return err == nil && len(decoded) == 70
+	if err != nil {
+		return false
+	}
+	// Real statsig IDs are 70 bytes. The browser also sends a 72-byte
+	// "error-type" fallback (base64 of "x:TypeError: Cannot read
+	// properties of undefined (reading 'childNodes')") that xAI's
+	// anti-bot accepts. Accept both.
+	return len(decoded) == 70 || len(decoded) == 72
 }
 
 func validCredentialEncryptionKey(value string) bool {

--- a/backend/internal/infra/provider/web/image.go
+++ b/backend/internal/infra/provider/web/image.go
@@ -1467,6 +1467,11 @@ func (a *Adapter) postJSONWithReferer(ctx context.Context, cfg Config, lease *eg
 		}
 		request.Header = buildHeaders(token, lease, "application/json")
 		applyAppHeaders(request.Header, cfg.BaseURL, referer)
+		// tls-client (Chrome JA3) passes the app-level anti-bot checks that
+		// soft-block Go's default TLS fingerprint with 429/403. It only
+		// auto-decompresses gzip, so restrict Accept-Encoding to gzip;
+		// br/zstd bodies would arrive compressed and break json.Unmarshal.
+		request.Header.Set("Accept-Encoding", "gzip")
 		a.applySignedStatsig(requestCtx, request, token, lease)
 		response, err := lease.DoDeferredForbidden(request)
 		if err != nil {

--- a/backend/internal/infra/provider/web/statsig.go
+++ b/backend/internal/infra/provider/web/statsig.go
@@ -415,7 +415,14 @@ func validStatsigID(value string) bool {
 	if err != nil {
 		decoded, err = base64.StdEncoding.DecodeString(value)
 	}
-	return err == nil && len(decoded) == 70
+	if err != nil {
+		return false
+	}
+	// Real statsig IDs are 70 bytes. The browser also sends a 72-byte
+	// "error-type" fallback (base64 of "x:TypeError: Cannot read
+	// properties of undefined (reading 'childNodes')") that xAI's
+	// anti-bot accepts. Accept both.
+	return len(decoded) == 70 || len(decoded) == 72
 }
 
 func (a *Adapter) applySignedStatsig(ctx context.Context, request *http.Request, token string, lease *infraegress.Lease) {

--- a/backend/internal/infra/provider/web/video.go
+++ b/backend/internal/infra/provider/web/video.go
@@ -270,6 +270,12 @@ func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoReque
 	if err != nil {
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoCreateFailureStage(err), 0, err)
 	}
+	// Free Web accounts reject videoLength > 6 with 429 "Too many requests"
+	// (verified: 6→200, 7/8/15→429). The gateway default duration is 8, so
+	// clamp to the upstream maximum instead of burning the retry loop.
+	if request.Duration > webVideoMaxSeconds {
+		request.Duration = webVideoMaxSeconds
+	}
 	segments := videoSegments(request.Duration)
 	if len(segments) == 0 {
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoStagePrepare, 0, fmt.Errorf("duration 必须在 1 到 15 秒之间"))
@@ -534,6 +540,10 @@ func nestedMap(value map[string]any, keys ...string) map[string]any {
 	}
 	return current
 }
+
+// webVideoMaxSeconds is the maximum videoLength accepted by grok.com Web
+// media generation on free accounts.
+const webVideoMaxSeconds = 6
 
 func videoSegments(seconds int) []int {
 	if seconds < 1 || seconds > 15 {


### PR DESCRIPTION
## Summary

Follow-up fixes for Web video generation (`/v1/videos/generations`, #948). Three independent upstream-facing issues stack on top of each other; with all three applied, video jobs complete end-to-end on free Web accounts (verified: jobs reach `completed`, mp4 assets land in the media store, zero 403/429 in logs).

## 1. `Accept-Encoding: gzip` for media POSTs

`tls-client` only auto-decompresses **gzip**. `buildHeaders` advertised `gzip, deflate, br, zstd`, so upstream could answer with brotli and the body reached `json.Unmarshal` still compressed — media post creation always failed with `创建媒体 Post 响应无效`. Restrict to `gzip` in `postJSONWithReferer`.

## 2. Accept the 72-byte error-type statsig fallback

`validStatsigID` required exactly 70 decoded bytes. Chrome also sends a 72-byte fallback ID (base64 of `x:TypeError: Cannot read properties of undefined (reading 'childNodes')`) which grok.com's anti-bot accepts, while signer-produced IDs are rejected with `403 Request rejected by anti-bot rules` on `/rest/app-chat/conversations/new`. Accepting 70 or 72 bytes lets users configure the known-good fallback as the manual statsig value.

## 3. Clamp duration to the 6s upstream maximum

Free Web accounts reject `videoLength > 6` with `429 Too many requests` (bisect: 5/6 → 200, 7/8/15 → 429). The gateway default duration is 8, so every default video request burned the whole account retry loop with 429s. `GenerateVideo` now clamps to `webVideoMaxSeconds = 6`.

## Testing

- `go build ./...`, `go vet`, package tests for `infra/config` and `infra/provider/web` pass.
- End-to-end on live grok.com: `POST /v1/videos/generations` with default and explicit durations → jobs complete, videos downloaded to the media store.
