### PR TITLE
fix: emit response.failed with required model for Grok TUI serde

### DIFF
--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1151,7 +1151,7 @@ func (h *Handler) handleCreate(c *gin.Context, compact bool) {
 		writeGatewayError(c, err)
 		return
 	}
-	h.writeResult(c, result, request.Stream && !compact, streamProtocolResponses)
+	h.writeResponsesResult(c, result, request.Stream && !compact, request.Model)
 }
 
 func isJSONRequest(c *gin.Context) bool {
@@ -1211,14 +1211,18 @@ func (h *Handler) handleOwnedResource(c *gin.Context, deleteResource bool) {
 }
 
 func (h *Handler) writeResult(c *gin.Context, result *gateway.Result, stream bool, protocol streamProtocol) {
-	h.writeProtocolResult(c, result, stream, false, protocol)
+	h.writeProtocolResult(c, result, stream, false, protocol, "")
+}
+
+func (h *Handler) writeResponsesResult(c *gin.Context, result *gateway.Result, stream bool, fallbackModel string) {
+	h.writeProtocolResult(c, result, stream, false, streamProtocolResponses, fallbackModel)
 }
 
 func (h *Handler) writeAnthropicResult(c *gin.Context, result *gateway.Result, stream bool) {
-	h.writeProtocolResult(c, result, stream, true, streamProtocolAnthropic)
+	h.writeProtocolResult(c, result, stream, true, streamProtocolAnthropic, "")
 }
 
-func (h *Handler) writeProtocolResult(c *gin.Context, result *gateway.Result, stream, anthropic bool, protocol streamProtocol) {
+func (h *Handler) writeProtocolResult(c *gin.Context, result *gateway.Result, stream, anthropic bool, protocol streamProtocol, fallbackModel string) {
 	usage := gateway.Usage{}
 	responseID := ""
 	errorCode := ""
@@ -1250,7 +1254,7 @@ func (h *Handler) writeProtocolResult(c *gin.Context, result *gateway.Result, st
 	}
 	var err error
 	if stream {
-		metadata, copyErr := copyStream(c.Writer, result.Body, protocol, result.MarkFirstToken)
+		metadata, copyErr := copyStreamWithFallbackModel(c.Writer, result.Body, protocol, result.MarkFirstToken, fallbackModel)
 		usage, responseID, err = metadata.Usage, metadata.ResponseID, copyErr
 		if metadata.StreamFailure != nil && result.RecordStreamFailure != nil {
 			result.RecordStreamFailure(*metadata.StreamFailure)
@@ -1287,9 +1291,14 @@ type responseMetadata struct {
 }
 
 func copyStream(writer gin.ResponseWriter, source io.Reader, protocol streamProtocol, onFirstToken func()) (responseMetadata, error) {
+	return copyStreamWithFallbackModel(writer, source, protocol, onFirstToken, "")
+}
+
+func copyStreamWithFallbackModel(writer gin.ResponseWriter, source io.Reader, protocol streamProtocol, onFirstToken func(), fallbackModel string) (responseMetadata, error) {
 	inspector := &responseInspector{protocol: protocol, onFirstToken: onFirstToken}
 	markerFilter := internalSSEMarkerFilter{enabled: protocol == streamProtocolChat}
 	var compat responsesCompatState
+	compat.model = strings.TrimSpace(fallbackModel)
 	buffer := make([]byte, responseCopyBufferBytes)
 	received := 0
 	transferred := 0
@@ -1435,9 +1444,8 @@ func streamAbortTrailer(protocol streamProtocol, cause error, meta responseMetad
 			"model":        model,
 			"output":       []any{},
 			"error": map[string]any{
-				"code":    code,
-				"message": message,
-				"type":    "server_error",
+				"code":    "server_error",
+				"message": code + ": " + message,
 			},
 		}
 		event := map[string]any{

--- a/backend/internal/transport/http/inference/handler.go
+++ b/backend/internal/transport/http/inference/handler.go
@@ -1418,21 +1418,30 @@ func streamAbortTrailer(protocol streamProtocol, cause error, meta responseMetad
 		}
 		compat.rememberFromMeta(meta)
 		id := compat.ensureID()
-		response := map[string]any{
-			"id":                 id,
-			"object":             "response",
-			"created_at":         compat.createdAt,
-			"completed_at":       compat.createdAt,
-			"status":             "incomplete",
-			"output":             []any{},
-			"error":              nil,
-			"incomplete_details": map[string]any{"reason": code},
+		// Grok TUI 0.2.93 treats any response.incomplete as fatal
+		// max_tokens_truncation (not retryable), ignoring incomplete_details.reason.
+		// Stream aborts are transport failures — emit response.failed so the
+		// client can retry instead of killing the turn.
+		model := strings.TrimSpace(meta.Model)
+		if model == "" {
+			model = strings.TrimSpace(compat.model)
 		}
-		if model := strings.TrimSpace(meta.Model); model != "" {
-			response["model"] = model
+		response := map[string]any{
+			"id":           id,
+			"object":       "response",
+			"created_at":   compat.createdAt,
+			"completed_at": compat.createdAt,
+			"status":       "failed",
+			"model":        model,
+			"output":       []any{},
+			"error": map[string]any{
+				"code":    code,
+				"message": message,
+				"type":    "server_error",
+			},
 		}
 		event := map[string]any{
-			"type":            "response.incomplete",
+			"type":            "response.failed",
 			"id":              id,
 			"sequence_number": meta.SequenceNumber + 1,
 			"response":        response,
@@ -1442,7 +1451,7 @@ func streamAbortTrailer(protocol streamProtocol, cause error, meta responseMetad
 		if err != nil {
 			return nil
 		}
-		return []byte("event: response.incomplete\ndata: " + string(payload) + "\n\n")
+		return []byte("event: response.failed\ndata: " + string(payload) + "\n\n")
 	case streamProtocolAnthropic:
 		payload, err := json.Marshal(map[string]any{
 			"type":  "error",

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -991,14 +991,14 @@ func TestCopyStreamWritesTerminalOnIdleTimeout(t *testing.T) {
 		want     []string
 	}{
 		{name: "chat", protocol: streamProtocolChat, want: []string{`"code":"upstream_stream_idle_timeout"`, "data: [DONE]"}},
-		{name: "responses", protocol: streamProtocolResponses, want: []string{`"type":"response.failed"`, `"id":"resp_abort"`, `"created_at":`, `"sequence_number":`, `"code":"upstream_stream_idle_timeout"`, `"status":"failed"`, `"model":`}},
+		{name: "responses", protocol: streamProtocolResponses, want: []string{`"type":"response.failed"`, `"id":"resp_abort"`, `"created_at":`, `"sequence_number":`, `"code":"server_error"`, `"message":"upstream_stream_idle_timeout:`, `"status":"failed"`, `"model":"grok-test"`}},
 		{name: "anthropic", protocol: streamProtocolAnthropic, want: []string{`"type":"error"`, "上游流式响应长时间无数据"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			context, _ := gin.CreateTestContext(recorder)
-			_, err := copyStream(context.Writer, &idleErrorReader{}, test.protocol, nil)
+			_, err := copyStreamWithFallbackModel(context.Writer, &idleErrorReader{}, test.protocol, nil, "grok-test")
 			if !errors.Is(err, errUpstreamStreamRead) || !errors.Is(err, neterror.ErrUpstreamStreamIdleTimeout) {
 				t.Fatalf("copy error = %v", err)
 			}
@@ -1094,24 +1094,24 @@ func TestCopyStreamWritesTerminalOnIncompleteEOF(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
-	_, err := copyStream(context.Writer, strings.NewReader(""), streamProtocolResponses, nil)
+	_, err := copyStreamWithFallbackModel(context.Writer, strings.NewReader(""), streamProtocolResponses, nil, "grok-test")
 	if !errors.Is(err, errUpstreamStreamIncomplete) {
 		t.Fatalf("copy error = %v", err)
 	}
 	got := recorder.Body.String()
-	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"code":"upstream_stream_incomplete"`) {
+	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"code":"server_error"`) || !strings.Contains(got, `"message":"upstream_stream_incomplete:`) || !strings.Contains(got, `"model":"grok-test"`) {
 		t.Fatalf("incomplete EOF missing terminal SSE event: %q", got)
 	}
 }
 
 func TestSanitizeResponsesFillsMissingIDs(t *testing.T) {
-	state := &responsesCompatState{}
+	state := &responsesCompatState{model: "grok-test"}
 	got := rewriteResponsesDataLine([]byte(`data: {"type":"response.output_item.added","item":{"type":"reasoning"}}`+"\n"), state)
 	if !bytes.Contains(got, []byte(`"id":"item_1"`)) {
 		t.Fatalf("item id not filled: %s", got)
 	}
 	got = rewriteResponsesDataLine([]byte(`data: {"type":"response.created","response":{"status":"in_progress"}}`+"\n"), state)
-	if !bytes.Contains(got, []byte(`"id":"resp_abort"`)) || !bytes.Contains(got, []byte(`"created_at":`)) || !bytes.Contains(got, []byte(`"model":`)) {
+	if !bytes.Contains(got, []byte(`"id":"resp_abort"`)) || !bytes.Contains(got, []byte(`"created_at":`)) || !bytes.Contains(got, []byte(`"model":"grok-test"`)) {
 		t.Fatalf("response id/created_at/model not filled: %s", got)
 	}
 }
@@ -1120,13 +1120,61 @@ func TestCopyStreamAbortTrailerAlwaysIncludesModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
-	_, err := copyStream(context.Writer, &idleErrorReader{}, streamProtocolResponses, nil)
+	_, err := copyStreamWithFallbackModel(context.Writer, &idleErrorReader{}, streamProtocolResponses, nil, "grok-test")
 	if !errors.Is(err, errUpstreamStreamRead) {
 		t.Fatalf("copy error = %v", err)
 	}
 	got := recorder.Body.String()
-	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"model":`) {
+	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"model":"grok-test"`) {
 		t.Fatalf("abort trailer missing model: %q", got)
+	}
+}
+
+func TestCopyStreamAbortTrailerPrefersUpstreamModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	body := []byte(`data: {"type":"response.created","response":{"id":"resp_real","model":"upstream-model","status":"in_progress"}}` + "\n\n")
+	_, err := copyStreamWithFallbackModel(context.Writer, &chunkErrorReader{data: body}, streamProtocolResponses, nil, "request-model")
+	if !errors.Is(err, errUpstreamStreamRead) {
+		t.Fatalf("copy error = %v", err)
+	}
+	got := recorder.Body.String()
+	failedAt := strings.LastIndex(got, "event: response.failed")
+	if failedAt < 0 {
+		t.Fatalf("abort trailer missing: %q", got)
+	}
+	failed := got[failedAt:]
+	if !strings.Contains(failed, `"model":"upstream-model"`) || strings.Contains(failed, `"model":"request-model"`) {
+		t.Fatalf("abort trailer did not prefer upstream model: %q", failed)
+	}
+}
+
+func TestResponsesAbortTrailerUsesStandardErrorShape(t *testing.T) {
+	trailer := streamAbortTrailer(
+		streamProtocolResponses,
+		neterror.ErrUpstreamStreamIdleTimeout,
+		responseMetadata{},
+		&responsesCompatState{model: "grok-test"},
+	)
+	dataAt := bytes.Index(trailer, []byte("data: "))
+	if dataAt < 0 {
+		t.Fatalf("abort trailer missing data line: %q", trailer)
+	}
+	payload := bytes.TrimSpace(trailer[dataAt+len("data: "):])
+	var event struct {
+		Response struct {
+			Error map[string]any `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("decode abort trailer: %v; payload=%q", err, payload)
+	}
+	if event.Response.Error["code"] != "server_error" || !strings.Contains(stringAny(event.Response.Error["message"]), "upstream_stream_idle_timeout") {
+		t.Fatalf("unexpected Responses error: %#v", event.Response.Error)
+	}
+	if _, exists := event.Response.Error["type"]; exists {
+		t.Fatalf("Responses error contains non-protocol type: %#v", event.Response.Error)
 	}
 }
 

--- a/backend/internal/transport/http/inference/handler_test.go
+++ b/backend/internal/transport/http/inference/handler_test.go
@@ -991,7 +991,7 @@ func TestCopyStreamWritesTerminalOnIdleTimeout(t *testing.T) {
 		want     []string
 	}{
 		{name: "chat", protocol: streamProtocolChat, want: []string{`"code":"upstream_stream_idle_timeout"`, "data: [DONE]"}},
-		{name: "responses", protocol: streamProtocolResponses, want: []string{`"type":"response.incomplete"`, `"id":"resp_abort"`, `"created_at":`, `"sequence_number":`, `"incomplete_details"`}},
+		{name: "responses", protocol: streamProtocolResponses, want: []string{`"type":"response.failed"`, `"id":"resp_abort"`, `"created_at":`, `"sequence_number":`, `"code":"upstream_stream_idle_timeout"`, `"status":"failed"`, `"model":`}},
 		{name: "anthropic", protocol: streamProtocolAnthropic, want: []string{`"type":"error"`, "上游流式响应长时间无数据"}},
 	}
 	for _, test := range tests {
@@ -1046,7 +1046,7 @@ func TestCopyStreamFlushesUnterminatedResponsesTailBeforeAbort(t *testing.T) {
 		t.Fatalf("copy error = %v", err)
 	}
 	got := recorder.Body.String()
-	if !strings.Contains(got, `"delta":"partial"`) || !strings.Contains(got, "\n\nevent: response.incomplete") {
+	if !strings.Contains(got, `"delta":"partial"`) || !strings.Contains(got, "\n\nevent: response.failed") {
 		t.Fatalf("unterminated tail and abort event were not separated: %q", got)
 	}
 	if marked != 1 {
@@ -1070,7 +1070,7 @@ func TestCopyStreamDropsMalformedResponsesTailBeforeAbort(t *testing.T) {
 	if strings.Contains(got, string(malformed)) {
 		t.Fatalf("malformed tail leaked before terminal event: %q", got)
 	}
-	if !strings.Contains(got, `"type":"response.incomplete"`) {
+	if !strings.Contains(got, `"type":"response.failed"`) {
 		t.Fatalf("abort event missing after malformed tail: %q", got)
 	}
 }
@@ -1099,7 +1099,7 @@ func TestCopyStreamWritesTerminalOnIncompleteEOF(t *testing.T) {
 		t.Fatalf("copy error = %v", err)
 	}
 	got := recorder.Body.String()
-	if !strings.Contains(got, `"type":"response.incomplete"`) || !strings.Contains(got, `"reason":"upstream_stream_incomplete"`) {
+	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"code":"upstream_stream_incomplete"`) {
 		t.Fatalf("incomplete EOF missing terminal SSE event: %q", got)
 	}
 }
@@ -1111,8 +1111,22 @@ func TestSanitizeResponsesFillsMissingIDs(t *testing.T) {
 		t.Fatalf("item id not filled: %s", got)
 	}
 	got = rewriteResponsesDataLine([]byte(`data: {"type":"response.created","response":{"status":"in_progress"}}`+"\n"), state)
-	if !bytes.Contains(got, []byte(`"id":"resp_abort"`)) || !bytes.Contains(got, []byte(`"created_at":`)) {
-		t.Fatalf("response id/created_at not filled: %s", got)
+	if !bytes.Contains(got, []byte(`"id":"resp_abort"`)) || !bytes.Contains(got, []byte(`"created_at":`)) || !bytes.Contains(got, []byte(`"model":`)) {
+		t.Fatalf("response id/created_at/model not filled: %s", got)
+	}
+}
+
+func TestCopyStreamAbortTrailerAlwaysIncludesModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	_, err := copyStream(context.Writer, &idleErrorReader{}, streamProtocolResponses, nil)
+	if !errors.Is(err, errUpstreamStreamRead) {
+		t.Fatalf("copy error = %v", err)
+	}
+	got := recorder.Body.String()
+	if !strings.Contains(got, `"type":"response.failed"`) || !strings.Contains(got, `"model":`) {
+		t.Fatalf("abort trailer missing model: %q", got)
 	}
 }
 

--- a/backend/internal/transport/http/inference/responses_compat.go
+++ b/backend/internal/transport/http/inference/responses_compat.go
@@ -12,6 +12,7 @@ import (
 type responsesCompatState struct {
 	responseID      string
 	createdAt       int64
+	model           string
 	itemSeq         int
 	itemIDs         map[int64]string
 	usedItemIDs     map[string]struct{}
@@ -102,6 +103,9 @@ func (s *responsesCompatState) rememberFromMeta(meta responseMetadata) {
 	if id := strings.TrimSpace(meta.ResponseID); id != "" {
 		s.responseID = id
 	}
+	if model := strings.TrimSpace(meta.Model); model != "" {
+		s.model = model
+	}
 	s.ensureID()
 }
 
@@ -171,6 +175,13 @@ func sanitizeResponsesEvent(event map[string]any, state *responsesCompatState) b
 		}
 		if resp["output"] == nil {
 			resp["output"] = []any{}
+			changed = true
+		}
+		if model := strings.TrimSpace(stringAny(resp["model"])); model != "" {
+			state.model = model
+		} else {
+			// Grok TUI serde requires `model` on response.failed / completed.
+			resp["model"] = state.model
 			changed = true
 		}
 		if errObj, ok := resp["error"].(map[string]any); ok && strings.TrimSpace(stringAny(errObj["id"])) == "" {


### PR DESCRIPTION
## Summary
- Grok TUI 0.2.93 treats any `response.incomplete` as fatal `max_tokens_truncation`, ignoring `incomplete_details.reason`. Stream idle / incomplete EOF / interrupted used that event, so the client killed the turn instead of retrying.
- serde also requires `model` on `response.failed` / `completed`. Official abort trailers only set `model` when `meta.Model` was already parsed, so empty streams failed with `missing field \`model\``.
- Emit `response.failed` with `status=failed` and an `error` object, and always fill `model` from stream metadata or the last seen response event.

## Why
This is the same serde class as #978 (`output_text.annotations`). Missing required fields make TUI Retrying die on the abort trailer even after the empty-stream retry in #980.

## Test plan
- [x] `go test ./internal/transport/http/inference/ -run 'CopyStream|SanitizeResponses'`
- [x] idle timeout / incomplete EOF / interrupted emit `response.failed`
- [x] abort trailer always includes `"model"`
- [x] sanitize fills missing `model` on `response.created`