### PR TITLE
fix: fill required output_text.annotations for Grok CLI serde

### DIFF
--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -1166,6 +1166,26 @@ func TestSanitizeResponsesDoesNotAddResponseIDToErrorEvent(t *testing.T) {
 	}
 }
 
+func TestSanitizeResponsesFillsMissingOutputTextAnnotations(t *testing.T) {
+	state := &responsesCompatState{}
+	added := rewriteResponsesDataLine([]byte(`data: {"type":"response.output_item.added","item":{"type":"message","content":[{"type":"output_text","text":"hi"}]}}`+"\n"), state)
+	if !bytes.Contains(added, []byte(`"annotations":[]`)) {
+		t.Fatalf("item output_text missing annotations: %s", added)
+	}
+	completed := rewriteResponsesDataLine([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}]}}`+"\n"), state)
+	if !bytes.Contains(completed, []byte(`"annotations":[]`)) {
+		t.Fatalf("completed output_text missing annotations: %s", completed)
+	}
+	part := rewriteResponsesDataLine([]byte(`data: {"type":"response.content_part.added","part":{"type":"output_text","text":"hi"}}`+"\n"), state)
+	if !bytes.Contains(part, []byte(`"annotations":[]`)) {
+		t.Fatalf("content_part output_text missing annotations: %s", part)
+	}
+	kept := rewriteResponsesDataLine([]byte(`data: {"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"hi","annotations":[{"type":"url_citation","url":"https://x.test"}]}]}}`+"\n"), state)
+	if !bytes.Contains(kept, []byte(`"url":"https://x.test"`)) || bytes.Contains(kept, []byte(`"annotations":[]`)) {
+		t.Fatalf("existing annotations were replaced: %s", kept)
+	}
+}
+
 func TestResponsesCompatBoundsUnterminatedLineBuffer(t *testing.T) {
 	state := &responsesCompatState{}
 	chunk := bytes.Repeat([]byte{'x'}, maxStreamEventInspectionBytes+1)

--- a/backend/internal/transport/http/inference/responses_compat.go
+++ b/backend/internal/transport/http/inference/responses_compat.go
@@ -221,6 +221,35 @@ func sanitizeResponsesEvent(event map[string]any, state *responsesCompatState) b
 			}
 		}
 	}
+	if ensureOutputTextAnnotations(event) {
+		changed = true
+	}
+	return changed
+}
+
+// Grok CLI serde requires output_text.annotations even when there are no
+// citations. Missing the field makes a retry fail with
+// "serialization error: missing field `annotations`".
+func ensureOutputTextAnnotations(node any) bool {
+	changed := false
+	switch typed := node.(type) {
+	case map[string]any:
+		if stringAny(typed["type"]) == "output_text" && typed["annotations"] == nil {
+			typed["annotations"] = []any{}
+			changed = true
+		}
+		for _, key := range []string{"item", "part", "response", "content", "output", "delta"} {
+			if ensureOutputTextAnnotations(typed[key]) {
+				changed = true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if ensureOutputTextAnnotations(child) {
+				changed = true
+			}
+		}
+	}
 	return changed
 }
 


### PR DESCRIPTION
## Summary
- Grok CLI serde requires `output_text.annotations` even when there are no citations.
- A missing field fails with `serialization error: missing field \`annotations\`` and the TUI retries the turn.
- Fill `annotations: []` on `output_text` nodes in Responses SSE. Leave existing citation arrays untouched.

## Why
Independent of the quality hold. This is the same class of CLI required-field fill as the response/item id patches in v3.1.4.

## Test plan
- [x] `go test ./internal/transport/http/inference/`
- [x] `output_item.added`, `response.completed`, and `content_part.added` get `annotations: []`
- [x] Existing `url_citation` arrays are not replaced