### PR TITLE
fix: hold TUI tool-schema and after-tool agent turns

### DIFF
--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -270,13 +270,11 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// Retrying an in-flight tool *result* can repeat external side effects.
-	// Grok TUI always declares a tools schema even on the first thinking
-	// turn; skipping that schema would disable the hold for every agent
-	// request. Only skip when the body already contains tool output.
-	if qualityRequestHasInFlightToolResults(input.Body) {
-		return false
-	}
+	// Grok TUI always declares a tools schema, and after local tools run the
+	// next /v1/responses body already contains function_call_output. Retrying
+	// that body on another account does not re-execute TUI tools — it only
+	// regenerates the model turn. Skipping hold here let 0-thinking dumps
+	// through on the common agent loop. Keep holding.
 	// Aliases are rewritten before this gate, so inspect the effective request
 	// body instead of only the reasoning-capable base model. In particular,
 	// grok-4.3-none becomes grok-4.3 plus an explicit disabled setting.
@@ -287,10 +285,6 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 		return true
 	}
 	return modeldomain.SupportsReasoningForProvider(route.Provider, route.UpstreamModel)
-}
-
-func qualityRequestUsesTools(body []byte) bool {
-	return qualityRequestHasInFlightToolResults(body)
 }
 
 func qualityRequestHasInFlightToolResults(body []byte) bool {

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -270,11 +270,14 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// Grok TUI always declares a tools schema, and after local tools run the
-	// next /v1/responses body already contains function_call_output. Retrying
-	// that body on another account does not re-execute TUI tools — it only
-	// regenerates the model turn. Skipping hold here let 0-thinking dumps
-	// through on the common agent loop. Keep holding.
+	// Client-executed tools are safe to hold: their calls have not reached the
+	// client yet, and completed results in the next request are immutable input.
+	// Hosted tools are different. Retrying them can repeat an upstream search,
+	// sandbox run, image job, or remote MCP call, so retain the old no-replay
+	// safety boundary for any request that declares one.
+	if qualityRequestHasReplayUnsafeHostedTools(input.Body) {
+		return false
+	}
 	// Aliases are rewritten before this gate, so inspect the effective request
 	// body instead of only the reasoning-capable base model. In particular,
 	// grok-4.3-none becomes grok-4.3 plus an explicit disabled setting.
@@ -287,32 +290,68 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 	return modeldomain.SupportsReasoningForProvider(route.Provider, route.UpstreamModel)
 }
 
-func qualityRequestHasInFlightToolResults(body []byte) bool {
-	var payload any
-	if json.Unmarshal(body, &payload) != nil {
+func qualityRequestHasReplayUnsafeHostedTools(body []byte) bool {
+	var payload map[string]any
+	if json.Unmarshal(body, &payload) != nil || payload == nil {
 		return false
 	}
-	return jsonTreeHasInFlightToolResult(payload)
-}
-
-func jsonTreeHasInFlightToolResult(node any) bool {
-	switch typed := node.(type) {
-	case map[string]any:
-		role := jsonNodeString(typed["role"])
-		typ := jsonNodeString(typed["type"])
-		if role == "tool" || typ == "function_call_output" || typ == "tool_result" || typ == "tool_use_output" {
+	if raw, exists := payload["web_search_options"]; exists && raw != nil {
+		return true
+	}
+	if raw, exists := payload["mcp_servers"]; exists && raw != nil {
+		servers, ok := raw.([]any)
+		if !ok || len(servers) > 0 {
 			return true
 		}
-		for _, child := range typed {
-			if jsonTreeHasInFlightToolResult(child) {
-				return true
-			}
+	}
+	if qualityToolListHasReplayUnsafeHostedTool(payload["tools"]) {
+		return true
+	}
+	// Responses Tool Search can load declarations later in the request. Only
+	// inspect additional_tools items; arbitrary user/schema objects may also
+	// contain a field named "tools" and must not affect the retry policy.
+	items, _ := payload["input"].([]any)
+	for _, rawItem := range items {
+		item, ok := rawItem.(map[string]any)
+		if !ok || jsonNodeString(item["type"]) != "additional_tools" {
+			continue
 		}
-	case []any:
-		for _, child := range typed {
-			if jsonTreeHasInFlightToolResult(child) {
+		if qualityToolListHasReplayUnsafeHostedTool(item["tools"]) {
+			return true
+		}
+	}
+	return false
+}
+
+func qualityToolListHasReplayUnsafeHostedTool(value any) bool {
+	tools, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind := jsonNodeString(tool["type"])
+		switch kind {
+		case "", "function", "custom", "local_shell", "apply_patch", "tool_search":
+			// These declarations only ask the model to return a call. Execution
+			// happens in the client after the held response is committed.
+			continue
+		case "shell":
+			environment, _ := tool["environment"].(map[string]any)
+			if jsonNodeString(environment["type"]) != "local" {
 				return true
 			}
+		case "namespace":
+			if qualityToolListHasReplayUnsafeHostedTool(tool["tools"]) {
+				return true
+			}
+		default:
+			// Default to no replay for every server/native tool, including types
+			// added by future protocol versions that this gateway does not know yet.
+			return true
 		}
 	}
 	return false
@@ -345,14 +384,6 @@ func qualityRequestDisablesReasoning(body []byte) bool {
 		}
 	}
 	return jsonStringEquals(payload["thinking"], "disabled")
-}
-
-func nonEmptyJSONCollection(raw json.RawMessage) bool {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed == "null" || trimmed == "[]" || trimmed == "{}" {
-		return false
-	}
-	return strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{")
 }
 
 func jsonStringEquals(raw json.RawMessage, want string) bool {

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -270,10 +270,11 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// Retrying a tool-capable request can repeat external side effects. Tool
-	// requests remain outside this feature until they have their own replay
-	// safety contract.
-	if qualityRequestUsesTools(input.Body) {
+	// Retrying an in-flight tool *result* can repeat external side effects.
+	// Grok TUI always declares a tools schema even on the first thinking
+	// turn; skipping that schema would disable the hold for every agent
+	// request. Only skip when the body already contains tool output.
+	if qualityRequestHasInFlightToolResults(input.Body) {
 		return false
 	}
 	// Aliases are rewritten before this gate, so inspect the effective request
@@ -289,11 +290,43 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 }
 
 func qualityRequestUsesTools(body []byte) bool {
-	var payload map[string]json.RawMessage
+	return qualityRequestHasInFlightToolResults(body)
+}
+
+func qualityRequestHasInFlightToolResults(body []byte) bool {
+	var payload any
 	if json.Unmarshal(body, &payload) != nil {
 		return false
 	}
-	return nonEmptyJSONCollection(payload["tools"]) || nonEmptyJSONCollection(payload["functions"])
+	return jsonTreeHasInFlightToolResult(payload)
+}
+
+func jsonTreeHasInFlightToolResult(node any) bool {
+	switch typed := node.(type) {
+	case map[string]any:
+		role := jsonNodeString(typed["role"])
+		typ := jsonNodeString(typed["type"])
+		if role == "tool" || typ == "function_call_output" || typ == "tool_result" || typ == "tool_use_output" {
+			return true
+		}
+		for _, child := range typed {
+			if jsonTreeHasInFlightToolResult(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if jsonTreeHasInFlightToolResult(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func jsonNodeString(value any) string {
+	text, _ := value.(string)
+	return strings.ToLower(strings.TrimSpace(text))
 }
 
 func qualityRequestDisablesReasoning(body []byte) bool {

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -596,8 +596,11 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			request := input
 			request.Body = []byte(test.body)
-			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
-				t.Fatal("in-flight tool results must not be held")
+			if !qualityRequestHasInFlightToolResults(request.Body) {
+				t.Fatal("fixture must still be detected as tool output")
+			}
+			if !shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("in-flight tool results must still be held so 0-thinking agent turns are classified")
 			}
 		})
 	}

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -576,6 +576,10 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		{name: "client tools schema", body: `{"tools":[{"type":"function","function":{"name":"charge"}}]}`},
 		{name: "legacy functions schema", body: `{"functions":[{"name":"charge"}]}`},
 		{name: "tui tools schema plus user input", body: `{"model":"grok-4.6","tools":[{"type":"function","name":"read_file"}],"input":[{"role":"user","content":"hello"}]}`},
+		{name: "local shell declaration", body: `{"tools":[{"type":"local_shell"}]}`},
+		{name: "local environment shell declaration", body: `{"tools":[{"type":"shell","environment":{"type":"local"}}]}`},
+		{name: "apply patch declaration", body: `{"tools":[{"type":"apply_patch"}]}`},
+		{name: "client namespace", body: `{"tools":[{"type":"namespace","name":"local","tools":[{"type":"function","name":"read_file"}]}]}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request := input
@@ -596,13 +600,53 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			request := input
 			request.Body = []byte(test.body)
-			if !qualityRequestHasInFlightToolResults(request.Body) {
-				t.Fatal("fixture must still be detected as tool output")
-			}
 			if !shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
 				t.Fatal("in-flight tool results must still be held so 0-thinking agent turns are classified")
 			}
 		})
+	}
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "responses web search", body: `{"tools":[{"type":"web_search"}]}`},
+		{name: "versioned web search", body: `{"tools":[{"type":"web_search_2025_08_26"}]}`},
+		{name: "x search", body: `{"tools":[{"type":"x_search"}]}`},
+		{name: "image generation", body: `{"tools":[{"type":"image_generation"}]}`},
+		{name: "file search", body: `{"tools":[{"type":"file_search"}]}`},
+		{name: "collections search", body: `{"tools":[{"type":"collections_search"}]}`},
+		{name: "code execution", body: `{"tools":[{"type":"code_execution"}]}`},
+		{name: "code interpreter", body: `{"tools":[{"type":"code_interpreter"}]}`},
+		{name: "hosted shell", body: `{"tools":[{"type":"shell","environment":{"type":"container_auto"}}]}`},
+		{name: "future native tool skips replay", body: `{"tools":[{"type":"future_server_tool"}]}`},
+		{name: "remote mcp", body: `{"tools":[{"type":"mcp","server_url":"https://example.com"}]}`},
+		{name: "mixed client and hosted", body: `{"tools":[{"type":"function","name":"read_file"},{"type":"web_search"}]}`},
+		{name: "chat web search options", body: `{"web_search_options":{}}`},
+		{name: "messages web search", body: `{"tools":[{"type":"web_search_20250305","name":"web_search"}]}`},
+		{name: "messages mcp servers", body: `{"mcp_servers":[{"type":"url","url":"https://example.com"}]}`},
+		{name: "deferred hosted tool", body: `{"input":[{"type":"additional_tools","tools":[{"type":"mcp","server_url":"https://example.com"}]}]}`},
+		{name: "nested hosted tool", body: `{"tools":[{"type":"namespace","name":"remote","tools":[{"type":"web_search"}]}]}`},
+		{name: "after local tool with hosted declaration", body: `{"tools":[{"type":"web_search"}],"input":[{"type":"function_call_output","call_id":"call_1","output":"done"}]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := input
+			request.Body = []byte(test.body)
+			if !qualityRequestHasReplayUnsafeHostedTools(request.Body) {
+				t.Fatal("fixture must be classified as replay-unsafe hosted tooling")
+			}
+			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("hosted tools must not be held because account retry can execute them again")
+			}
+		})
+	}
+	for _, body := range []string{
+		`{"tools":[{"type":"function","name":"read_file","parameters":{"type":"object","properties":{"tools":{"type":"array"}}}}]}`,
+		`{"mcp_servers":[]}`,
+		`{"web_search_options":null}`,
+	} {
+		if qualityRequestHasReplayUnsafeHostedTools([]byte(body)) {
+			t.Fatalf("safe or empty tool metadata classified as hosted: %s", body)
+		}
 	}
 	toolCache := input
 	toolCache.Body = []byte(`{"messages":[{"role":"user","content":"hello"}]}`)

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -560,14 +560,44 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		{name: "responses reasoning none", body: `{"reasoning":{"effort":"none"}}`},
 		{name: "messages thinking disabled", body: `{"thinking":{"type":"disabled"}}`},
 		{name: "messages zero thinking budget", body: `{"thinking":{"type":"enabled","budget_tokens":0}}`},
-		{name: "client tools", body: `{"tools":[{"type":"function","function":{"name":"charge"}}]}`},
-		{name: "legacy functions", body: `{"functions":[{"name":"charge"}]}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			request := input
 			request.Body = []byte(test.body)
 			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
-				t.Fatal("explicitly disabled reasoning and tool requests must not be held")
+				t.Fatal("explicitly disabled reasoning must not be held")
+			}
+		})
+	}
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "client tools schema", body: `{"tools":[{"type":"function","function":{"name":"charge"}}]}`},
+		{name: "legacy functions schema", body: `{"functions":[{"name":"charge"}]}`},
+		{name: "tui tools schema plus user input", body: `{"model":"grok-4.6","tools":[{"type":"function","name":"read_file"}],"input":[{"role":"user","content":"hello"}]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := input
+			request.Body = []byte(test.body)
+			if !shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("tools schema alone must still hold so TUI thinking turns are classified")
+			}
+		})
+	}
+	for _, test := range []struct {
+		name string
+		body string
+	}{
+		{name: "function_call_output", body: `{"input":[{"type":"function_call_output","call_id":"call_1","output":"done"}]}`},
+		{name: "tool_result", body: `{"input":[{"type":"tool_result","tool_use_id":"tool_1","content":"done"}]}`},
+		{name: "role tool", body: `{"messages":[{"role":"tool","content":"done"}]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := input
+			request.Body = []byte(test.body)
+			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("in-flight tool results must not be held")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Grok TUI declares a `tools` array on **every** agent request, including the first thinking turn.
- Official `qualityRequestUsesTools` skipped the request-path hold whenever that schema was present, so missing-thinking TUI turns were forwarded as HTTP 200.
- After local tools run, the next `/v1/responses` body already contains `function_call_output`. Retrying that body on another account does **not** re-execute TUI tools — it only regenerates the model turn. Skipping hold there still let 0-thinking dumps through on the common agent loop.
- Hold both the tools/functions schema **and** in-flight tool results (`function_call_output`, `tool_result`, `role=tool`).

## Why
The schema skip was meant to avoid replaying external side effects. TUI tools already ran locally, so that risk does not apply. The hold is what stops degraded 0-thinking turns from fail-opening as HTTP 200.

This does **not** reopen #974:
- TUI compact still sets `skipQualityHold`
- `previous_response_id` ownership pinning is unchanged
- `reasoning none` still skips

## Test plan
- [x] `go test ./internal/application/gateway/ -run ShouldHoldQualityStreamGates`
- [x] `tools` / `functions` schema holds
- [x] `function_call_output`, `tool_result`, and `role=tool` still hold
- [x] Compact / pinned ownership / reasoning-none skips stay