### PR TITLE
fix: align video generation with current mediaGenInput protocol

### DIFF
--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -138,7 +138,7 @@ func (s *Service) CreateVideo(ctx context.Context, input VideoInput) (media.Job,
 	if err != nil {
 		return media.Job{}, err
 	}
-	routes, err = routesForVideoParameters(routes, operation, input.Resolution, len(input.ReferenceURLs), input.Duration)
+	routes, err = routesForVideoParameters(routes, operation, input.Resolution, strings.TrimSpace(input.ImageURL) != "", len(input.ReferenceURLs), input.Duration)
 	if err != nil {
 		return media.Job{}, err
 	}
@@ -209,14 +209,14 @@ func (s *Service) CreateVideo(ctx context.Context, input VideoInput) (media.Job,
 // Callers must first apply capability, client-key, and Provider eligibility:
 // the same public model may aggregate Console, Build, and Web routes with
 // different input contracts.
-func routesForVideoParameters(routes []model.Route, operation provider.VideoOperation, resolution string, referenceCount, duration int) ([]model.Route, error) {
+func routesForVideoParameters(routes []model.Route, operation provider.VideoOperation, resolution string, hasImage bool, referenceCount, duration int) ([]model.Route, error) {
 	if len(routes) == 0 {
 		return routes, nil
 	}
 	compatible := make([]model.Route, 0, len(routes))
 	var firstErr error
 	for _, candidate := range routes {
-		if err := validateVideoRouteParameters(candidate.Provider, operation, candidate.UpstreamModel, resolution, referenceCount, duration); err != nil {
+		if err := validateVideoRouteParameters(candidate.Provider, operation, candidate.UpstreamModel, resolution, hasImage, referenceCount, duration); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -233,12 +233,15 @@ func routesForVideoParameters(routes []model.Route, operation provider.VideoOper
 // Console 视频输入的上限与时长按「Provider + 入口字段 + 上游模型」分档。
 // /v1/videos/generations 是异步接口，只在 adapter 层拦截会产出必然失败的任务；
 // adapter 仍保留同一约束，作为最终出站边界的防御校验。
-func validateVideoRouteParameters(providerValue account.Provider, operation provider.VideoOperation, upstreamModel, resolution string, referenceCount, duration int) error {
+func validateVideoRouteParameters(providerValue account.Provider, operation provider.VideoOperation, upstreamModel, resolution string, hasImage bool, referenceCount, duration int) error {
 	if operation != provider.VideoOperationGenerate {
 		return nil
 	}
 	trimmedModel := strings.TrimSpace(upstreamModel)
 	hasReferences := referenceCount > 0
+	if providerValue == account.ProviderWeb && (hasImage || hasReferences) {
+		return fmt.Errorf("%w: Grok Web 当前仅支持文本生视频；图片视频请使用 Build 或 Console Provider", ErrVideoOperationUnsupported)
+	}
 	if providerValue == account.ProviderConsole && (trimmedModel == "grok-imagine-video" || trimmedModel == "grok-imagine-video-1.5") {
 		// 实测：8 张 reference_images 上游回 400
 		// "Too many reference images: 8. Maximum allowed is 7."（两个视频模型一致）。

--- a/backend/internal/application/gateway/video_test.go
+++ b/backend/internal/application/gateway/video_test.go
@@ -176,34 +176,40 @@ func TestVideoPricingLeavesUnmeasurableOperationsUnpriced(t *testing.T) {
 // 客户端会先拿到 request_id 再从轮询里读到失败任务。入队前校验让错误立刻可见。
 func TestVideoRouteParametersRejectConsoleReferenceLimits(t *testing.T) {
 	// 实测：8 张 reference_images 上游回 400 "Too many reference images: 8. Maximum allowed is 7."
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", 8, 6); !errors.Is(err, ErrVideoParameterInvalid) {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", false, 8, 6); !errors.Is(err, ErrVideoParameterInvalid) {
 		t.Fatalf("8 references error = %v", err)
 	}
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", 7, 6); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", false, 7, 6); err != nil {
 		t.Fatalf("7 references error = %v", err)
 	}
 	// 实测：grok-imagine-video 的 reference-to-video 回 400
 	// "Duration 15s exceeds the maximum allowed for reference-to-video, which is 10s."
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", 1, 15); !errors.Is(err, ErrVideoParameterInvalid) {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", false, 1, 15); !errors.Is(err, ErrVideoParameterInvalid) {
 		t.Fatalf("base model reference duration error = %v", err)
 	}
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", 1, 10); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", false, 1, 10); err != nil {
 		t.Fatalf("base model 10s reference error = %v", err)
 	}
 	// image-to-video（无 reference_images）与 1.5 都保持 15s。
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", 0, 15); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "720p", true, 0, 15); err != nil {
 		t.Fatalf("base model text/first-frame 15s error = %v", err)
 	}
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", 2, 15); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", false, 2, 15); err != nil {
 		t.Fatalf("1.5 multi-reference 15s error = %v", err)
 	}
 	// Build 使用相同的 1.5 上游模型名，但支持通用上限 8；不能因同名套用 Console 的 7 张限制。
-	if err := validateVideoRouteParameters(account.ProviderBuild, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", 8, 15); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderBuild, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "720p", false, 8, 15); err != nil {
 		t.Fatalf("Build 1.5 references error = %v", err)
 	}
-	// Web 同样与 Console 共享基础模型名，不受 Console 专属时长限制。
-	if err := validateVideoRouteParameters(account.ProviderWeb, provider.VideoOperationGenerate, "grok-imagine-video", "720p", 8, 15); err != nil {
-		t.Fatalf("Web base references error = %v", err)
+	// Web 新协议只有文本生视频抓包证据；不能退回已删除的 media-post 旧链路。
+	if err := validateVideoRouteParameters(account.ProviderWeb, provider.VideoOperationGenerate, "grok-imagine-video", "720p", false, 0, 15); err != nil {
+		t.Fatalf("Web text video error = %v", err)
+	}
+	if err := validateVideoRouteParameters(account.ProviderWeb, provider.VideoOperationGenerate, "grok-imagine-video", "720p", true, 0, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
+		t.Fatalf("Web image video error = %v", err)
+	}
+	if err := validateVideoRouteParameters(account.ProviderWeb, provider.VideoOperationGenerate, "grok-imagine-video", "720p", false, 1, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
+		t.Fatalf("Web reference video error = %v", err)
 	}
 }
 
@@ -212,14 +218,14 @@ func TestRoutesForVideoParametersKeepsCompatibleSameNameProviders(t *testing.T) 
 		{ID: 1, PublicID: "shared-video", Provider: account.ProviderConsole, UpstreamModel: "grok-imagine-video-1.5"},
 		{ID: 2, PublicID: "shared-video", Provider: account.ProviderBuild, UpstreamModel: "grok-imagine-video-1.5"},
 	}
-	compatible, err := routesForVideoParameters(routes, provider.VideoOperationGenerate, "720p", 8, 15)
+	compatible, err := routesForVideoParameters(routes, provider.VideoOperationGenerate, "720p", false, 8, 15)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(compatible) != 1 || compatible[0].ID != 2 {
 		t.Fatalf("compatible routes = %#v", compatible)
 	}
-	if _, err := routesForVideoParameters(routes[:1], provider.VideoOperationGenerate, "720p", 8, 15); !errors.Is(err, ErrVideoParameterInvalid) {
+	if _, err := routesForVideoParameters(routes[:1], provider.VideoOperationGenerate, "720p", false, 8, 15); !errors.Is(err, ErrVideoParameterInvalid) {
 		t.Fatalf("Console-only invalid route error = %v", err)
 	}
 }
@@ -260,13 +266,13 @@ func TestCreateVideoAppliesRouteConstraintsAfterKeyEligibilityAndBeforeInputIO(t
 }
 
 func TestVideo1080pValidationUsesResolvedUpstreamModel(t *testing.T) {
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "1080P", 0, 6); err != nil {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "1080P", false, 0, 6); err != nil {
 		t.Fatalf("1.5 text/image 1080p rejected: %v", err)
 	}
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "1080p", 0, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video", "1080p", false, 0, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
 		t.Fatalf("legacy 1080p error = %v", err)
 	}
-	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "1080p", 1, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
+	if err := validateVideoRouteParameters(account.ProviderConsole, provider.VideoOperationGenerate, "grok-imagine-video-1.5", "1080p", false, 1, 6); !errors.Is(err, ErrVideoOperationUnsupported) {
 		t.Fatalf("reference 1080p error = %v", err)
 	}
 }

--- a/backend/internal/infra/provider/web/image.go
+++ b/backend/internal/infra/provider/web/image.go
@@ -1392,66 +1392,6 @@ func directFileUploadTerminalError(raw json.RawMessage) bool {
 	}
 }
 
-func (a *Adapter) createMediaPost(ctx context.Context, cfg Config, lease *egress.Lease, token, mediaType, mediaURL, prompt, stage string) (string, error) {
-	payload := map[string]any{"mediaType": mediaType}
-	if mediaURL != "" {
-		payload["mediaUrl"] = mediaURL
-	}
-	if prompt != "" {
-		payload["prompt"] = prompt
-	}
-	response, err := a.postJSON(ctx, cfg, lease, token, cfg.BaseURL+"/rest/media/post/create", payload, time.Minute)
-	if err != nil {
-		return "", err
-	}
-	defer response.Body.Close()
-	return parseMediaPostResponseWithDiagnostics(response, func(upstreamErr *webMediaUpstreamError) {
-		a.logWebMediaUpstreamRejection(stage, response, upstreamErr)
-	})
-}
-
-func parseMediaPostResponse(response *http.Response) (string, error) {
-	return parseMediaPostResponseWithDiagnostics(response, nil)
-}
-
-func parseMediaPostResponseWithDiagnostics(response *http.Response, onUpstreamError func(*webMediaUpstreamError)) (string, error) {
-	const responseLimit = 2 << 20
-	readLimit := responseLimit
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		readLimit = webMediaDiagnosticBodyLimit
-	}
-	body, err := io.ReadAll(io.LimitReader(response.Body, int64(readLimit)+1))
-	if err != nil {
-		return "", fmt.Errorf("读取媒体 Post 响应: %w", err)
-	}
-	truncated := len(body) > readLimit
-	if truncated {
-		body = body[:readLimit]
-	}
-	if truncated && response.StatusCode >= 200 && response.StatusCode < 300 {
-		return "", fmt.Errorf("创建媒体 Post 响应超过安全上限")
-	}
-	if response.StatusCode == http.StatusUnauthorized {
-		return "", provider.ErrUnauthorized
-	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		upstreamErr := newWebMediaUpstreamError(response.StatusCode, body, truncated)
-		if onUpstreamError != nil {
-			onUpstreamError(upstreamErr)
-		}
-		return "", upstreamErr
-	}
-	var value struct {
-		Post struct {
-			ID string `json:"id"`
-		} `json:"post"`
-	}
-	if json.Unmarshal(body, &value) != nil || strings.TrimSpace(value.Post.ID) == "" {
-		return "", fmt.Errorf("创建媒体 Post 响应无效")
-	}
-	return strings.TrimSpace(value.Post.ID), nil
-}
-
 func (a *Adapter) postJSON(ctx context.Context, cfg Config, lease *egress.Lease, token, endpoint string, payload any, timeout time.Duration) (*http.Response, error) {
 	return a.postJSONWithReferer(ctx, cfg, lease, token, endpoint, payload, timeout, cfg.BaseURL+"/imagine")
 }

--- a/backend/internal/infra/provider/web/protocol_test.go
+++ b/backend/internal/infra/provider/web/protocol_test.go
@@ -100,24 +100,6 @@ func TestWebImagePublicNamesMatchProtocolProducts(t *testing.T) {
 	}
 }
 
-func TestParseMediaPostResponsePreservesStatusAndPostID(t *testing.T) {
-	postID, err := parseMediaPostResponse(&http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`{"post":{"id":"post_1","videos":[{"id":"post_1"}]}}`)),
-	})
-	if err != nil || postID != "post_1" {
-		t.Fatalf("postID=%q err=%v", postID, err)
-	}
-	_, err = parseMediaPostResponse(&http.Response{
-		StatusCode: http.StatusForbidden,
-		Body:       io.NopCloser(strings.NewReader(`{"error":"challenge"}`)),
-	})
-	var upstreamErr *webMediaUpstreamError
-	if !errors.As(err, &upstreamErr) || upstreamErr.status != http.StatusForbidden || !strings.Contains(err.Error(), "challenge") {
-		t.Fatalf("error = %#v", err)
-	}
-}
-
 func TestWebChatPricingUsesGrok45(t *testing.T) {
 	registry := provider.NewRegistry(&Adapter{})
 	for _, upstreamModel := range []string{"grok-chat-fast", "grok-chat-auto", "grok-chat-expert", "grok-chat-heavy"} {
@@ -1091,58 +1073,6 @@ func TestBuildDirectFileUploadBodyOmitsSourceForChat(t *testing.T) {
 	}
 }
 
-func TestVideoReferenceUsesV2DirectUpload(t *testing.T) {
-	dataURI := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/http/upload-file-v2/direct" {
-			t.Errorf("unexpected upload path %q", request.URL.Path)
-			writer.WriteHeader(http.StatusNotFound)
-			return
-		}
-		if err := request.ParseMultipartForm(2 << 20); err != nil {
-			t.Errorf("multipart: %v", err)
-			writer.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		file, header, err := request.FormFile("file")
-		if err != nil {
-			t.Errorf("file part: %v", err)
-			writer.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		defer file.Close()
-		content, _ := io.ReadAll(file)
-		if header.Filename != "image.png" || header.Header.Get("Content-Type") != "image/png" || len(content) == 0 {
-			t.Errorf("upload filename=%q content-type=%q bytes=%d", header.Filename, header.Header.Get("Content-Type"), len(content))
-		}
-		if request.FormValue("file_source") != imagineSelfUploadSource {
-			t.Errorf("file_source = %q", request.FormValue("file_source"))
-		}
-		writer.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(writer, `{"uploadId":"upload-1","fileMetadata":{"fileMetadataId":"metadata-1","fileUri":"users/test/reference/content"}}`)
-	}))
-	defer server.Close()
-
-	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	manager := infraegress.NewManager(egressRepositoryStub{}, cipher)
-	lease, err := manager.Acquire(context.Background(), egressdomain.ScopeWeb, "video-reference-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer lease.Release()
-	adapter := NewAdapter(Config{BaseURL: server.URL}, manager, cipher, nil, nil)
-	uri, err := adapter.prepareVideoReference(context.Background(), adapter.config(), lease, "test-sso", dataURI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if uri != "https://assets.grok.com/users/test/reference/content" {
-		t.Fatalf("uri = %q", uri)
-	}
-}
-
 func TestDecodeDirectFileUploadResponse(t *testing.T) {
 	uploaded, err := decodeDirectFileUploadResponse(strings.NewReader(`{
 		"uploadId":"upload-1",
@@ -1618,6 +1548,48 @@ func TestParseVideoStreamFixture(t *testing.T) {
 	}
 }
 
+func TestTextToVideoPayloadMatchesCapturedMediaGenInputShape(t *testing.T) {
+	payload := videoCreatePayload("雨后天晴！", "9:16", "480p", 6)
+	if len(payload) != 8 || payload["modelName"] != "imagine-video-gen" ||
+		payload["message"] != "雨后天晴！ --mode=custom" ||
+		payload["enableImageStreaming"] != true || payload["enableSideBySide"] != true ||
+		payload["sendFinalMetadata"] != true || payload["kind"] != "CONVERSATION_KIND_IMAGINE" {
+		t.Fatalf("payload = %#v", payload)
+	}
+
+	metadata, ok := payload["responseMetadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("responseMetadata = %#v", payload["responseMetadata"])
+	}
+	if experiments, ok := metadata["experiments"].([]any); !ok || len(experiments) != 0 {
+		t.Fatalf("experiments = %#v", metadata["experiments"])
+	}
+	override, ok := metadata["modelConfigOverride"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelConfigOverride = %#v", metadata["modelConfigOverride"])
+	}
+	modelMap, ok := override["modelMap"].(map[string]any)
+	if !ok || len(modelMap) != 0 {
+		t.Fatalf("modelMap = %#v", override["modelMap"])
+	}
+
+	mediaGenInput, ok := payload["mediaGenInput"].(map[string]any)
+	if !ok {
+		t.Fatalf("mediaGenInput = %#v", payload["mediaGenInput"])
+	}
+	textToVideo, ok := mediaGenInput["textToVideo"].(map[string]any)
+	if !ok || textToVideo["prompt"] != "雨后天晴！" || textToVideo["aspectRatio"] != "9:16" ||
+		textToVideo["duration"] != 6 || textToVideo["resolutionName"] != "480p" {
+		t.Fatalf("textToVideo = %#v", mediaGenInput["textToVideo"])
+	}
+
+	for _, field := range []string{"temporary", "videoGenModelConfig", "parentPostId"} {
+		if _, exists := payload[field]; exists {
+			t.Fatalf("legacy field %q leaked into text-to-video payload: %#v", field, payload)
+		}
+	}
+}
+
 func TestParseVideoStreamPreservesUpstreamStatus(t *testing.T) {
 	response := &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("limited"))}
 	_, _, err := parseVideoStream(response, nil)
@@ -1633,8 +1605,17 @@ func TestGenerateVideoClassifiesOnlyExplicitHTTPRejectionAsCreateFailure(t *test
 		writer.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/rest/media/post/create":
-			_, _ = io.WriteString(writer, `{"post":{"id":"post_1"}}`)
+			t.Error("text-to-video unexpectedly used the retired media-post endpoint")
+			writer.WriteHeader(http.StatusInternalServerError)
 		case "/rest/app-chat/conversations/new":
+			var payload map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Errorf("decode video payload: %v", err)
+			}
+			mediaGenInput, _ := payload["mediaGenInput"].(map[string]any)
+			if _, ok := mediaGenInput["textToVideo"].(map[string]any); !ok {
+				t.Errorf("textToVideo payload = %#v", payload)
+			}
 			writer.WriteHeader(status)
 			if status == http.StatusOK {
 				_, _ = io.WriteString(writer, `{}`)

--- a/backend/internal/infra/provider/web/video.go
+++ b/backend/internal/infra/provider/web/video.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	domainegress "github.com/chenyme/grok2api/backend/internal/domain/egress"
-	"github.com/chenyme/grok2api/backend/internal/infra/egress"
 	"github.com/chenyme/grok2api/backend/internal/infra/provider"
 )
 
@@ -234,6 +233,9 @@ func boundWebMediaDiagnostic(value string, limit int) string {
 }
 
 func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoRequest) (provider.VideoResult, error) {
+	if strings.TrimSpace(request.ImageURL) != "" || len(request.ReferenceURLs) > 0 {
+		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoStagePrepare, 0, fmt.Errorf("Grok Web 当前仅支持文本生视频；图片视频请使用 Build 或 Console Provider"))
+	}
 	cfg := a.config()
 	token, err := a.cipher.Decrypt(request.Credential.EncryptedAccessToken)
 	if err != nil {
@@ -244,32 +246,6 @@ func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoReque
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoStagePrepare, 0, err)
 	}
 	defer lease.Release()
-	parentID := ""
-	rawReferences := make([]string, 0, 1+len(request.ReferenceURLs))
-	if imageURL := strings.TrimSpace(request.ImageURL); imageURL != "" {
-		rawReferences = append(rawReferences, imageURL)
-	}
-	for _, rawReference := range request.ReferenceURLs {
-		if value := strings.TrimSpace(rawReference); value != "" {
-			rawReferences = append(rawReferences, value)
-		}
-	}
-	references := make([]string, 0, len(rawReferences))
-	for _, rawReference := range rawReferences {
-		reference, referenceErr := a.prepareVideoReference(ctx, cfg, lease, token, rawReference)
-		if referenceErr != nil {
-			return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoCreateFailureStage(referenceErr), 0, referenceErr)
-		}
-		references = append(references, reference)
-	}
-	if len(references) > 0 {
-		parentID, err = a.createMediaPost(ctx, cfg, lease, token, "MEDIA_POST_TYPE_IMAGE", references[0], "", "video_reference_media_post")
-	} else {
-		parentID, err = a.createMediaPost(ctx, cfg, lease, token, "MEDIA_POST_TYPE_VIDEO", "", request.Prompt, "video_prompt_media_post")
-	}
-	if err != nil {
-		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoCreateFailureStage(err), 0, err)
-	}
 	segments := videoSegments(request.Duration)
 	if len(segments) == 0 {
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoStagePrepare, 0, fmt.Errorf("duration 必须在 1 到 15 秒之间"))
@@ -279,7 +255,7 @@ func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoReque
 	if resolution == "" {
 		resolution = "720p"
 	}
-	payload := videoCreatePayload(request.Prompt, parentID, ratio, resolution, segments[0], references)
+	payload := videoCreatePayload(request.Prompt, ratio, resolution, segments[0])
 	response, err := a.postJSON(ctx, cfg, lease, token, cfg.BaseURL+"/rest/app-chat/conversations/new", payload, time.Duration(cfg.VideoTimeoutSeconds)*time.Second)
 	if err != nil {
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoCreateFailureStage(err), 0, err)
@@ -300,25 +276,6 @@ func (a *Adapter) GenerateVideo(ctx context.Context, request provider.VideoReque
 		return provider.VideoResult{}, provider.WrapVideoStage(provider.VideoStagePoll, 0, fmt.Errorf("视频生成完成但没有返回内容 URL"))
 	}
 	return result, nil
-}
-
-func (a *Adapter) prepareVideoReference(ctx context.Context, cfg Config, lease *egress.Lease, token, value string) (string, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", fmt.Errorf("视频参考图片 URL 不能为空")
-	}
-	image, err := a.loadChatImage(ctx, lease, value, 20<<20)
-	if err != nil {
-		return "", err
-	}
-	uploaded, err := a.uploadFileV2Direct(ctx, cfg, lease, token, image, cfg.BaseURL+"/imagine", imagineSelfUploadSource, "video_reference_upload")
-	if err != nil {
-		return "", err
-	}
-	if uploaded.URI == "" {
-		return "", fmt.Errorf("上传视频参考图片后未返回 fileUri")
-	}
-	return uploaded.URI, nil
 }
 
 // DownloadVideo retrieves a completed Grok asset through its source SSO
@@ -542,15 +499,31 @@ func videoSegments(seconds int) []int {
 	return []int{seconds}
 }
 
-func videoCreatePayload(prompt, parentID, ratio, resolution string, seconds int, references []string) map[string]any {
-	config := map[string]any{"parentPostId": parentID, "aspectRatio": ratio, "videoLength": seconds, "resolutionName": resolution}
-	if len(references) > 0 {
-		config["isVideoEdit"] = false
-		config["isReferenceToVideo"] = true
-		config["imageReferences"] = references
-	}
+// videoCreatePayload mirrors the current Grok Imagine browser request.
+// In particular, the generation parameters belong in mediaGenInput rather
+// than the legacy modelConfigOverride map. Keeping this shape explicit also
+// prevents text-to-video from depending on a synthetic media post.
+func videoCreatePayload(prompt, ratio, resolution string, seconds int) map[string]any {
 	return map[string]any{
-		"temporary": true, "modelName": "imagine-video-gen", "message": prompt + " --mode=custom", "enableSideBySide": true,
-		"responseMetadata": map[string]any{"experiments": []any{}, "modelConfigOverride": map[string]any{"modelMap": map[string]any{"videoGenModelConfig": config}}},
+		"modelName":            "imagine-video-gen",
+		"message":              prompt + " --mode=custom",
+		"enableImageStreaming": true,
+		"enableSideBySide":     true,
+		"sendFinalMetadata":    true,
+		"responseMetadata": map[string]any{
+			"experiments": []any{},
+			"modelConfigOverride": map[string]any{
+				"modelMap": map[string]any{},
+			},
+		},
+		"mediaGenInput": map[string]any{
+			"textToVideo": map[string]any{
+				"prompt":         prompt,
+				"aspectRatio":    ratio,
+				"duration":       seconds,
+				"resolutionName": resolution,
+			},
+		},
+		"kind": "CONVERSATION_KIND_IMAGINE",
 	}
 }


### PR DESCRIPTION
## Summary

- Align Grok Web text-to-video requests with the current Imagine browser protocol.
- Send generation parameters through `mediaGenInput.textToVideo`.
- Remove the legacy media-post preflight and `videoGenModelConfig` request path.
- Include the current browser fields:
  - `enableImageStreaming`
  - `enableSideBySide`
  - `sendFinalMetadata`
  - `kind: CONVERSATION_KIND_IMAGINE`
- Exclude Web routes for image/reference video inputs until their current upstream protocol is verified; eligible Build or Console routes remain available.

## Why

Grok Web now submits text-to-video requests directly to:

```text
/rest/app-chat/conversations/new
```

The previous implementation first created a synthetic media post and placed video parameters under:

```text
responseMetadata.modelConfigOverride.modelMap.videoGenModelConfig
```

That legacy request shape no longer matches the current browser protocol and may enter an upstream compatibility or degraded path, producing unrelated demo videos even though generation completes successfully.

## Removed

The following obsolete code was removed:

- `/rest/media/post/create` preflight for Web video generation
- `parentPostId`
- `videoGenModelConfig`
- `temporary: true`
- Legacy media-post response parsing
- Legacy Web reference-image upload path

These paths were removed instead of retained as fallback because silently using an unverified protocol can consume quota while returning unrelated output.

## Compatibility

- Web text-to-video continues to use `grok-imagine-video`.
- Build and Console video generation are unchanged.
- Web image-to-video and reference-to-video are no longer sent through the obsolete media-post protocol.
- When compatible Build or Console routes exist, routing can select those providers.
- Web-only image/reference requests return a clear unsupported-operation error rather than silently ignoring the input.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- Added a captured-request payload test for `mediaGenInput.textToVideo`.
- Added a regression assertion that fails if text-to-video calls `/rest/media/post/create`.
- `git diff --check`
