### PR TITLE
fix: retry empty completed streams instead of waiting for idle

### DIFF
--- a/backend/internal/application/gateway/quality_retry_scan.go
+++ b/backend/internal/application/gateway/quality_retry_scan.go
@@ -25,6 +25,8 @@ type qualityScanState struct {
 	pending         []byte
 	hasThinking     bool
 	visibleRunes    int
+	aggregateRunes  int
+	semanticOutput  bool
 	reasoningTokens int64
 	outputTokens    int64
 	usage           Usage
@@ -124,7 +126,8 @@ func qualityProtocolForOperation(operation audit.Operation) string {
 }
 
 func (s *qualityScanState) signals() QualityStreamSignals {
-	visible := int64((s.visibleRunes + 3) / 4)
+	visibleRunes := max(s.visibleRunes, s.aggregateRunes)
+	visible := int64((visibleRunes + 3) / 4)
 	if s.usage.Reported {
 		fromUsage := s.usage.OutputTokens - s.usage.ReasoningTokens
 		if fromUsage > visible {
@@ -201,6 +204,8 @@ func observeQualityChat(state *qualityScanState, payload []byte) {
 				Reasoning        string `json:"reasoning"`
 				ReasoningContent string `json:"reasoning_content"`
 				ThinkingContent  string `json:"thinking_content"`
+				ToolCalls        []any  `json:"tool_calls"`
+				FunctionCall     any    `json:"function_call"`
 			} `json:"delta"`
 			FinishReason string `json:"finish_reason"`
 		} `json:"choices"`
@@ -240,24 +245,35 @@ func observeQualityChat(state *qualityScanState, payload []byte) {
 		if delta.Content != "" {
 			noteVisibleContent(state, delta.Content)
 		}
+		if len(delta.ToolCalls) > 0 || delta.FunctionCall != nil {
+			state.semanticOutput = true
+		}
 		if choice.FinishReason != "" {
 			state.terminal = true
 		}
 	}
 }
 
+type qualityResponsesOutputItem struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Content []struct {
+		Type    string `json:"type"`
+		Text    string `json:"text"`
+		Refusal string `json:"refusal"`
+	} `json:"content"`
+}
+
 func observeQualityResponses(state *qualityScanState, payload []byte) {
 	var event struct {
-		Type  string `json:"type"`
-		Delta string `json:"delta"`
-		Item  struct {
-			ID   string `json:"id"`
-			Type string `json:"type"`
-		} `json:"item"`
+		Type     string                     `json:"type"`
+		Delta    string                     `json:"delta"`
+		Item     qualityResponsesOutputItem `json:"item"`
 		Response *struct {
-			ID    string `json:"id"`
-			Model string `json:"model"`
-			Usage *struct {
+			ID     string                       `json:"id"`
+			Model  string                       `json:"model"`
+			Output []qualityResponsesOutputItem `json:"output"`
+			Usage  *struct {
 				OutputTokens        int64 `json:"output_tokens"`
 				InputTokens         int64 `json:"input_tokens"`
 				TotalTokens         int64 `json:"total_tokens"`
@@ -281,9 +297,16 @@ func observeQualityResponses(state *qualityScanState, payload []byte) {
 		if event.Item.Type == "reasoning" && event.Item.ID != "" {
 			state.hasThinking = true
 		}
+		state.aggregateRunes = max(state.aggregateRunes, observeQualityResponsesOutputItem(state, event.Item))
+	case "response.output_item.done":
+		state.aggregateRunes = max(state.aggregateRunes, observeQualityResponsesOutputItem(state, event.Item))
 	case "response.output_text.delta":
 		if event.Delta != "" {
 			noteVisibleContent(state, event.Delta)
+		}
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta", "response.mcp_call_arguments.delta":
+		if event.Delta != "" {
+			state.semanticOutput = true
 		}
 	}
 	if event.Response != nil {
@@ -303,7 +326,43 @@ func observeQualityResponses(state *qualityScanState, payload []byte) {
 				state.hasThinking = true
 			}
 		}
+		aggregateRunes := 0
+		for _, item := range event.Response.Output {
+			aggregateRunes += observeQualityResponsesOutputItem(state, item)
+		}
+		state.aggregateRunes = max(state.aggregateRunes, aggregateRunes)
 	}
+}
+
+func observeQualityResponsesOutputItem(state *qualityScanState, item qualityResponsesOutputItem) int {
+	if state == nil {
+		return 0
+	}
+	visibleRunes := 0
+	switch item.Type {
+	case "", "reasoning":
+		return 0
+	case "message":
+		for _, content := range item.Content {
+			text := content.Text
+			if text == "" {
+				text = content.Refusal
+			}
+			if text != "" {
+				visibleRunes += utf8.RuneCountInString(text)
+				state.semanticOutput = true
+				continue
+			}
+			if content.Type != "" && content.Type != "output_text" && content.Type != "refusal" {
+				state.semanticOutput = true
+			}
+		}
+	default:
+		// Function, shell, MCP and other call items are meaningful output even
+		// when the provider omits usage and argument-delta events.
+		state.semanticOutput = true
+	}
+	return visibleRunes
 }
 
 func observeQualityAnthropic(state *qualityScanState, payload []byte) {
@@ -311,11 +370,13 @@ func observeQualityAnthropic(state *qualityScanState, payload []byte) {
 		Type         string `json:"type"`
 		ContentBlock struct {
 			Type string `json:"type"`
+			Text string `json:"text"`
 		} `json:"content_block"`
 		Delta struct {
-			Type     string `json:"type"`
-			Text     string `json:"text"`
-			Thinking string `json:"thinking"`
+			Type        string `json:"type"`
+			Text        string `json:"text"`
+			Thinking    string `json:"thinking"`
+			PartialJSON string `json:"partial_json"`
 		} `json:"delta"`
 		Usage *struct {
 			OutputTokens        int64 `json:"output_tokens"`
@@ -331,8 +392,17 @@ func observeQualityAnthropic(state *qualityScanState, payload []byte) {
 	case "message_stop":
 		state.terminal = true
 	case "content_block_start":
-		if event.ContentBlock.Type == "thinking" {
+		switch event.ContentBlock.Type {
+		case "thinking", "redacted_thinking":
 			state.hasThinking = true
+		case "text":
+			if event.ContentBlock.Text != "" {
+				noteVisibleContent(state, event.ContentBlock.Text)
+				state.semanticOutput = true
+			}
+		case "":
+		default:
+			state.semanticOutput = true
 		}
 	case "content_block_delta":
 		if event.Delta.Type == "thinking_delta" && event.Delta.Thinking != "" {
@@ -340,6 +410,9 @@ func observeQualityAnthropic(state *qualityScanState, payload []byte) {
 		}
 		if event.Delta.Type == "text_delta" && event.Delta.Text != "" {
 			noteVisibleContent(state, event.Delta.Text)
+		}
+		if event.Delta.Type == "input_json_delta" && event.Delta.PartialJSON != "" {
+			state.semanticOutput = true
 		}
 	}
 	if event.Usage != nil {
@@ -427,6 +500,9 @@ func finishQualityPeek(held *bytes.Buffer, pump *qualityReadPump, state *quality
 	state.terminal = true
 	signals := state.signals()
 	if !signals.HasThinking && signals.ReasoningTokens <= 0 && signals.OutputTokens <= 0 && signals.VisibleTokens <= 0 {
+		if state.semanticOutput {
+			return newPrefixReplay(held, pump), QualityDeliver, state.usage, state.responseID, nil
+		}
 		return newPrefixReplay(held, pump), QualityWait, state.usage, state.responseID, errQualityEmptyStream
 	}
 	return newPrefixReplay(held, pump), ClassifyQualityHold(signals, cfg.MinOutputTokens), state.usage, state.responseID, nil

--- a/backend/internal/application/gateway/quality_retry_scan.go
+++ b/backend/internal/application/gateway/quality_retry_scan.go
@@ -376,6 +376,12 @@ func peekQualityStream(ctx context.Context, body io.ReadCloser, protocol string,
 		if verdict := ClassifyQualityHold(sig, cfg.MinOutputTokens); verdict != QualityWait {
 			return newPrefixReplay(&held, pump), verdict, state.usage, state.responseID, nil
 		}
+		// A completed empty stream must rotate immediately. Waiting for idle
+		// timeout after response.completed / [DONE] surfaces HTTP 200 with 0
+		// tokens and makes Grok TUI retry for 50–120s.
+		if sig.Terminal {
+			return finishQualityPeek(&held, pump, &state, cfg)
+		}
 
 		select {
 		case <-ctx.Done():

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -461,6 +461,48 @@ func TestPeekQualityStreamHoldTimeoutEmptyDoesNotFailOpen(t *testing.T) {
 	}
 }
 
+func TestPeekQualityStreamEmptyCompletedRetriesWithoutIdle(t *testing.T) {
+	t.Parallel()
+	started := time.Now()
+	replay, verdict, _, _, err := peekQualityStream(
+		context.Background(),
+		io.NopCloser(strings.NewReader(sse(
+			`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":0}}}`,
+		))),
+		qualityProtocolResponses,
+		QualityRetryRuntime{MinOutputTokens: 32, HoldTimeout: 2 * time.Second},
+	)
+	if replay != nil {
+		defer replay.Close()
+	}
+	if !errors.Is(err, errQualityEmptyStream) {
+		t.Fatalf("peek error = %v, want empty stream", err)
+	}
+	if verdict != QualityWait {
+		t.Fatalf("verdict = %s, want wait so the attempt loop retries as transport", verdict)
+	}
+	if time.Since(started) > 500*time.Millisecond {
+		t.Fatalf("empty completed stream waited %s, want immediate retry", time.Since(started))
+	}
+
+	started = time.Now()
+	replay, verdict, _, _, err = peekQualityStream(
+		context.Background(),
+		io.NopCloser(strings.NewReader(sse("data: [DONE]"))),
+		qualityProtocolChat,
+		QualityRetryRuntime{MinOutputTokens: 32, HoldTimeout: 2 * time.Second},
+	)
+	if replay != nil {
+		defer replay.Close()
+	}
+	if !errors.Is(err, errQualityEmptyStream) {
+		t.Fatalf("chat empty [DONE] peek error = %v, want empty stream", err)
+	}
+	if time.Since(started) > 500*time.Millisecond {
+		t.Fatalf("empty chat [DONE] waited %s, want immediate retry", time.Since(started))
+	}
+}
+
 func TestPeekQualityStreamEmptyEOFRequestsAnotherAccount(t *testing.T) {
 	t.Parallel()
 	replay, verdict, _, _, err := peekQualityStream(

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -461,45 +461,160 @@ func TestPeekQualityStreamHoldTimeoutEmptyDoesNotFailOpen(t *testing.T) {
 	}
 }
 
+type qualityOpenPeekResult struct {
+	replay  io.ReadCloser
+	verdict QualityVerdict
+	err     error
+}
+
+func peekOpenQualityStreamForTest(t *testing.T, protocol, stream string) qualityOpenPeekResult {
+	t.Helper()
+	reader, writer := io.Pipe()
+	done := make(chan qualityOpenPeekResult, 1)
+	go func() {
+		replay, verdict, _, _, err := peekQualityStream(
+			context.Background(), reader, protocol,
+			QualityRetryRuntime{MinOutputTokens: 32, HoldTimeout: 2 * time.Second},
+		)
+		done <- qualityOpenPeekResult{replay: replay, verdict: verdict, err: err}
+	}()
+	if _, err := io.WriteString(writer, stream); err != nil {
+		_ = writer.Close()
+		t.Fatal(err)
+	}
+	select {
+	case result := <-done:
+		_ = writer.Close()
+		return result
+	case <-time.After(500 * time.Millisecond):
+		_ = writer.CloseWithError(errors.New("test terminal stream timeout"))
+		result := <-done
+		if result.replay != nil {
+			_ = result.replay.Close()
+		}
+		t.Fatal("terminal stream waited for hold/idle instead of finishing while the connection remained open")
+		return qualityOpenPeekResult{}
+	}
+}
+
 func TestPeekQualityStreamEmptyCompletedRetriesWithoutIdle(t *testing.T) {
 	t.Parallel()
-	started := time.Now()
-	replay, verdict, _, _, err := peekQualityStream(
-		context.Background(),
-		io.NopCloser(strings.NewReader(sse(
-			`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":0}}}`,
-		))),
-		qualityProtocolResponses,
-		QualityRetryRuntime{MinOutputTokens: 32, HoldTimeout: 2 * time.Second},
-	)
-	if replay != nil {
-		defer replay.Close()
+	for _, test := range []struct {
+		name     string
+		protocol string
+		stream   string
+	}{
+		{
+			name:     "responses completed",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":0}}}`,
+			),
+		},
+		{
+			name:     "responses completed with empty text node",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":""}]}],"usage":{"output_tokens":0}}}`,
+			),
+		},
+		{name: "chat done", protocol: qualityProtocolChat, stream: sse("data: [DONE]")},
+		{
+			name:     "chat finish reason",
+			protocol: qualityProtocolChat,
+			stream:   sse(`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`),
+		},
+		{name: "anthropic message stop", protocol: qualityProtocolAnthropic, stream: sse(`data: {"type":"message_stop"}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := peekOpenQualityStreamForTest(t, test.protocol, test.stream)
+			if result.replay != nil {
+				defer result.replay.Close()
+			}
+			if !errors.Is(result.err, errQualityEmptyStream) {
+				t.Fatalf("peek error = %v, want empty stream", result.err)
+			}
+			if result.verdict != QualityWait {
+				t.Fatalf("verdict = %s, want wait so the attempt loop retries as transport", result.verdict)
+			}
+		})
 	}
-	if !errors.Is(err, errQualityEmptyStream) {
-		t.Fatalf("peek error = %v, want empty stream", err)
-	}
-	if verdict != QualityWait {
-		t.Fatalf("verdict = %s, want wait so the attempt loop retries as transport", verdict)
-	}
-	if time.Since(started) > 500*time.Millisecond {
-		t.Fatalf("empty completed stream waited %s, want immediate retry", time.Since(started))
-	}
+}
 
-	started = time.Now()
-	replay, verdict, _, _, err = peekQualityStream(
-		context.Background(),
-		io.NopCloser(strings.NewReader(sse("data: [DONE]"))),
-		qualityProtocolChat,
-		QualityRetryRuntime{MinOutputTokens: 32, HoldTimeout: 2 * time.Second},
-	)
-	if replay != nil {
-		defer replay.Close()
-	}
-	if !errors.Is(err, errQualityEmptyStream) {
-		t.Fatalf("chat empty [DONE] peek error = %v, want empty stream", err)
-	}
-	if time.Since(started) > 500*time.Millisecond {
-		t.Fatalf("empty chat [DONE] waited %s, want immediate retry", time.Since(started))
+func TestPeekQualityStreamTerminalSemanticOutputIsNotEmpty(t *testing.T) {
+	t.Parallel()
+	longText := strings.Repeat("word ", 40)
+	shortText := strings.Repeat("a", 80)
+	for _, test := range []struct {
+		name        string
+		protocol    string
+		stream      string
+		wantVerdict QualityVerdict
+	}{
+		{
+			name:     "responses aggregate function call",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{}"}]}}`,
+			),
+			wantVerdict: QualityDeliver,
+		},
+		{
+			name:     "responses streamed function call",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"read_file","arguments":""}}`,
+				`data: {"type":"response.completed","response":{"id":"resp_1","output":[]}}`,
+			),
+			wantVerdict: QualityDeliver,
+		},
+		{
+			name:     "chat tool call",
+			protocol: qualityProtocolChat,
+			stream: sse(
+				`data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`,
+			),
+			wantVerdict: QualityDeliver,
+		},
+		{
+			name:     "anthropic tool use",
+			protocol: qualityProtocolAnthropic,
+			stream: sse(
+				`data: {"type":"content_block_start","content_block":{"type":"tool_use","id":"tool_1","name":"read_file","input":{}}}`,
+				`data: {"type":"message_stop"}`,
+			),
+			wantVerdict: QualityDeliver,
+		},
+		{
+			name:     "responses aggregate long text",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"` + longText + `"}]}]}}`,
+			),
+			wantVerdict: QualityWithhold,
+		},
+		{
+			name:     "responses aggregate does not double count deltas",
+			protocol: qualityProtocolResponses,
+			stream: sse(
+				`data: {"type":"response.output_text.delta","delta":"`+shortText+`"}`,
+				`data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"`+shortText+`"}]}]}}`,
+			),
+			wantVerdict: QualityDeliver,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := peekOpenQualityStreamForTest(t, test.protocol, test.stream)
+			if result.replay != nil {
+				defer result.replay.Close()
+			}
+			if result.err != nil {
+				t.Fatalf("peek error = %v, want semantic output", result.err)
+			}
+			if result.verdict != test.wantVerdict {
+				t.Fatalf("verdict = %s, want %s", result.verdict, test.wantVerdict)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- After `response.completed` or Chat `[DONE]` with zero tokens, `ClassifyQualityHold` returned `Wait`.
- `peekQualityStream` then sat until the upstream idle timeout (often 50–120s). The client already had HTTP 200 headers and showed Retrying with 0 tokens.
- If the stream is already terminal and still empty, finish the peek immediately and return `errQualityEmptyStream` so the attempt loop rotates.

## Why
#968 correctly refused to fail-open an *open* empty hang as HTTP 200. A **completed** empty stream is different: there will be no more bytes. Waiting for idle still produces the 200 + empty body the TUI retries on.

Open empty hangs (no terminal event) still wait for idle and do not fail-open.

## Test plan
- [x] `go test ./internal/application/gateway/ -run 'PeekQualityStreamEmpty'`
- [x] Empty `response.completed` and Chat `[DONE]` return `errQualityEmptyStream` in well under the hold timeout
- [x] Open empty pipe + hold timeout still waits; idle cancel does not fail-open