### PR TITLE
fix: refresh Statsig on stale-page media rejection

### DIFF
--- a/backend/internal/infra/provider/web/image.go
+++ b/backend/internal/infra/provider/web/image.go
@@ -1432,8 +1432,18 @@ func (a *Adapter) postJSONWithReferer(ctx context.Context, cfg Config, lease *eg
 				_ = a.invalidateSignedStatsig(http.MethodPost, endpoint)
 				return response, nil
 			}
-			// Structured JSON responses are application policy decisions. They
-			// must not invalidate Clearance, affect egress health, or be replayed.
+			// Code 7 is the application-layer equivalent of reloading the Grok
+			// page: refresh only the path-bound Statsig signature and replay the
+			// explicitly rejected POST once. It is not a Cloudflare challenge, so
+			// the current Clearance lease remains valid.
+			if isStatsigRefreshableMediaError(upstreamErr, body) {
+				if attempt == 0 && a.invalidateSignedStatsig(http.MethodPost, endpoint) {
+					continue
+				}
+				return response, nil
+			}
+			// Remaining structured JSON responses are application policy decisions.
+			// They must not invalidate Clearance, affect egress health, or be replayed.
 			if upstreamErr.bodyKind == "json" || attempt > 0 || !a.invalidateSignedStatsig(http.MethodPost, endpoint) {
 				return response, nil
 			}

--- a/backend/internal/infra/provider/web/protocol_test.go
+++ b/backend/internal/infra/provider/web/protocol_test.go
@@ -1590,6 +1590,99 @@ func TestTextToVideoPayloadMatchesCapturedMediaGenInputShape(t *testing.T) {
 	}
 }
 
+func TestGenerateVideoRefreshesOnlyReloadStatsigForbidden(t *testing.T) {
+	tests := []struct {
+		name             string
+		forbiddenBody    string
+		wantRequestCalls int
+		wantSuccess      bool
+	}{
+		{
+			name:             "page out of date",
+			forbiddenBody:    `{"code":7,"message":"This page is out of date. Reload to continue.","details":[]}`,
+			wantRequestCalls: 2,
+			wantSuccess:      true,
+		},
+		{
+			name:             "content moderation",
+			forbiddenBody:    `{"error":{"code":"content-moderated","message":"rejected"}}`,
+			wantRequestCalls: 1,
+		},
+		{
+			name:             "definitive account block",
+			forbiddenBody:    `{"code":7,"message":"User is blocked [WKE=unauthorized:blocked-user]","details":[]}`,
+			wantRequestCalls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestCalls := 0
+			signerCalls := 0
+			signatures := make([]string, 0, 2)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				switch request.URL.Path {
+				case "/sign":
+					signerCalls++
+					value := base64.RawStdEncoding.EncodeToString(bytes.Repeat([]byte{byte('a' + signerCalls)}, 70))
+					writer.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(writer).Encode(map[string]string{"x-statsig-id": value})
+				case "/rest/app-chat/conversations/new":
+					requestCalls++
+					signatures = append(signatures, request.Header.Get("x-statsig-id"))
+					if requestCalls == 1 {
+						writer.Header().Set("Content-Type", "application/json")
+						writer.WriteHeader(http.StatusForbidden)
+						_, _ = io.WriteString(writer, test.forbiddenBody)
+						return
+					}
+					writer.Header().Set("Content-Type", "text/event-stream")
+					_, _ = io.WriteString(writer, `data: {"result":{"response":{"streamingVideoGenerationResponse":{"progress":100,"videoPostId":"post_1","videoUrl":"/videos/final.mp4"}}}}`+"\n\n")
+				default:
+					http.NotFound(writer, request)
+				}
+			}))
+			defer server.Close()
+
+			cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			encryptedToken, err := cipher.Encrypt("test-sso")
+			if err != nil {
+				t.Fatal(err)
+			}
+			adapter := NewAdapter(Config{
+				BaseURL: server.URL, StatsigMode: "url", StatsigSignerURL: server.URL + "/sign", VideoTimeoutSeconds: 5,
+			}, infraegress.NewManager(egressRepositoryStub{}, cipher), cipher, nil, nil)
+			adapter.statsig.fetchMeta = func(context.Context, string, string, *infraegress.Lease) (string, error) {
+				return "current-page-meta", nil
+			}
+			adapter.statsig.validateEndpoint = func(context.Context, string) error { return nil }
+
+			result, err := adapter.GenerateVideo(context.Background(), provider.VideoRequest{
+				Credential: account.Credential{ID: 1, Provider: account.ProviderWeb, EncryptedAccessToken: encryptedToken},
+				Prompt:     "test", Duration: 5,
+			})
+			if test.wantSuccess {
+				if err != nil || result.URL != "https://assets.grok.com/videos/final.mp4" {
+					t.Fatalf("result=%#v err=%v", result, err)
+				}
+			} else if err == nil {
+				t.Fatal("structured policy rejection unexpectedly succeeded")
+			}
+			if requestCalls != test.wantRequestCalls || signerCalls != test.wantRequestCalls {
+				t.Fatalf("request calls=%d signer calls=%d, want %d", requestCalls, signerCalls, test.wantRequestCalls)
+			}
+			if len(signatures) != test.wantRequestCalls || signatures[0] == "" {
+				t.Fatalf("signatures = %#v", signatures)
+			}
+			if test.wantRequestCalls == 2 && signatures[0] == signatures[1] {
+				t.Fatalf("rejected Statsig signature was reused: %#v", signatures)
+			}
+		})
+	}
+}
+
 func TestParseVideoStreamPreservesUpstreamStatus(t *testing.T) {
 	response := &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("limited"))}
 	_, _, err := parseVideoStream(response, nil)

--- a/backend/internal/infra/provider/web/video.go
+++ b/backend/internal/infra/provider/web/video.go
@@ -54,6 +54,23 @@ func isClearanceRefreshableMediaError(e *webMediaUpstreamError) bool {
 	return e.cloudflareChallenge || e.bodyKind == "empty" || e.bodyKind == "html"
 }
 
+// isStatsigRefreshableMediaError identifies application-layer rejections that
+// tell the browser to reload its page state. Grok uses code 7 for this anti-bot
+// response, but the same code can also wrap a definitive account block; blocked
+// credentials must remain terminal and must not be replayed with a fresh signature.
+func isStatsigRefreshableMediaError(e *webMediaUpstreamError, body []byte) bool {
+	if e == nil || e.status != http.StatusForbidden || e.bodyKind != "json" || provider.IsDefinitiveAccountBlockBody(body) {
+		return false
+	}
+	code, message, structured := extractWebMediaUpstreamErrorFields(body)
+	if !structured {
+		return false
+	}
+	normalized := strings.ToLower(message)
+	return code == "7" || strings.Contains(normalized, "anti-bot") ||
+		strings.Contains(normalized, "page is out of date") || strings.Contains(normalized, "reload to continue")
+}
+
 func (e *webMediaUpstreamError) providerResponse() *provider.Response {
 	if e == nil {
 		return nil


### PR DESCRIPTION
## Summary

- Detect Grok Web media `403 code=7` responses that report `This page is out of date. Reload to continue.`
- Invalidate the path-bound Statsig signature and replay the rejected media request once.
- Keep the current Cloudflare Clearance lease because this is an application-layer rejection, not a Cloudflare challenge.
- Preserve terminal handling for account blocks, content moderation, and other structured policy errors.

## Why

Grok Web may reject video generation when the cached Statsig signature is stale. Previously, the media path returned the 403 directly, causing gateway retries to repeat the same invalid request—sometimes across multiple accounts.

Refreshing only the rejected endpoint’s Statsig signature restores the request without unnecessarily rotating Clearance or retrying non-recoverable policy failures.

## Tests

- stale-page `code=7` response refreshes Statsig and succeeds on one replay
- refreshed request uses a different Statsig signature
- content-moderation 403 is not replayed
- definitive account-block response is not replayed
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Fixes #992