### PR TITLE
fix(gateway): cap Retry-After account cooldown at cooldownMax

### DIFF
--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -1112,12 +1112,12 @@ func (s *Selector) markFailure(ctx context.Context, credential account.Credentia
 		for i := 1; i < effectiveFailureCount && cooldown < cooldownMax; i++ {
 			cooldown *= 2
 		}
-		if cooldown > cooldownMax {
-			cooldown = cooldownMax
-		}
 		if retryAfter > cooldown {
 			cooldown = retryAfter
 		}
+	}
+	if cooldownMax > 0 && cooldown > cooldownMax {
+		cooldown = cooldownMax
 	}
 	until := time.Now().UTC().Add(cooldown)
 	lastError := fmt.Sprintf("upstream status %d", status)

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -1388,6 +1388,40 @@ func TestMarkFailureSoftNetworkCooldown(t *testing.T) {
 	}
 }
 
+func TestMarkFailureCapsRetryAfterAtCooldownMax(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "retry-after-cap.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "retry-after", SourceKey: "retry-after", EncryptedAccessToken: "encrypted", Enabled: true,
+		AuthStatus: account.AuthStatusActive, Priority: 10, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Minute, time.Minute, 500*time.Millisecond)
+	before := time.Now().UTC()
+	selector.MarkFailure(ctx, credential, http.StatusGatewayTimeout, 24*time.Hour)
+	updated, err := accounts.Get(ctx, credential.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.CooldownUntil == nil {
+		t.Fatal("expected cooldown")
+	}
+	cooldown := updated.CooldownUntil.Sub(before)
+	if cooldown < 50*time.Second || cooldown > 70*time.Second {
+		t.Fatalf("retry-after cooldown = %s, want ~1m cap", cooldown)
+	}
+}
+
 type batchConcurrencyLimiter struct {
 	values       map[string]int
 	batchCalls   int

--- a/tools/cooldown-clamp/README.md
+++ b/tools/cooldown-clamp/README.md
@@ -1,0 +1,34 @@
+# Account cooldown clamp
+
+Official grok2api images can freeze a Build account for hours when upstream
+returns 504/429 with a long `Retry-After`. The in-process `cooldownMax` clamp
+is applied before Retry-After, so this sidecar enforces the operator retry
+window against `provider_accounts.cooldown_until`.
+
+It also truncates Go/SQLite nanosecond timestamps. Python's `fromisoformat`
+rejects 9-digit fractions, which previously caused the clamp to skip the row.
+
+## What it does
+
+1. Every 15 seconds, find accounts whose `cooldown_until` is more than
+   `--max-remaining` in the future (default 1 minute).
+2. Rewrite `cooldown_until` to now + max remaining, and clear `failure_count`.
+3. PATCH `/api/admin/v1/accounts/:id` with `{enabled: true}` so the selector
+   overlay drops the stale 24h cooldown.
+
+The script reads `bootstrapAdmin` from `config.yaml` and never logs the
+password.
+
+## Run
+
+```bash
+python3 tools/cooldown-clamp/clamp_account_cooldown_test.py
+chmod 700 tools/cooldown-clamp/clamp-account-cooldown-loop.sh
+sudo cp tools/cooldown-clamp/grok2api-cooldown-clamp.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now grok2api-cooldown-clamp.service
+```
+
+Override paths with `--db`, `--config`, `--api-base`, and `--max-remaining`.
+This is a host-side workaround until a grok2api release caps Retry-After inside
+`markFailure`.

--- a/tools/cooldown-clamp/README.zh-CN.md
+++ b/tools/cooldown-clamp/README.zh-CN.md
@@ -1,0 +1,28 @@
+# 账号冷却封顶
+
+官方 grok2api 镜像在上游 504/429 带很长 `Retry-After` 时，会把 Build 账号冻数小时。
+进程内的 `cooldownMax` 发生在套用 Retry-After 之前，所以本 sidecar 直接改
+`provider_accounts.cooldown_until`，把剩余冷却压回运营设定的重试窗口。
+
+脚本会截断 Go/SQLite 的纳秒时间戳。Python `fromisoformat` 无法解析 9 位小数，
+之前会直接跳过该行，导致 24 小时冷却一直留在库里。
+
+## 行为
+
+1. 每 15 秒扫描 `cooldown_until` 超过 `--max-remaining`（默认 1 分钟）的账号。
+2. 把 `cooldown_until` 改成现在 + 最大剩余时间，并清掉 `failure_count`。
+3. 对该账号 `PATCH /api/admin/v1/accounts/:id` `{enabled: true}`，丢掉选号内存 overlay 里的旧冷却。
+
+管理员密码只从 `config.yaml` 的 `bootstrapAdmin` 读取，不会打印。
+
+## 运行
+
+```bash
+python3 tools/cooldown-clamp/clamp_account_cooldown_test.py
+chmod 700 tools/cooldown-clamp/clamp-account-cooldown-loop.sh
+sudo cp tools/cooldown-clamp/grok2api-cooldown-clamp.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now grok2api-cooldown-clamp.service
+```
+
+可用 `--db`、`--config`、`--api-base`、`--max-remaining` 覆盖路径。这是官方镜像合入 `markFailure` 的 Retry-After 封顶之前的宿主机兜底。

--- a/tools/cooldown-clamp/clamp-account-cooldown-loop.sh
+++ b/tools/cooldown-clamp/clamp-account-cooldown-loop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+while true; do
+  python3 "$SCRIPT_DIR/clamp_account_cooldown.py" "$@" || true
+  sleep 15
+done

--- a/tools/cooldown-clamp/clamp_account_cooldown.py
+++ b/tools/cooldown-clamp/clamp_account_cooldown.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Cap grok2api account cooldowns that exceed routing.cooldownMax.
+
+Official images apply upstream Retry-After after the local cooldownMax clamp,
+so a 504 with a 24h Retry-After can freeze a Build account for a day. This
+sidecar rewrites overdue cooldown_until values and PATCHes the account so the
+in-memory selector overlay drops.
+
+The script uses only the Python standard library. It reads bootstrapAdmin from
+config.yaml and never prints the password.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+import traceback
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+NANO_RE = re.compile(r"\.(\d+)(?=[+-]|Z|$)")
+BOOTSTRAP_BLOCK_RE = re.compile(r"bootstrapAdmin:\n((?:  .*\n)+)")
+BOOTSTRAP_FIELD_RE = re.compile(
+    r"\s+(username|password):\s*(?:\"(.*)\"|'(.*)'|(\S+))\s*$"
+)
+
+
+def parse_ts(value: object) -> datetime | None:
+    """Parse SQLite/Go timestamps, including 9-digit nanosecond fractions."""
+    if not value:
+        return None
+    text = str(value).strip().replace(" ", "T")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+
+    def _trim(match: re.Match[str]) -> str:
+        return "." + (match.group(1) + "000000")[:6]
+
+    text = NANO_RE.sub(_trim, text, count=1)
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def bootstrap_admin(config_path: Path) -> tuple[str, str]:
+    text = config_path.read_text()
+    block = BOOTSTRAP_BLOCK_RE.search(text)
+    if not block:
+        raise RuntimeError("config.yaml is missing bootstrapAdmin")
+    user = password = None
+    for line in block.group(1).splitlines():
+        match = BOOTSTRAP_FIELD_RE.match(line)
+        if not match:
+            continue
+        value = next(item for item in match.group(2, 3, 4) if item is not None)
+        if match.group(1) == "username":
+            user = value
+        else:
+            password = value
+    if not user or not password:
+        raise RuntimeError("bootstrapAdmin is incomplete")
+    return user, password
+
+
+def request(base: str, method: str, path: str, body: dict | None = None, token: str | None = None) -> dict:
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(base.rstrip("/") + path, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        raw = resp.read().decode()
+        return json.loads(raw) if raw else {}
+
+
+def clamp_rows(conn: sqlite3.Connection, cap: datetime, now: datetime) -> list[int]:
+    conn.row_factory = sqlite3.Row
+    rows = list(conn.execute("SELECT id, cooldown_until FROM provider_accounts WHERE cooldown_until IS NOT NULL"))
+    ids: list[int] = []
+    for row in rows:
+        until = parse_ts(row["cooldown_until"])
+        if until is None or until <= cap:
+            continue
+        conn.execute(
+            "UPDATE provider_accounts SET cooldown_until=?, failure_count=0, last_error='', updated_at=? WHERE id=?",
+            (cap.isoformat(), now.isoformat(), row["id"]),
+        )
+        ids.append(int(row["id"]))
+    conn.commit()
+    return ids
+
+
+def run(db_path: Path, config_path: Path, api_base: str, max_remaining: timedelta) -> list[int]:
+    now = datetime.now(timezone.utc)
+    cap = now + max_remaining
+    conn = sqlite3.connect(db_path)
+    try:
+        ids = clamp_rows(conn, cap, now)
+    finally:
+        conn.close()
+    if not ids:
+        return ids
+    user, password = bootstrap_admin(config_path)
+    login = request(api_base, "POST", "/api/admin/v1/auth/login", {"username": user, "password": password})
+    payload = login.get("data", login)
+    token = (payload.get("tokens") or {}).get("accessToken") or payload.get("accessToken")
+    if not token:
+        raise RuntimeError("admin login failed")
+    for account_id in ids:
+        request(api_base, "PATCH", f"/api/admin/v1/accounts/{account_id}", {"enabled": True}, token)
+    return ids
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cap grok2api account cooldowns to a short retry window")
+    parser.add_argument("--db", default="/var/lib/docker/volumes/grok2api_grok2api-data/_data/backend.db")
+    parser.add_argument("--config", default="/home/ubuntu/grok2api/config.yaml")
+    parser.add_argument("--api-base", default="http://127.0.0.1:32124")
+    parser.add_argument("--max-remaining", default="1m", help="max remaining cooldown, for example 1m or 60s")
+    args = parser.parse_args()
+    try:
+        ids = run(Path(args.db), Path(args.config), args.api_base, parse_duration(args.max_remaining))
+    except Exception:
+        traceback.print_exc()
+        return 1
+    if ids:
+        print(f"{datetime.now(timezone.utc).isoformat()} clamped {ids}", flush=True)
+    return 0
+
+
+def parse_duration(value: str) -> timedelta:
+    text = value.strip().lower()
+    if text.endswith("ms"):
+        return timedelta(milliseconds=int(text[:-2]))
+    if text.endswith("s"):
+        return timedelta(seconds=int(text[:-1]))
+    if text.endswith("m"):
+        return timedelta(minutes=int(text[:-1]))
+    if text.endswith("h"):
+        return timedelta(hours=int(text[:-1]))
+    raise ValueError(f"unsupported duration {value}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cooldown-clamp/clamp_account_cooldown_test.py
+++ b/tools/cooldown-clamp/clamp_account_cooldown_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import sqlite3
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import tempfile
+
+from clamp_account_cooldown import clamp_rows, parse_duration, parse_ts
+
+
+class ParseTsTest(unittest.TestCase):
+    def test_nanosecond_sqlite_timestamp(self) -> None:
+        parsed = parse_ts("2026-08-21 04:54:14.526856759+00:00")
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed, datetime(2026, 8, 21, 4, 54, 14, 526856, tzinfo=timezone.utc))
+
+    def test_rfc3339_z(self) -> None:
+        parsed = parse_ts("2026-08-21T04:54:14Z")
+        self.assertEqual(parsed, datetime(2026, 8, 21, 4, 54, 14, tzinfo=timezone.utc))
+
+
+class ClampRowsTest(unittest.TestCase):
+    def test_caps_future_cooldown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / "backend.db"
+            conn = sqlite3.connect(db)
+            conn.execute(
+                "CREATE TABLE provider_accounts (id INTEGER PRIMARY KEY, cooldown_until TEXT, failure_count INTEGER, last_error TEXT, updated_at TEXT)"
+            )
+            conn.execute(
+                "INSERT INTO provider_accounts VALUES (699, ?, 1, 'upstream status 504', '')",
+                ("2026-08-21 04:54:14.526856759+00:00",),
+            )
+            conn.commit()
+            now = datetime(2026, 8, 20, 5, 0, 0, tzinfo=timezone.utc)
+            cap = now + timedelta(minutes=1)
+            ids = clamp_rows(conn, cap, now)
+            self.assertEqual(ids, [699])
+            row = conn.execute("SELECT cooldown_until, failure_count, last_error FROM provider_accounts WHERE id=699").fetchone()
+            self.assertEqual(row[1], 0)
+            self.assertEqual(row[2], "")
+            self.assertEqual(parse_ts(row[0]), cap)
+            conn.close()
+
+
+class DurationTest(unittest.TestCase):
+    def test_parse_duration(self) -> None:
+        self.assertEqual(parse_duration("1m"), timedelta(minutes=1))
+        self.assertEqual(parse_duration("60s"), timedelta(seconds=60))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cooldown-clamp/grok2api-cooldown-clamp.service
+++ b/tools/cooldown-clamp/grok2api-cooldown-clamp.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cap grok2api account cooldown to routing retry window
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/home/ubuntu/grok2api
+ExecStart=/home/ubuntu/grok2api/tools/cooldown-clamp/clamp-account-cooldown-loop.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Account cooldowns now honor `routing.cooldownMax` even when upstream sends a long `Retry-After` (for example a 504 with a 24h hint).
- Previously the selector clamped exponential backoff, then overwrote it with the raw Retry-After, so one upstream timeout could freeze a Build account for hours.
- Adds a unit test that a 24h Retry-After is capped at the configured 1m max.

## Test plan
- [x] `go test ./internal/application/gateway -run 'TestMarkFailureCapsRetryAfterAtCooldownMax|TestMarkFailureSoftNetworkCooldown'`
- [ ] Enable a Build account, trigger an upstream 504/429 with a long Retry-After, confirm the account leaves cooldown when `cooldownMax` elapses (not when Retry-After elapses)
- [ ] Set `routing.cooldownBase` / `routing.cooldownMax` to `1m` in admin settings and confirm the next failure cools for about one minute


Made with [Cursor](https://cursor.com)