### PR TITLE
fix: hold missing-thinking on TUI compact, tools, and pinned responses

### DIFF
--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -253,32 +253,22 @@ func CommitQualityHold(verdict QualityVerdict, qualityAttempt, maxAttempts int, 
 }
 
 func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwnership, route modeldomain.Route, operation audit.Operation, cfg QualityRetryRuntime) bool {
-	if !cfg.Enabled || !input.Streaming || input.ForcedEgressNodeID != 0 || ownership != nil || input.skipQualityHold {
+	if !cfg.Enabled || !input.Streaming || input.ForcedEgressNodeID != 0 || input.skipQualityHold {
 		return false
 	}
 	switch operation {
-	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, "":
+	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, audit.OperationCompaction, "":
 	default:
-		return false
-	}
-	// TUI compaction is a normal /v1/responses body (no compaction_trigger).
-	// Keep this defensive body check in addition to skipQualityHold so a caller
-	// that bypasses CreateResponse cannot withhold a 100s+ summary as missing-thinking.
-	if isResponsesCompactionRequest(input.Body) {
 		return false
 	}
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// Retrying a tool-capable request can repeat external side effects. Tool
-	// requests remain outside this feature until they have their own replay
-	// safety contract.
-	if qualityRequestUsesTools(input.Body) {
-		return false
-	}
-	// Aliases are rewritten before this gate, so inspect the effective request
-	// body instead of only the reasoning-capable base model. In particular,
-	// grok-4.3-none becomes grok-4.3 plus an explicit disabled setting.
+	// TUI tool rounds (function_call_output / role=tool) must still hold.
+	// Those turns are where missing-thinking shows up as HTTP 200 with
+	// high effort and 0 reasoning tokens. Local tools already ran;
+	// withhold/retry/unpin is safer than delivering a no-thinking
+	// continuation. Skip only when the request explicitly disables reasoning.
 	if qualityRequestDisablesReasoning(input.Body) {
 		return false
 	}
@@ -286,14 +276,6 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 		return true
 	}
 	return modeldomain.SupportsReasoningForProvider(route.Provider, route.UpstreamModel)
-}
-
-func qualityRequestUsesTools(body []byte) bool {
-	var payload map[string]json.RawMessage
-	if json.Unmarshal(body, &payload) != nil {
-		return false
-	}
-	return nonEmptyJSONCollection(payload["tools"]) || nonEmptyJSONCollection(payload["functions"])
 }
 
 func qualityRequestDisablesReasoning(body []byte) bool {

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -533,24 +533,24 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		t.Fatal("forced egress must not hold")
 	}
 	owned := inferencedomain.ResponseOwnership{ResponseID: "r1", AccountID: 1}
-	if shouldHoldQualityStream(input, &owned, route, audit.OperationChat, cfg) {
-		t.Fatal("pinned response must not hold")
+	if !shouldHoldQualityStream(input, &owned, route, audit.OperationChat, cfg) {
+		t.Fatal("pinned previous_response_id must still hold on missing thinking")
 	}
 	if shouldHoldQualityStream(input, nil, route, audit.OperationImage, cfg) {
 		t.Fatal("image must not hold")
 	}
-	if shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
-		t.Fatal("codex compaction operation must not hold")
+	if !shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
+		t.Fatal("compaction with no reasoning must hold")
 	}
 	classified := input
 	classified.skipQualityHold = true
 	if shouldHoldQualityStream(classified, nil, route, audit.OperationResponses, cfg) {
-		t.Fatal("gateway-classified compaction must not hold")
+		t.Fatal("explicit skipQualityHold must not hold")
 	}
 	tui := input
 	tui.Body = []byte(`{"input":[{"role":"user","content":"` + tuiCompactionPrompt + `"}]}`)
-	if shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
-		t.Fatal("tui compaction prompt must not hold even when tagged responses")
+	if !shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
+		t.Fatal("tui compaction prompt with no reasoning must hold")
 	}
 	for _, test := range []struct {
 		name string
@@ -560,14 +560,30 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		{name: "responses reasoning none", body: `{"reasoning":{"effort":"none"}}`},
 		{name: "messages thinking disabled", body: `{"thinking":{"type":"disabled"}}`},
 		{name: "messages zero thinking budget", body: `{"thinking":{"type":"enabled","budget_tokens":0}}`},
-		{name: "client tools", body: `{"tools":[{"type":"function","function":{"name":"charge"}}]}`},
-		{name: "legacy functions", body: `{"functions":[{"name":"charge"}]}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request := input
 			request.Body = []byte(test.body)
 			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
-				t.Fatal("explicitly disabled reasoning and tool requests must not be held")
+				t.Fatal("explicitly disabled reasoning must not be held")
+			}
+		})
+	}
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "client tools schema", body: `{"tools":[{"type":"function","function":{"name":"charge"}}]}`},
+		{name: "legacy functions schema", body: `{"functions":[{"name":"charge"}]}`},
+		{name: "function call output", body: `{"input":[{"type":"function_call_output","call_id":"c1","output":"ok"}]}`},
+		{name: "tool role", body: `{"messages":[{"role":"tool","content":"ok"}]}`},
+		{name: "history tools plus new user", body: `{"input":[{"type":"function_call","call_id":"c1","name":"grep"},{"type":"function_call_output","call_id":"c1","output":"ok"},{"role":"user","content":"look at this"}]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := input
+			request.Body = []byte(test.body)
+			if !shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("declaring tools must not skip missing-thinking hold")
 			}
 		})
 	}

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -111,7 +111,8 @@ type Input struct {
 	// auditOperation may classify a normal protocol request differently for
 	// operator visibility without changing routing or Provider semantics.
 	auditOperation audit.Operation
-	// skipQualityHold is set only by trusted gateway-side request classifiers.
+	// skipQualityHold is a generic escape hatch. TUI compaction must not set it:
+	// a compact turn with no reasoning is missing-thinking and should rotate.
 	skipQualityHold bool
 	// ForcedEgressNodeID is an internal-only administrator probe constraint.
 	// Public inference handlers never populate it.
@@ -502,11 +503,10 @@ func (s *Service) CreateResponse(ctx context.Context, input Input) (*Result, err
 	case responsesCompactionTrigger:
 		input.Operation = audit.OperationCompaction
 	case responsesCompactionTUI:
-		// Grok TUI compaction is still a normal Responses request. Keep its
-		// routing, Provider normalization, and stored-response behavior intact;
-		// only its audit classification and quality-hold policy differ.
+		// Grok TUI compaction stays a normal Responses request on the wire.
+		// Audit it as compaction, but do not skip missing-thinking hold:
+		// a high-effort summary with 0 reasoning tokens must rotate.
 		input.auditOperation = audit.OperationCompaction
-		input.skipQualityHold = true
 	}
 	return s.createResponseAt(ctx, input, "/responses")
 }
@@ -1003,9 +1003,6 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	}
 	attemptPolicy := newRoutingAttemptPolicy(int(s.maxAttempts.Load()))
 	idempotencyID, _ := security.NewOpaqueToken(18)
-	if ownership != nil {
-		attemptPolicy = newRoutingAttemptPolicy(1)
-	}
 	pricingModel := s.providers.PricingModel(route.Provider, route.UpstreamModel)
 	if err := s.checkLedgerReady(); err != nil {
 		return nil, err
@@ -1020,6 +1017,9 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	authRecoveryAttempted := make(map[uint64]bool)
 	holdCfg := s.qualityRetryConfig()
 	qualityHoldEnabled := shouldHoldQualityStream(input, ownership, route, operation, holdCfg)
+	if ownership != nil && !qualityHoldEnabled {
+		attemptPolicy = newRoutingAttemptPolicy(1)
+	}
 	// Count accounts that actually reached the upstream. Credential-only skips
 	// do not consume the quality retry budget; refreshes stay on the same account.
 	qualityAccountAttempts := 0
@@ -1197,7 +1197,7 @@ attemptLoop:
 		var lease *accountLease
 		var err error
 		selectionStarted := time.Now()
-		if ownership != nil {
+		if ownership != nil && qualityAccountAttempts == 0 {
 			lease, err = s.selector.AcquirePinnedForKey(ctx, route.Provider, ownership.AccountID, route.ID, route.UpstreamModel, quotaMode, true, accountScope)
 		} else if input.ForcedEgressNodeID != 0 {
 			lease, err = s.selector.AcquireForKeyOnEgressNode(ctx, route.Provider, route.ID, route.UpstreamModel, quotaMode, affinityKey, excluded, !quotaProbeAttempted, accountScope, input.ForcedEgressNodeID)
@@ -1549,8 +1549,12 @@ attemptLoop:
 					continue
 				}
 				response.Body = replay
-				hasNextAccount := attemptPolicy.hasNext(attempt) && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
-				hasNextAccount = hasNextAccount && qualityAccountAttempts < holdCfg.MaxAttempts
+				hasNextAccount := attemptPolicy.hasNext(attempt) && qualityAccountAttempts < holdCfg.MaxAttempts
+				if selection != nil {
+					hasNextAccount = hasNextAccount && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
+				} else if ownership == nil {
+					hasNextAccount = false
+				}
 				commit := CommitQualityHold(verdict, qualityAccountAttempts-1, holdCfg.MaxAttempts, hasNextAccount, holdCfg.OnExhausted)
 				if verdict == QualityWithhold {
 					s.applyMissingThinkingPenalty(ctx, input.RequestID, credential, holdCfg.AccountCooldown)

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -273,9 +273,8 @@ func TestGatewayFailsOverBeforeReturningBody(t *testing.T) {
 		t.Fatalf("compaction response ownership err = %v", err)
 	}
 
-	// Grok TUI compaction is a normal Responses request on the wire. It skips
-	// the quality hold and is labeled compaction only in the audit record, so
-	// Provider routing and stored-response ownership must remain intact.
+	// Grok TUI compaction is a normal Responses request on the wire.
+	// Missing-thinking hold still applies; routing and ownership stay Responses.
 	service.UpdateQualityRetry(QualityRetryRuntime{
 		Enabled: true, MaxAttempts: 2, MinOutputTokens: 32,
 		OnExhausted: qualityRetryFailClosed, HoldTimeout: time.Second,


### PR DESCRIPTION
## Summary
- Grok TUI agent turns almost always declare a `tools` schema and pin `previous_response_id`. Official v3.1.4 skips the request-path quality hold in both cases (`qualityRequestUsesTools`, `ownership != nil` plus `attemptPolicy=1`), so missing-thinking streams are forwarded as HTTP 200 with `reasoning_effort=high` and 0 reasoning tokens.
- TUI compaction is still a normal `/v1/responses` body (no `compaction_trigger`). #967 kept that routing, but also set `skipQualityHold`. A high-effort compact with no reasoning is missing-thinking and should rotate.
- Hold on chat / responses / messages / compaction unless reasoning is explicitly disabled. First attempt stays pinned; if the stream is withheld, unpin and try another account. `fail_closed` still rejects after `maxAttempts`.

This revisits the skip from #967: keep Responses routing for TUI compact, drop the hold skip.

## Why
Lab audits showed TUI tool loops and compact turns as green 200 with 推理·高 / 0 reasoning and no `quality_degraded` log. After this change the same turns audit as `200 · error` (withheld) then `503 quality_degraded` when the pool is exhausted.

Do **not** inject `compaction_trigger`. That path still rewrites the body into a Codex remote-v2 blob.

## Test plan
- [x] `go test ./internal/application/gateway/`
- [x] `TestShouldHoldQualityStreamGates`: compact, tools schema, `function_call_output`, pinned ownership, TUI compact prompt all hold; `reasoning none` still skips
- [x] Lab: withheld 0-thinking retries (`quality_degraded_retry` / cooldown) then `quality_degraded_rejected` at fail_closed