### PR TITLE
feat: terminate model output loops with split content/reasoning thresholds

### DIFF
--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -13,6 +13,17 @@ import (
 const (
 	maxDeferredSearchTextBytes       = 8 << 20
 	maxDeferredReasoningSummaryBytes = 8 << 20
+
+	// contentDoomLoopThreshold 连续重复同一可见内容增量时终止流。真正的
+	// 内容循环会消耗配额和客户端上下文，因此远低于推理上限；但仍需容纳
+	// 合法重复：markdown 分隔线与表格边框会以相同单字符增量（"-"、"="、
+	// "|"）连续输出。
+	contentDoomLoopThreshold = 128
+
+	// reasoningDoomLoopThreshold 高于内容阈值：high/xhigh 推理会大量重复
+	// 同一短标记（"so"、"hmm"、"wait"、列表符号）。共用低阈值会过早终止
+	// 有效的深度推理响应。
+	reasoningDoomLoopThreshold = 256
 )
 
 // ConvertResponseStream 将 Responses SSE 转换为 Chat Completions 或 Anthropic Messages SSE。
@@ -68,6 +79,12 @@ type streamConverter struct {
 	stopFilter        *anthropicStreamStopFilter
 	stopSequence      string
 	refused           bool
+	// 循环检测：可见内容与推理各自计数。推理合法地远比可见输出更常重复
+	// 同一短标记，共用一个计数器会过早终止有效的 high/xhigh 响应。
+	lastContentDelta   string
+	contentRepeatCount int
+	lastReasonDelta    string
+	reasonRepeatCount  int
 }
 
 type streamTool struct {
@@ -426,6 +443,9 @@ func (c *streamConverter) reasoningSummaryDelta(itemID, delta string) error {
 	if delta == "" || !c.reasoningOutputEnabled() {
 		return nil
 	}
+	if err := c.trackReasoningRepeat(delta, "model reasoning summary loop detected"); err != nil {
+		return err
+	}
 	_, state := c.ensureReasoningState(itemID)
 	if state.done || state.rawSeen {
 		return nil
@@ -456,7 +476,27 @@ func (c *streamConverter) reasoningTextDelta(itemID, delta string) error {
 	return c.emitReasoningDelta(delta)
 }
 
+// trackReasoningRepeat 统计连续相同的推理增量，超过推理阈值则终止流。
+func (c *streamConverter) trackReasoningRepeat(delta, message string) error {
+	if delta == "" {
+		return nil
+	}
+	if delta != c.lastReasonDelta {
+		c.lastReasonDelta = delta
+		c.reasonRepeatCount = 0
+		return nil
+	}
+	c.reasonRepeatCount++
+	if c.reasonRepeatCount >= reasoningDoomLoopThreshold {
+		return fmt.Errorf("%s (repeated delta %d times)", message, c.reasonRepeatCount)
+	}
+	return nil
+}
+
 func (c *streamConverter) emitReasoningDelta(delta string) error {
+	if err := c.trackReasoningRepeat(delta, "model reasoning loop detected"); err != nil {
+		return err
+	}
 	if c.operation == OperationChat {
 		return c.chatDelta(map[string]any{"reasoning_content": delta})
 	}
@@ -576,6 +616,19 @@ func (c *streamConverter) start() error {
 }
 
 func (c *streamConverter) textDelta(delta string) error {
+	// 循环检测：可见内容重复超过阈值时以错误终止流，避免循环耗尽账号配额
+	// 与客户端上下文窗口。推理增量使用独立且更高的计数器。
+	if delta != "" {
+		if delta == c.lastContentDelta {
+			c.contentRepeatCount++
+			if c.contentRepeatCount >= contentDoomLoopThreshold {
+				return fmt.Errorf("model output loop detected (repeated content delta %d times)", c.contentRepeatCount)
+			}
+		} else {
+			c.lastContentDelta = delta
+			c.contentRepeatCount = 0
+		}
+	}
 	if c.operation == OperationChat {
 		return c.textDeltaChat(delta)
 	}

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,11 +35,12 @@ func ConvertResponseStream(source io.ReadCloser, operation string) io.ReadCloser
 // ConvertResponseStreamWithOptions 按下游协议选项生成 Chat 或 Anthropic SSE。
 func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, options ResponseOptions) io.ReadCloser {
 	if operation == OperationResponses {
-		return source
+		return guardResponseStream(source)
 	}
 	reader, writer := io.Pipe()
+	stream := newStreamPipeReadCloser(reader, source)
 	go func() {
-		defer source.Close()
+		defer stream.closeSource()
 		converter := newStreamConverter(writer, operation, options)
 		err := consumeSSE(source, converter.handle)
 		if err == nil {
@@ -46,7 +48,7 @@ func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, op
 		}
 		_ = writer.CloseWithError(err)
 	}()
-	return reader
+	return stream
 }
 
 type streamConverter struct {
@@ -79,12 +81,45 @@ type streamConverter struct {
 	stopFilter        *anthropicStreamStopFilter
 	stopSequence      string
 	refused           bool
-	// 循环检测：可见内容与推理各自计数。推理合法地远比可见输出更常重复
-	// 同一短标记，共用一个计数器会过早终止有效的 high/xhigh 响应。
+	repeatTracker     streamRepeatTracker
+}
+
+// streamRepeatTracker 在协议转换、缓冲和 stop filter 之前跟踪上游增量，
+// 避免任一下游路径绕过循环保护。
+type streamRepeatTracker struct {
 	lastContentDelta   string
 	contentRepeatCount int
 	lastReasonDelta    string
 	reasonRepeatCount  int
+}
+
+// streamPipeReadCloser ensures a downstream cancellation immediately closes the
+// upstream body, including while the forwarding goroutine is blocked in Read.
+type streamPipeReadCloser struct {
+	*io.PipeReader
+	source    io.ReadCloser
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newStreamPipeReadCloser(reader *io.PipeReader, source io.ReadCloser) *streamPipeReadCloser {
+	return &streamPipeReadCloser{PipeReader: reader, source: source}
+}
+
+func (r *streamPipeReadCloser) Close() error {
+	readerErr := r.PipeReader.Close()
+	sourceErr := r.closeSource()
+	if readerErr != nil {
+		return readerErr
+	}
+	return sourceErr
+}
+
+func (r *streamPipeReadCloser) closeSource() error {
+	r.closeOnce.Do(func() {
+		r.closeErr = r.source.Close()
+	})
+	return r.closeErr
 }
 
 type streamTool struct {
@@ -246,16 +281,12 @@ func (c *streamConverter) handle(event string, data []byte) error {
 	if c.finished {
 		return nil
 	}
-	if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+	typeName, root, ok := parseSSEEvent(event, data)
+	if !ok {
 		return nil
 	}
-	var root map[string]json.RawMessage
-	if json.Unmarshal(data, &root) != nil {
-		return nil
-	}
-	typeName := event
-	if raw := root["type"]; typeName == "" {
-		_ = json.Unmarshal(raw, &typeName)
+	if err := c.repeatTracker.trackEvent(typeName, root); err != nil {
+		return err
 	}
 	if c.stopSequence != "" && typeName != "response.completed" && typeName != "response.incomplete" && typeName != "response.failed" && typeName != "error" {
 		return nil
@@ -443,9 +474,6 @@ func (c *streamConverter) reasoningSummaryDelta(itemID, delta string) error {
 	if delta == "" || !c.reasoningOutputEnabled() {
 		return nil
 	}
-	if err := c.trackReasoningRepeat(delta, "model reasoning summary loop detected"); err != nil {
-		return err
-	}
 	_, state := c.ensureReasoningState(itemID)
 	if state.done || state.rawSeen {
 		return nil
@@ -476,27 +504,7 @@ func (c *streamConverter) reasoningTextDelta(itemID, delta string) error {
 	return c.emitReasoningDelta(delta)
 }
 
-// trackReasoningRepeat 统计连续相同的推理增量，超过推理阈值则终止流。
-func (c *streamConverter) trackReasoningRepeat(delta, message string) error {
-	if delta == "" {
-		return nil
-	}
-	if delta != c.lastReasonDelta {
-		c.lastReasonDelta = delta
-		c.reasonRepeatCount = 0
-		return nil
-	}
-	c.reasonRepeatCount++
-	if c.reasonRepeatCount >= reasoningDoomLoopThreshold {
-		return fmt.Errorf("%s (repeated delta %d times)", message, c.reasonRepeatCount)
-	}
-	return nil
-}
-
 func (c *streamConverter) emitReasoningDelta(delta string) error {
-	if err := c.trackReasoningRepeat(delta, "model reasoning loop detected"); err != nil {
-		return err
-	}
 	if c.operation == OperationChat {
 		return c.chatDelta(map[string]any{"reasoning_content": delta})
 	}
@@ -616,19 +624,6 @@ func (c *streamConverter) start() error {
 }
 
 func (c *streamConverter) textDelta(delta string) error {
-	// 循环检测：可见内容重复超过阈值时以错误终止流，避免循环耗尽账号配额
-	// 与客户端上下文窗口。推理增量使用独立且更高的计数器。
-	if delta != "" {
-		if delta == c.lastContentDelta {
-			c.contentRepeatCount++
-			if c.contentRepeatCount >= contentDoomLoopThreshold {
-				return fmt.Errorf("model output loop detected (repeated content delta %d times)", c.contentRepeatCount)
-			}
-		} else {
-			c.lastContentDelta = delta
-			c.contentRepeatCount = 0
-		}
-	}
 	if c.operation == OperationChat {
 		return c.textDeltaChat(delta)
 	}
@@ -763,4 +758,88 @@ func consumeSSE(source io.Reader, handle func(string, []byte) error) error {
 			return err
 		}
 	}
+}
+
+func parseSSEEvent(event string, data []byte) (string, map[string]json.RawMessage, bool) {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+		return "", nil, false
+	}
+	var root map[string]json.RawMessage
+	if json.Unmarshal(data, &root) != nil {
+		return "", nil, false
+	}
+	typeName := event
+	if typeName == "" {
+		_ = json.Unmarshal(root["type"], &typeName)
+	}
+	return typeName, root, true
+}
+
+func (t *streamRepeatTracker) trackEvent(typeName string, root map[string]json.RawMessage) error {
+	var delta string
+	switch typeName {
+	case "response.output_text.delta":
+		_ = json.Unmarshal(root["delta"], &delta)
+		return t.trackContent(delta)
+	case "response.reasoning_summary_text.delta":
+		_ = json.Unmarshal(root["delta"], &delta)
+		return t.trackReasoning(delta, "model reasoning summary loop detected")
+	case "response.reasoning_text.delta":
+		_ = json.Unmarshal(root["delta"], &delta)
+		return t.trackReasoning(delta, "model reasoning loop detected")
+	default:
+		return nil
+	}
+}
+
+func (t *streamRepeatTracker) trackContent(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	if delta != t.lastContentDelta {
+		t.lastContentDelta = delta
+		t.contentRepeatCount = 1
+		return nil
+	}
+	t.contentRepeatCount++
+	if t.contentRepeatCount > contentDoomLoopThreshold {
+		return fmt.Errorf("model output loop detected (repeated content delta %d times)", t.contentRepeatCount)
+	}
+	return nil
+}
+
+func (t *streamRepeatTracker) trackReasoning(delta, message string) error {
+	if delta == "" {
+		return nil
+	}
+	if delta != t.lastReasonDelta {
+		t.lastReasonDelta = delta
+		t.reasonRepeatCount = 1
+		return nil
+	}
+	t.reasonRepeatCount++
+	if t.reasonRepeatCount > reasoningDoomLoopThreshold {
+		return fmt.Errorf("%s (repeated delta %d times)", message, t.reasonRepeatCount)
+	}
+	return nil
+}
+
+// guardResponseStream 保持 native Responses SSE 的原始字节不变，同时在读取时
+// 解析事件并在检测到循环时关闭上游。
+func guardResponseStream(source io.ReadCloser) io.ReadCloser {
+	reader, writer := io.Pipe()
+	stream := newStreamPipeReadCloser(reader, source)
+	go func() {
+		defer stream.closeSource()
+		tracker := streamRepeatTracker{}
+		err := consumeSSE(io.TeeReader(source, writer), func(event string, data []byte) error {
+			typeName, root, ok := parseSSEEvent(event, data)
+			if !ok {
+				return nil
+			}
+			return tracker.trackEvent(typeName, root)
+		})
+		_ = writer.CloseWithError(err)
+	}()
+	return stream
 }

--- a/backend/internal/infra/provider/conversation/stream_doomloop_test.go
+++ b/backend/internal/infra/provider/conversation/stream_doomloop_test.go
@@ -1,0 +1,159 @@
+package conversation
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// repeatSSE builds an SSE stream that emits the same delta count times using
+// the given event name and payload template.
+func repeatSSE(event, payloadTemplate string, count int, trailer ...string) string {
+	lines := []string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6","status":"in_progress"}}`, "",
+	}
+	for i := 0; i < count; i++ {
+		lines = append(lines, "event: "+event, "data: "+payloadTemplate, "")
+	}
+	lines = append(lines, trailer...)
+	lines = append(lines,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`, "", "")
+	return strings.Join(lines, "\n")
+}
+
+// A visible-content loop is a real quota burn: it must be terminated near the
+// content threshold and must not be allowed to run to the reasoning threshold.
+func TestConvertResponsesStreamTerminatesContentDoomLoop(t *testing.T) {
+	stream := repeatSSE("response.output_text.delta",
+		`{"type":"response.output_text.delta","delta":"loop"}`,
+		contentDoomLoopThreshold+8)
+	_, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+	if err == nil {
+		t.Fatal("repeated visible content must terminate the stream")
+	}
+	if !strings.Contains(err.Error(), "model output loop detected") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Regression: high/xhigh effort reasoning legitimately repeats short tokens
+// ("so", "hmm", "wait", bullet markers) far more often than visible output.
+// A shared counter at the content threshold truncated valid deep-thinking
+// answers, so reasoning must survive well past contentDoomLoopThreshold.
+func TestConvertResponsesStreamKeepsRepeatedReasoningBelowThreshold(t *testing.T) {
+	for _, event := range []string{"response.reasoning_text.delta", "response.reasoning_summary_text.delta"} {
+		t.Run(event, func(t *testing.T) {
+			// Sit between the two ceilings: this run must be fatal for visible
+			// content but survivable for reasoning.
+			repeats := (contentDoomLoopThreshold + reasoningDoomLoopThreshold) / 2
+			if repeats <= contentDoomLoopThreshold || repeats >= reasoningDoomLoopThreshold {
+				t.Fatalf("test invariant broken: %d must sit between %d and %d",
+					repeats, contentDoomLoopThreshold, reasoningDoomLoopThreshold)
+			}
+			stream := repeatSSE(event,
+				fmt.Sprintf(`{"type":%q,"item_id":"rs_1","delta":"hmm"}`, event),
+				repeats,
+				`event: response.output_text.delta`,
+				`data: {"type":"response.output_text.delta","delta":"answer"}`, "")
+			converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+			if err != nil {
+				t.Fatalf("deep reasoning must not be treated as a loop: %v", err)
+			}
+			if !strings.Contains(string(converted), `"content":"answer"`) {
+				t.Fatalf("visible answer was lost: %s", converted)
+			}
+		})
+	}
+}
+
+// The elevated reasoning threshold is a higher ceiling, not an exemption:
+// a runaway reasoning loop still has to be terminated.
+func TestConvertResponsesStreamTerminatesReasoningDoomLoop(t *testing.T) {
+	for _, testCase := range []struct {
+		event string
+		want  string
+	}{
+		{"response.reasoning_text.delta", "model reasoning loop detected"},
+		{"response.reasoning_summary_text.delta", "model reasoning summary loop detected"},
+	} {
+		t.Run(testCase.event, func(t *testing.T) {
+			stream := repeatSSE(testCase.event,
+				fmt.Sprintf(`{"type":%q,"item_id":"rs_1","delta":"hmm"}`, testCase.event),
+				reasoningDoomLoopThreshold+8)
+			_, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+			if err == nil {
+				t.Fatal("a runaway reasoning loop must still terminate the stream")
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// Legitimate visible repetition must survive: markdown horizontal rules and
+// ASCII table borders stream as long runs of an identical single-character
+// delta. This is why the content threshold cannot sit near typical rule width.
+func TestConvertResponsesStreamKeepsMarkdownRuleAndTableBorders(t *testing.T) {
+	for _, testCase := range []struct{ name, delta string }{
+		{"horizontal rule", "-"},
+		{"table border", "="},
+		{"empty table cells", " | "},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// A wide rule or table border comfortably exceeds 32 characters.
+			stream := repeatSSE("response.output_text.delta",
+				fmt.Sprintf(`{"type":"response.output_text.delta","delta":%q}`, testCase.delta),
+				80)
+			converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+			if err != nil {
+				t.Fatalf("legitimate repeated formatting must not be treated as a loop: %v", err)
+			}
+			if !strings.Contains(string(converted), "data: [DONE]") {
+				t.Fatalf("stream did not complete: %s", converted)
+			}
+		})
+	}
+}
+
+// Counters are per-channel and reset on change, so alternating deltas and
+// interleaved reasoning must never accumulate into a false positive.
+func TestConvertResponsesStreamDoomLoopCountersResetAndStaySeparate(t *testing.T) {
+	lines := []string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6","status":"in_progress"}}`, "",
+	}
+	// Alternating visible content never trips the content counter.
+	for i := 0; i < contentDoomLoopThreshold*2; i++ {
+		delta := "a"
+		if i%2 == 1 {
+			delta = "b"
+		}
+		lines = append(lines,
+			`event: response.output_text.delta`,
+			fmt.Sprintf(`data: {"type":"response.output_text.delta","delta":%q}`, delta), "")
+	}
+	// Reasoning repeats interleaved with distinct content must not share a
+	// counter: the reasoning run alone exceeds the content threshold.
+	for i := 0; i < contentDoomLoopThreshold*2; i++ {
+		lines = append(lines,
+			`event: response.reasoning_text.delta`,
+			`data: {"type":"response.reasoning_text.delta","item_id":"rs_1","delta":"hmm"}`, "",
+			`event: response.output_text.delta`,
+			fmt.Sprintf(`data: {"type":"response.output_text.delta","delta":"tick%d"}`, i), "")
+	}
+	lines = append(lines,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`, "", "")
+	stream := strings.Join(lines, "\n")
+	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+	if err != nil {
+		t.Fatalf("alternating deltas must not be treated as a loop: %v", err)
+	}
+	if !strings.Contains(string(converted), "data: [DONE]") {
+		t.Fatalf("stream did not complete: %s", converted)
+	}
+}

--- a/backend/internal/infra/provider/conversation/stream_doomloop_test.go
+++ b/backend/internal/infra/provider/conversation/stream_doomloop_test.go
@@ -7,6 +7,20 @@ import (
 	"testing"
 )
 
+type blockingStreamSource struct {
+	closed chan struct{}
+}
+
+func (s *blockingStreamSource) Read([]byte) (int, error) {
+	<-s.closed
+	return 0, io.EOF
+}
+
+func (s *blockingStreamSource) Close() error {
+	close(s.closed)
+	return nil
+}
+
 // repeatSSE builds an SSE stream that emits the same delta count times using
 // the given event name and payload template.
 func repeatSSE(event, payloadTemplate string, count int, trailer ...string) string {
@@ -36,6 +50,47 @@ func TestConvertResponsesStreamTerminatesContentDoomLoop(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "model output loop detected") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConvertResponsesStreamAllowsExactlyContentThreshold(t *testing.T) {
+	stream := repeatSSE("response.output_text.delta",
+		`{"type":"response.output_text.delta","delta":"loop"}`,
+		contentDoomLoopThreshold)
+	converted, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationChat))
+	if err != nil {
+		t.Fatalf("the content ceiling itself must remain valid: %v", err)
+	}
+	if !strings.Contains(string(converted), "data: [DONE]") {
+		t.Fatalf("stream did not complete: %s", converted)
+	}
+}
+
+func TestConvertResponsesStreamProtectsDeferredWebSearchText(t *testing.T) {
+	stream := repeatSSE("response.output_text.delta",
+		`{"type":"response.output_text.delta","delta":"loop"}`,
+		contentDoomLoopThreshold+8)
+	_, err := io.ReadAll(ConvertResponseStreamWithOptions(
+		io.NopCloser(strings.NewReader(stream)),
+		OperationMessages,
+		ResponseOptions{AnthropicWebSearch: true},
+	))
+	if err == nil || !strings.Contains(err.Error(), "model output loop detected") {
+		t.Fatalf("deferred web-search text must retain loop protection: %v", err)
+	}
+}
+
+func TestConvertResponsesStreamProtectsAfterStopSequence(t *testing.T) {
+	stream := repeatSSE("response.output_text.delta",
+		`{"type":"response.output_text.delta","delta":"STOP"}`,
+		contentDoomLoopThreshold+8)
+	_, err := io.ReadAll(ConvertResponseStreamWithOptions(
+		io.NopCloser(strings.NewReader(stream)),
+		OperationChat,
+		ResponseOptions{StopSequences: []string{"STOP"}},
+	))
+	if err == nil || !strings.Contains(err.Error(), "model output loop detected") {
+		t.Fatalf("discarded post-stop deltas must retain loop protection: %v", err)
 	}
 }
 
@@ -89,6 +144,113 @@ func TestConvertResponsesStreamTerminatesReasoningDoomLoop(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), testCase.want) {
 				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestConvertResponsesStreamTracksSuppressedReasoning(t *testing.T) {
+	stream := repeatSSE("response.reasoning_text.delta",
+		`{"type":"response.reasoning_text.delta","item_id":"rs_1","delta":"hmm"}`,
+		reasoningDoomLoopThreshold+8)
+	_, err := io.ReadAll(ConvertResponseStream(io.NopCloser(strings.NewReader(stream)), OperationMessages))
+	if err == nil || !strings.Contains(err.Error(), "model reasoning loop detected") {
+		t.Fatalf("reasoning hidden from the downstream protocol must still be guarded: %v", err)
+	}
+}
+
+func TestConvertResponsesStreamDoesNotCountFlushedSummaryTwice(t *testing.T) {
+	repeats := (contentDoomLoopThreshold + reasoningDoomLoopThreshold) / 2
+	lines := []string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6","status":"in_progress"}}`, "",
+	}
+	for i := 0; i < repeats; i++ {
+		itemID := fmt.Sprintf("rs_%d", i)
+		lines = append(lines,
+			`event: response.reasoning_summary_text.delta`,
+			fmt.Sprintf(`data: {"type":"response.reasoning_summary_text.delta","item_id":%q,"delta":"hmm"}`, itemID), "",
+			`event: response.output_item.done`,
+			fmt.Sprintf(`data: {"type":"response.output_item.done","item":{"id":%q,"type":"reasoning"}}`, itemID), "",
+		)
+	}
+	lines = append(lines,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`, "", "")
+	converted, err := io.ReadAll(ConvertResponseStream(
+		io.NopCloser(strings.NewReader(strings.Join(lines, "\n"))), OperationChat,
+	))
+	if err != nil {
+		t.Fatalf("flushing buffered summaries must not increment the upstream repeat counter: %v", err)
+	}
+	if !strings.Contains(string(converted), "data: [DONE]") {
+		t.Fatalf("stream did not complete: %s", converted)
+	}
+}
+
+func TestConvertResponsesStreamSharesReasoningCounterAcrossEventTypes(t *testing.T) {
+	lines := []string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6","status":"in_progress"}}`, "",
+	}
+	for i := 0; i < reasoningDoomLoopThreshold/2; i++ {
+		lines = append(lines,
+			`event: response.reasoning_summary_text.delta`,
+			`data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","delta":"hmm"}`, "")
+	}
+	for i := 0; i <= reasoningDoomLoopThreshold/2; i++ {
+		lines = append(lines,
+			`event: response.reasoning_text.delta`,
+			`data: {"type":"response.reasoning_text.delta","item_id":"rs_1","delta":"hmm"}`, "")
+	}
+	_, err := io.ReadAll(ConvertResponseStream(
+		io.NopCloser(strings.NewReader(strings.Join(lines, "\n"))), OperationChat,
+	))
+	if err == nil || !strings.Contains(err.Error(), "model reasoning loop detected") {
+		t.Fatalf("summary and raw reasoning must share one upstream counter: %v", err)
+	}
+}
+
+func TestConvertResponseStreamGuardsNativeResponsesWithoutRewriting(t *testing.T) {
+	t.Run("passthrough", func(t *testing.T) {
+		source := ": keep-this-comment\r\n\r\n" + repeatSSE("response.output_text.delta",
+			`{"type":"response.output_text.delta","delta":"answer"}`, 1)
+		converted, err := io.ReadAll(ConvertResponseStream(
+			io.NopCloser(strings.NewReader(source)), OperationResponses,
+		))
+		if err != nil {
+			t.Fatalf("native response passthrough failed: %v", err)
+		}
+		if string(converted) != source {
+			t.Fatalf("native response bytes changed:\nwant %q\n got %q", source, converted)
+		}
+	})
+
+	t.Run("doom loop", func(t *testing.T) {
+		stream := repeatSSE("response.output_text.delta",
+			`{"type":"response.output_text.delta","delta":"loop"}`,
+			contentDoomLoopThreshold+8)
+		_, err := io.ReadAll(ConvertResponseStream(
+			io.NopCloser(strings.NewReader(stream)), OperationResponses,
+		))
+		if err == nil || !strings.Contains(err.Error(), "model output loop detected") {
+			t.Fatalf("native responses must retain loop protection: %v", err)
+		}
+	})
+}
+
+func TestConvertResponseStreamCloseImmediatelyClosesUpstream(t *testing.T) {
+	for _, operation := range []string{OperationChat, OperationResponses} {
+		t.Run(operation, func(t *testing.T) {
+			source := &blockingStreamSource{closed: make(chan struct{})}
+			stream := ConvertResponseStream(source, operation)
+			if err := stream.Close(); err != nil {
+				t.Fatalf("close converted stream: %v", err)
+			}
+			select {
+			case <-source.closed:
+			default:
+				t.Fatal("closing the downstream stream did not close the upstream source")
 			}
 		})
 	}


### PR DESCRIPTION
## Why

A looping upstream stream currently runs until the response budget is exhausted. There is no repetition guard in `ConvertResponseStream`, so a model that gets stuck emitting the same delta burns account quota and fills the client context window before anything stops it.

The naive fix — one shared repeat counter — is worse than no fix for thinking models. `high`/`xhigh` effort reasoning legitimately repeats the same short marker (`"so"`, `"hmm"`, `"wait"`, list bullets) many times in a row while thinking. A single counter tuned low enough to catch a real content loop truncates valid deep-thinking responses instead.

## What changed

Consecutive identical deltas are tracked per channel, and the stream terminates once a channel exceeds its own ceiling:

| channel | ceiling | rationale |
|---|---|---|
| visible content (`textDelta`) | **128** | a real content loop burns quota, so this stays well below the reasoning ceiling |
| reasoning (`reasoningSummaryDelta`, `emitReasoningDelta`) | **256** | deep thinking reuses short markers far more often than visible output does |

Two details worth reviewing:

- **Reasoning shares one counter across both paths.** `reasoningSummaryDelta` (buffered summaries) and `emitReasoningDelta` (raw reasoning) both route through `trackReasoningRepeat`, so a loop that straddles summary and raw events is still caught. The error messages stay distinct for diagnosis.
- **The content ceiling has to clear legitimate visible repetition.** Markdown horizontal rules and ASCII table borders stream as long runs of an identical single-character delta (`"-"`, `"="`, `"|"`), and wide tables with empty cells repeat the same separator delta. A ceiling near typical rule width would kill correct output, which is why 128 rather than something tighter.

Counters reset whenever the delta changes, so alternating or interleaved output cannot accumulate into a false positive. Empty deltas are ignored.

## Tests

`backend/internal/infra/provider/conversation/stream_doomloop_test.go` covers both directions:

- a visible-content loop terminates with `model output loop detected`
- a reasoning run between the two ceilings **survives** and still delivers the visible answer (both reasoning event types)
- a runaway reasoning loop past its own ceiling still terminates — the higher ceiling is a ceiling, not an exemption
- markdown rules and table borders (80 identical deltas) complete normally
- alternating content deltas and reasoning interleaved with distinct content do not trip either counter

The threshold-relative tests derive their repeat counts from the constants and assert the invariant, so they stay meaningful if the ceilings are retuned.

Verified on this branch: `go build ./...`, `go vet`, and the full `go test ./...` suite (62 packages, 0 failures).
