### PR TITLE
fix: add a scoped access-cookie fallback for stripped bearer auth

### DIFF
--- a/backend/internal/transport/http/adminauth/handler.go
+++ b/backend/internal/transport/http/adminauth/handler.go
@@ -11,11 +11,10 @@ import (
 	adminapp "github.com/chenyme/grok2api/backend/internal/application/adminauth"
 	admindomain "github.com/chenyme/grok2api/backend/internal/domain/admin"
 	"github.com/chenyme/grok2api/backend/internal/shared/response"
+	"github.com/chenyme/grok2api/backend/internal/transport/http/adminsession"
 	"github.com/chenyme/grok2api/backend/internal/transport/http/middleware"
 	"github.com/gin-gonic/gin"
 )
-
-const refreshCookieName = "grok2api_admin_refresh"
 
 type Handler struct {
 	service       *adminapp.Service
@@ -81,7 +80,7 @@ func (h *Handler) login(c *gin.Context) {
 		response.Error(c, http.StatusUnauthorized, "invalidCredentials", "管理员账号或密码错误")
 		return
 	}
-	h.setRefreshCookie(c, tokens)
+	h.setSessionCookies(c, tokens)
 	response.Success(c, http.StatusOK, gin.H{"admin": newAdminResponse(adminValue), "tokens": newTokenResponse(tokens)})
 }
 
@@ -101,7 +100,7 @@ func (h *Handler) refresh(c *gin.Context) {
 		return
 	}
 	if request.RefreshToken == "" {
-		request.RefreshToken, _ = c.Cookie(refreshCookieName)
+		request.RefreshToken, _ = c.Cookie(adminsession.RefreshCookieName)
 	}
 	if request.RefreshToken == "" {
 		response.Error(c, http.StatusUnauthorized, "invalidRefreshToken", "刷新会话无效")
@@ -116,7 +115,7 @@ func (h *Handler) refresh(c *gin.Context) {
 		response.Error(c, http.StatusUnauthorized, "invalidRefreshToken", "刷新会话无效")
 		return
 	}
-	h.setRefreshCookie(c, tokens)
+	h.setSessionCookies(c, tokens)
 	response.Success(c, http.StatusOK, newTokenResponse(tokens))
 }
 
@@ -127,14 +126,13 @@ func (h *Handler) logout(c *gin.Context) {
 		return
 	}
 	if request.RefreshToken == "" {
-		request.RefreshToken, _ = c.Cookie(refreshCookieName)
+		request.RefreshToken, _ = c.Cookie(adminsession.RefreshCookieName)
 	}
 	if err := h.service.Logout(c.Request.Context(), request.RefreshToken); err != nil {
 		response.Error(c, http.StatusServiceUnavailable, "authRuntimeUnavailable", "管理员认证服务暂不可用")
 		return
 	}
-	c.SetSameSite(http.SameSiteStrictMode)
-	c.SetCookie(refreshCookieName, "", -1, "/api/admin/v1/auth", "", h.secureCookies || c.Request.TLS != nil, true)
+	h.clearSessionCookies(c)
 	response.Success(c, http.StatusOK, gin.H{"loggedOut": true})
 }
 
@@ -179,11 +177,24 @@ func newTokenResponse(value adminapp.Tokens) tokenResponse {
 	return tokenResponse{AccessToken: value.AccessToken, AccessTokenExpiresAt: value.AccessTokenExpiresAt.Format(time.RFC3339), RefreshTokenExpiresAt: value.RefreshTokenExpiresAt.Format(time.RFC3339)}
 }
 
-func (h *Handler) setRefreshCookie(c *gin.Context, value adminapp.Tokens) {
-	maxAge := int(time.Until(value.RefreshTokenExpiresAt).Seconds())
+func (h *Handler) setSessionCookies(c *gin.Context, value adminapp.Tokens) {
+	secure := h.secureCookies || c.Request.TLS != nil
+	c.SetSameSite(http.SameSiteStrictMode)
+	c.SetCookie(adminsession.AccessCookieName, value.AccessToken, cookieMaxAge(value.AccessTokenExpiresAt), adminsession.AccessCookiePath, "", secure, true)
+	c.SetCookie(adminsession.RefreshCookieName, value.RefreshToken, cookieMaxAge(value.RefreshTokenExpiresAt), adminsession.RefreshCookiePath, "", secure, true)
+}
+
+func (h *Handler) clearSessionCookies(c *gin.Context) {
+	secure := h.secureCookies || c.Request.TLS != nil
+	c.SetSameSite(http.SameSiteStrictMode)
+	c.SetCookie(adminsession.AccessCookieName, "", -1, adminsession.AccessCookiePath, "", secure, true)
+	c.SetCookie(adminsession.RefreshCookieName, "", -1, adminsession.RefreshCookiePath, "", secure, true)
+}
+
+func cookieMaxAge(expiresAt time.Time) int {
+	maxAge := int(time.Until(expiresAt).Seconds())
 	if maxAge < 0 {
 		maxAge = 0
 	}
-	c.SetSameSite(http.SameSiteStrictMode)
-	c.SetCookie(refreshCookieName, value.RefreshToken, maxAge, "/api/admin/v1/auth", "", h.secureCookies || c.Request.TLS != nil, true)
+	return maxAge
 }

--- a/backend/internal/transport/http/adminauth/handler_test.go
+++ b/backend/internal/transport/http/adminauth/handler_test.go
@@ -12,10 +12,12 @@ import (
 	adminapp "github.com/chenyme/grok2api/backend/internal/application/adminauth"
 	"github.com/chenyme/grok2api/backend/internal/infra/persistence/relational"
 	"github.com/chenyme/grok2api/backend/internal/infra/security"
+	"github.com/chenyme/grok2api/backend/internal/transport/http/adminsession"
+	"github.com/chenyme/grok2api/backend/internal/transport/http/middleware"
 	"github.com/gin-gonic/gin"
 )
 
-func TestRefreshUsesHTTPOnlyCookieAndDoesNotExposeToken(t *testing.T) {
+func TestSessionCookiesAuthenticateRefreshAndProtectedRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "auth.db"))
@@ -39,7 +41,12 @@ func TestRefreshUsesHTTPOnlyCookieAndDoesNotExposeToken(t *testing.T) {
 	}
 
 	router := gin.New()
-	NewHandler(service, true).RegisterPublic(router.Group("/api/admin/v1"))
+	handler := NewHandler(service, true)
+	root := router.Group("/api/admin/v1")
+	handler.RegisterPublic(root)
+	protected := root.Group("")
+	protected.Use(middleware.AdminAuth(service))
+	handler.RegisterAuthenticated(protected)
 
 	login := httptest.NewRecorder()
 	loginRequest := httptest.NewRequest(http.MethodPost, "/api/admin/v1/auth/login", strings.NewReader(`{"username":"admin","password":"password123"}`))
@@ -52,14 +59,27 @@ func TestRefreshUsesHTTPOnlyCookieAndDoesNotExposeToken(t *testing.T) {
 		t.Fatalf("login response exposed refresh token: %s", login.Body.String())
 	}
 	cookies := login.Result().Cookies()
-	if len(cookies) != 1 || cookies[0].Name != refreshCookieName || !cookies[0].HttpOnly || !cookies[0].Secure {
-		t.Fatalf("unexpected refresh cookie: %#v", cookies)
+	accessCookie := cookieNamed(cookies, adminsession.AccessCookieName)
+	refreshCookie := cookieNamed(cookies, adminsession.RefreshCookieName)
+	if accessCookie == nil || accessCookie.Path != adminsession.AccessCookiePath || !accessCookie.HttpOnly || !accessCookie.Secure || accessCookie.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("unexpected access cookie: %#v", accessCookie)
+	}
+	if refreshCookie == nil || refreshCookie.Path != adminsession.RefreshCookiePath || !refreshCookie.HttpOnly || !refreshCookie.Secure || refreshCookie.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("unexpected refresh cookie: %#v", refreshCookie)
+	}
+
+	me := httptest.NewRecorder()
+	meRequest := httptest.NewRequest(http.MethodGet, "/api/admin/v1/me", nil)
+	meRequest.AddCookie(accessCookie)
+	router.ServeHTTP(me, meRequest)
+	if me.Code != http.StatusOK {
+		t.Fatalf("cookie-authenticated me status = %d, body = %s", me.Code, me.Body.String())
 	}
 
 	refresh := httptest.NewRecorder()
 	refreshRequest := httptest.NewRequest(http.MethodPost, "/api/admin/v1/auth/refresh", strings.NewReader(`{}`))
 	refreshRequest.Header.Set("Content-Type", "application/json")
-	refreshRequest.AddCookie(cookies[0])
+	refreshRequest.AddCookie(refreshCookie)
 	router.ServeHTTP(refresh, refreshRequest)
 	if refresh.Code != http.StatusOK {
 		t.Fatalf("refresh status = %d, body = %s", refresh.Code, refresh.Body.String())
@@ -67,4 +87,40 @@ func TestRefreshUsesHTTPOnlyCookieAndDoesNotExposeToken(t *testing.T) {
 	if strings.Contains(refresh.Body.String(), `"refreshToken":`) {
 		t.Fatalf("refresh response exposed refresh token: %s", refresh.Body.String())
 	}
+	rotatedAccessCookie := cookieNamed(refresh.Result().Cookies(), adminsession.AccessCookieName)
+	rotatedRefreshCookie := cookieNamed(refresh.Result().Cookies(), adminsession.RefreshCookieName)
+	if rotatedAccessCookie == nil || rotatedRefreshCookie == nil {
+		t.Fatalf("refresh did not rotate both session cookies: %#v", refresh.Result().Cookies())
+	}
+
+	logout := httptest.NewRecorder()
+	logoutRequest := httptest.NewRequest(http.MethodPost, "/api/admin/v1/auth/logout", strings.NewReader(`{}`))
+	logoutRequest.Header.Set("Content-Type", "application/json")
+	logoutRequest.AddCookie(rotatedRefreshCookie)
+	router.ServeHTTP(logout, logoutRequest)
+	if logout.Code != http.StatusOK {
+		t.Fatalf("logout status = %d, body = %s", logout.Code, logout.Body.String())
+	}
+	clearedAccessCookie := cookieNamed(logout.Result().Cookies(), adminsession.AccessCookieName)
+	clearedRefreshCookie := cookieNamed(logout.Result().Cookies(), adminsession.RefreshCookieName)
+	if clearedAccessCookie == nil || clearedAccessCookie.MaxAge >= 0 || clearedRefreshCookie == nil || clearedRefreshCookie.MaxAge >= 0 {
+		t.Fatalf("logout did not clear both session cookies: %#v", logout.Result().Cookies())
+	}
+
+	revoked := httptest.NewRecorder()
+	revokedRequest := httptest.NewRequest(http.MethodGet, "/api/admin/v1/me", nil)
+	revokedRequest.AddCookie(rotatedAccessCookie)
+	router.ServeHTTP(revoked, revokedRequest)
+	if revoked.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked access cookie status = %d, want %d", revoked.Code, http.StatusUnauthorized)
+	}
+}
+
+func cookieNamed(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, cookie := range cookies {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	return nil
 }

--- a/backend/internal/transport/http/adminsession/cookies.go
+++ b/backend/internal/transport/http/adminsession/cookies.go
@@ -1,0 +1,9 @@
+package adminsession
+
+const (
+	AccessCookieName  = "grok2api_admin_access"
+	RefreshCookieName = "grok2api_admin_refresh"
+
+	AccessCookiePath  = "/api/admin/v1"
+	RefreshCookiePath = "/api/admin/v1/auth"
+)

--- a/backend/internal/transport/http/middleware/auth.go
+++ b/backend/internal/transport/http/middleware/auth.go
@@ -4,11 +4,13 @@ import (
 	"crypto/subtle"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/chenyme/grok2api/backend/internal/application/adminauth"
 	clientkeyapp "github.com/chenyme/grok2api/backend/internal/application/clientkey"
 	"github.com/chenyme/grok2api/backend/internal/shared/response"
+	"github.com/chenyme/grok2api/backend/internal/transport/http/adminsession"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,10 +19,10 @@ const (
 	ClientKey = "clientKey"
 )
 
-// AdminAuth 校验管理员 Bearer JWT。
+// AdminAuth 校验管理员 access JWT。
 func AdminAuth(service *adminauth.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		raw, ok := bearerToken(c.GetHeader("Authorization"))
+		raw, ok := adminAccessToken(c.Request)
 		if !ok {
 			response.Error(c, http.StatusUnauthorized, "adminUnauthorized", "管理员登录已失效")
 			return
@@ -37,6 +39,40 @@ func AdminAuth(service *adminauth.Service) gin.HandlerFunc {
 		c.Set(AdminKey, value)
 		c.Next()
 	}
+}
+
+// adminAccessToken prefers the explicit Bearer credential used by the SPA and
+// API clients. The scoped HttpOnly cookie is a browser fallback for deployments
+// whose reverse proxy drops Authorization; unsafe cookie-authenticated requests
+// must still originate from the same host.
+func adminAccessToken(request *http.Request) (string, bool) {
+	header := strings.TrimSpace(request.Header.Get("Authorization"))
+	if header != "" {
+		return bearerToken(header)
+	}
+	cookie, err := request.Cookie(adminsession.AccessCookieName)
+	if err != nil || strings.TrimSpace(cookie.Value) == "" || !adminCookieRequestAllowed(request) {
+		return "", false
+	}
+	return strings.TrimSpace(cookie.Value), true
+}
+
+func adminCookieRequestAllowed(request *http.Request) bool {
+	if fetchSite := strings.ToLower(strings.TrimSpace(request.Header.Get("Sec-Fetch-Site"))); fetchSite != "" {
+		return fetchSite == "same-origin"
+	}
+	switch request.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		// Older browsers may omit Fetch Metadata on same-origin reads. SameSite=Strict,
+		// host-only cookies and the browser same-origin policy remain the fallback.
+		return true
+	}
+	origin := strings.TrimSpace(request.Header.Get("Origin"))
+	parsed, err := url.Parse(origin)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, request.Host)
 }
 
 // QualityGuardAuth accepts only the process-scoped token shared with the

--- a/backend/internal/transport/http/middleware/auth_test.go
+++ b/backend/internal/transport/http/middleware/auth_test.go
@@ -7,8 +7,63 @@ import (
 	"testing"
 
 	clientkeyapp "github.com/chenyme/grok2api/backend/internal/application/clientkey"
+	"github.com/chenyme/grok2api/backend/internal/transport/http/adminsession"
 	"github.com/gin-gonic/gin"
 )
+
+func TestAdminAccessTokenPrefersBearerAndFallsBackToScopedCookie(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/api/admin/v1/models", nil)
+	request.AddCookie(&http.Cookie{Name: adminsession.AccessCookieName, Value: "cookie-token"})
+
+	if token, ok := adminAccessToken(request); !ok || token != "cookie-token" {
+		t.Fatalf("cookie token = %q, ok = %v", token, ok)
+	}
+
+	request.Header.Set("Authorization", "Bearer header-token")
+	if token, ok := adminAccessToken(request); !ok || token != "header-token" {
+		t.Fatalf("header token = %q, ok = %v", token, ok)
+	}
+
+	request.Header.Set("Authorization", "Basic malformed")
+	if token, ok := adminAccessToken(request); ok || token != "" {
+		t.Fatalf("malformed explicit authorization fell back to cookie: token = %q, ok = %v", token, ok)
+	}
+}
+
+func TestAdminAccessCookieRequiresSameOriginForUnsafeRequests(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		method    string
+		origin    string
+		fetchSite string
+		host      string
+		ok        bool
+	}{
+		{name: "safe request", method: http.MethodGet, ok: true},
+		{name: "cross site safe request", method: http.MethodGet, fetchSite: "cross-site", ok: false},
+		{name: "same origin", method: http.MethodPost, origin: "https://admin.example.com", ok: true},
+		{name: "same origin with port", method: http.MethodDelete, origin: "https://admin.example.com:8443", host: "admin.example.com:8443", ok: true},
+		{name: "same origin metadata behind rewritten host", method: http.MethodPost, fetchSite: "same-origin", host: "backend:8000", ok: true},
+		{name: "cross site metadata wins", method: http.MethodPost, origin: "https://admin.example.com", fetchSite: "cross-site", ok: false},
+		{name: "missing origin", method: http.MethodPost, ok: false},
+		{name: "cross origin", method: http.MethodPost, origin: "https://attacker.example.com", ok: false},
+		{name: "opaque origin", method: http.MethodPut, origin: "null", ok: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, "https://admin.example.com/api/admin/v1/models", nil)
+			if test.host != "" {
+				request.Host = test.host
+			}
+			request.Header.Set("Origin", test.origin)
+			request.Header.Set("Sec-Fetch-Site", test.fetchSite)
+			request.AddCookie(&http.Cookie{Name: adminsession.AccessCookieName, Value: "cookie-token"})
+			_, ok := adminAccessToken(request)
+			if ok != test.ok {
+				t.Fatalf("ok = %v, want %v", ok, test.ok)
+			}
+		})
+	}
+}
 
 func TestClientRuntimeStoreFailureUsesServiceUnavailable(t *testing.T) {
 	err := errors.Join(clientkeyapp.ErrRuntimeUnavailable, errors.New("redis unavailable"))


### PR DESCRIPTION

## Summary

- Keep `Authorization: Bearer` as the primary administrator authentication mechanism.
- Add a dedicated short-lived HttpOnly access cookie scoped to `/api/admin/v1`.
- Fall back to the access cookie only when the Authorization header is completely absent.
- Keep the refresh cookie restricted to `/api/admin/v1/auth`.
- Clear both access and refresh cookies during logout.
- Require same-origin Fetch Metadata or Origin validation for cookie-authenticated requests.

## Investigation

The original #982 diagnosis was only partially correct.

The v3.1.4 frontend already stores the access token in memory and injects:

```http
Authorization: Bearer <accessToken>
```

The strings do not appear in the main `index-*.js` bundle because Vite places the shared API client in a separate chunk. Searching only the entry bundle therefore incorrectly suggests that the frontend relies entirely on cookies.

The standard same-origin v3.1.4 flow was verified successfully:

1. Login returns an access token and refresh cookie.
2. Protected admin requests send Bearer authentication.
3. Reloading refreshes the session and restores `/api/admin/v1/me`.
4. Dashboard, model listing, and model synchronization requests authenticate normally.

However, the admin API had only one access-token transport. A reverse proxy that removes `Authorization`, or a mismatched frontend deployment, causes every protected endpoint to return 401 even though the refresh session remains valid.

## Fix

Login and refresh now issue two separate cookies:

- `grok2api_admin_access`
  - Path: `/api/admin/v1`
  - Lifetime: access-token TTL
- `grok2api_admin_refresh`
  - Path: `/api/admin/v1/auth`
  - Lifetime: refresh-token TTL

Both cookies are HttpOnly, host-only, `SameSite=Strict`, and use the existing secure-cookie policy.

The authentication middleware:

1. Prefers an explicit Bearer token.
2. Does not fall back when an explicit Authorization header is malformed or invalid.
3. Uses the access cookie only when Authorization is absent.
4. Rejects cross-site cookie authentication using `Sec-Fetch-Site`.
5. Requires matching Origin/Host information for unsafe legacy-browser requests.

This avoids widening the refresh-token scope or persisting access tokens in localStorage.

## Verification

A local reverse proxy was configured to remove every Authorization header. Through that proxy, a real browser successfully completed:

- administrator login
- dashboard loading
- session restoration
- model listing
- `POST /api/admin/v1/models/sync`

The upstream application recorded HTTP 200 for the protected read and write requests.

Cross-site requests, missing-origin unsafe requests, malformed Authorization headers, session rotation, logout, and revoked-session behavior are covered by tests.

## Test plan

- [x] `go test ./...`
- [x] `go test -race ./internal/transport/http/adminauth ./internal/transport/http/middleware ./internal/transport/http`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `git diff --check`
- [x] Browser verification through an Authorization-stripping reverse proxy