### PR TITLE
fix: reconcile stale Grok Console quota after 429

### DIFF
--- a/backend/internal/app/application.go
+++ b/backend/internal/app/application.go
@@ -631,6 +631,10 @@ func (a *Application) Run(ctx context.Context) error {
 		a.runConsoleUsageMigration(taskCtx)
 		return nil
 	})
+	startBackground("console_quota_stale_catchup", func(taskCtx context.Context) error {
+		a.runConsoleQuotaCatchup(taskCtx)
+		return nil
+	})
 	startBackground("model_catalog_startup_catchup", func(taskCtx context.Context) error {
 		a.runModelCatalogCatchup(taskCtx)
 		return nil

--- a/backend/internal/app/startup.go
+++ b/backend/internal/app/startup.go
@@ -24,6 +24,9 @@ const (
 	webQuotaCatchupEvery       = 30 * time.Minute
 	consoleUsageMigrationEvery = 24 * time.Hour
 	consoleUsageMigrationRetry = 5 * time.Minute
+	consoleQuotaStaleAfter     = 6 * time.Hour
+	consoleQuotaCatchupEvery   = time.Minute
+	consoleQuotaCatchupBatch   = 10
 	modelCatalogStaleAfter     = 24 * time.Hour
 	modelCatalogCatchupEvery   = 6 * time.Hour
 )
@@ -439,6 +442,33 @@ func (a *Application) runConsoleUsageMigration(ctx context.Context) {
 			a.logger.Info("console_usage_migration_completed", "succeeded", succeeded, "failed", failed)
 		}
 		resetTimer(timer, nextRun)
+	}
+}
+
+func (a *Application) runConsoleQuotaCatchup(ctx context.Context) {
+	timer := time.NewTimer(time.Minute)
+	defer timer.Stop()
+	var afterID uint64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		runCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		succeeded, failed, nextAfterID, err := a.accounts.SyncStaleConsoleQuotas(runCtx, time.Now().UTC().Add(-consoleQuotaStaleAfter), afterID, consoleQuotaCatchupBatch)
+		cancel()
+		if err == nil {
+			afterID = nextAfterID
+		}
+		if err != nil && ctx.Err() == nil {
+			a.logger.Warn("console_quota_stale_catchup_failed", "succeeded", succeeded, "failed", failed, "error", err)
+		} else if failed > 0 {
+			a.logger.Warn("console_quota_stale_catchup_incomplete", "succeeded", succeeded, "failed", failed)
+		} else if succeeded > 0 {
+			a.logger.Info("console_quota_stale_catchup_completed", "succeeded", succeeded)
+		}
+		resetTimer(timer, consoleQuotaCatchupEvery)
 	}
 }
 

--- a/backend/internal/application/account/quota_refresh_test.go
+++ b/backend/internal/application/account/quota_refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -360,6 +361,202 @@ func TestRefreshQuotaModeDoesNotTriggerFullProviderSyncForAutoTier(t *testing.T)
 	}
 }
 
+func TestReconcileConsoleRateLimitVerifiesUsageBeforeExhausting(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining int
+		wantState RateLimitReconcileState
+	}{
+		{name: "transient rate limit keeps available quota", remaining: 9, wantState: RateLimitReconcileAvailable},
+		{name: "confirmed zero quota remains exhausted", remaining: 0, wantState: RateLimitReconcileExhausted},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-rate-limit.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = database.Close() })
+			if err := database.InitializeSchema(ctx); err != nil {
+				t.Fatal(err)
+			}
+			accounts := relational.NewAccountRepository(database)
+			credential, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+				Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+				Name: "console-rate-limit", SourceKey: "console-rate-limit", EncryptedAccessToken: "encrypted",
+				Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldSyncedAt := time.Now().UTC().Add(-24 * time.Hour)
+			if err := accounts.ReplaceQuotaWindows(ctx, credential.ID, "", oldSyncedAt, []accountdomain.QuotaWindow{
+				{Mode: "console", Remaining: 10, Total: 10, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+				{Mode: "console_image", Remaining: 5, Total: 5, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+				{Mode: "console_video", Remaining: 2, Total: 2, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			adapter := &rateLimitConsoleQuotaAdapter{remaining: test.remaining}
+			service := NewService(accounts, nil, nil, nil, provider.NewRegistry(adapter), nil, nil)
+			service.SetQuotaRecoveryQueue(memory.NewQuotaRecoveryQueue())
+
+			state, err := service.ReconcileRateLimit(ctx, credential.ID, "console", 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state != test.wantState || adapter.calls.Load() != 1 {
+				t.Fatalf("state=%s calls=%d, want state=%s", state, adapter.calls.Load(), test.wantState)
+			}
+			stored, err := accounts.GetQuotaWindows(ctx, []uint64{credential.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			window, ok := quotaWindowByMode(stored[credential.ID], "console")
+			if !ok || window.Remaining != test.remaining {
+				t.Fatalf("stored Console window = %#v, want remaining=%d", window, test.remaining)
+			}
+		})
+	}
+}
+
+func TestReconcileConsoleRateLimitQueuesRetryWhenUsageProbeFails(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-rate-limit-retry.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+		Name: "console-rate-limit-retry", SourceKey: "console-rate-limit-retry", EncryptedAccessToken: "encrypted",
+		Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := accounts.ReplaceQuotaWindows(ctx, credential.ID, "", now, []accountdomain.QuotaWindow{
+		{Mode: "console", Remaining: 9, Total: 10, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream},
+		{Mode: "console_image", Remaining: 5, Total: 5, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream},
+		{Mode: "console_video", Remaining: 2, Total: 2, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &rateLimitConsoleQuotaAdapter{err: errors.New("usage temporarily rate limited")}
+	service := NewService(accounts, nil, nil, nil, provider.NewRegistry(adapter), nil, nil)
+	if state, err := service.ReconcileRateLimit(ctx, credential.ID, "console", 0); err == nil || state != RateLimitReconcileInconclusive {
+		t.Fatalf("state=%s err=%v", state, err)
+	}
+	stored, err := accounts.GetQuotaWindows(ctx, []uint64{credential.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	window, ok := quotaWindowByMode(stored[credential.ID], "console")
+	if !ok || window.Remaining != 9 {
+		t.Fatalf("failed probe overwrote last snapshot: %#v", window)
+	}
+	service.quotaRefreshMu.Lock()
+	state := service.quotaRefreshes[strconv.FormatUint(credential.ID, 10)+":console"]
+	service.quotaRefreshMu.Unlock()
+	if state == nil || !state.pending {
+		t.Fatalf("retry state = %#v", state)
+	}
+}
+
+func TestReconcileConsoleRateLimitDoesNotQueueWhenAnotherReplicaIsRefreshing(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-rate-limit-busy.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+		Name: "console-rate-limit-busy", SourceKey: "console-rate-limit-busy", EncryptedAccessToken: "encrypted",
+		Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &rateLimitConsoleQuotaAdapter{remaining: 9}
+	service := NewService(accounts, nil, nil, nil, provider.NewRegistry(adapter), nil, nil)
+	service.refreshLock = deniedQuotaRefreshLock{}
+
+	state, err := service.ReconcileRateLimit(ctx, credential.ID, "console", 0)
+	if err != nil || state != RateLimitReconcileRefreshing {
+		t.Fatalf("state=%s err=%v, want refreshing without error", state, err)
+	}
+	if adapter.calls.Load() != 0 {
+		t.Fatalf("busy refresh made %d upstream calls", adapter.calls.Load())
+	}
+	service.quotaRefreshMu.Lock()
+	queued := service.quotaRefreshes[strconv.FormatUint(credential.ID, 10)+":console"]
+	service.quotaRefreshMu.Unlock()
+	if queued != nil {
+		t.Fatalf("busy refresh queued duplicate work: %#v", queued)
+	}
+}
+
+func TestConsoleImmediateAndQueuedRefreshUseSameDistributedLock(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-rate-limit-lock-key.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+		Name: "console-rate-limit-lock-key", SourceKey: "console-rate-limit-lock-key", EncryptedAccessToken: "encrypted",
+		Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSyncedAt := time.Now().UTC().Add(-time.Hour)
+	if err := accounts.ReplaceQuotaWindows(ctx, credential.ID, "", oldSyncedAt, []accountdomain.QuotaWindow{
+		{Mode: "console", Remaining: 9, Total: 10, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+		{Mode: "console_image", Remaining: 5, Total: 5, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+		{Mode: "console_video", Remaining: 2, Total: 2, SyncedAt: &oldSyncedAt, Source: accountdomain.QuotaSourceUpstream},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &rateLimitConsoleQuotaAdapter{err: errors.New("usage temporarily unavailable")}
+	refreshLock := &recordingQuotaRefreshLock{}
+	service := NewService(accounts, nil, nil, nil, provider.NewRegistry(adapter), nil, nil)
+	service.refreshLock = refreshLock
+
+	if state, err := service.ReconcileRateLimit(ctx, credential.ID, "console", 0); err == nil || state != RateLimitReconcileInconclusive {
+		t.Fatalf("state=%s err=%v", state, err)
+	}
+	request := <-service.quotaRefreshQueue
+	service.runQuotaRefresh(ctx, request)
+
+	keys := refreshLock.snapshot()
+	want := consoleQuotaRefreshLockKey(credential.ID)
+	if len(keys) < 2 {
+		t.Fatalf("lock keys = %v, want immediate and queued acquisitions", keys)
+	}
+	for _, key := range keys {
+		if key != want {
+			t.Fatalf("lock key = %q, want %q (all keys: %v)", key, want, keys)
+		}
+	}
+}
+
 func TestRefreshWebImagineQuotaModeAtomicallyReplacesGroup(t *testing.T) {
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "imagine-quota-group.db"))
@@ -630,8 +827,97 @@ func TestSyncIncompleteConsoleQuotasMigratesOnlyLegacySnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if succeeded != 0 || failed != 1 {
+	if succeeded != 1 || failed != 0 {
 		t.Fatalf("locked migration succeeded=%d failed=%d for account %d", succeeded, failed, blockedID)
+	}
+}
+
+func TestSyncStaleConsoleQuotasRefreshesOnlyOldCompleteSnapshots(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-quota-stale.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	now := time.Now().UTC()
+	staleAt := now.Add(-7 * time.Hour)
+	createComplete := func(name string, syncedAt time.Time) uint64 {
+		credential, _, createErr := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+			Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+			Name: name, SourceKey: name, EncryptedAccessToken: "encrypted", Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		if replaceErr := accounts.ReplaceQuotaWindows(ctx, credential.ID, "", syncedAt, []accountdomain.QuotaWindow{
+			{Mode: "console", Remaining: 9, Total: 10, SyncedAt: &syncedAt, Source: accountdomain.QuotaSourceUpstream},
+			{Mode: "console_image", Remaining: 5, Total: 5, SyncedAt: &syncedAt, Source: accountdomain.QuotaSourceUpstream},
+			{Mode: "console_video", Remaining: 2, Total: 2, SyncedAt: &syncedAt, Source: accountdomain.QuotaSourceUpstream},
+		}); replaceErr != nil {
+			t.Fatal(replaceErr)
+		}
+		return credential.ID
+	}
+	staleID := createComplete("stale-console", staleAt)
+	secondStaleID := createComplete("second-stale-console", staleAt)
+	freshID := createComplete("fresh-console", now)
+	legacy, _, err := accounts.UpsertByIdentity(ctx, accountdomain.Credential{
+		Provider: accountdomain.ProviderConsole, AuthType: accountdomain.AuthTypeSSO,
+		Name: "legacy-console", SourceKey: "legacy-console", EncryptedAccessToken: "encrypted", Enabled: true, AuthStatus: accountdomain.AuthStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := accounts.ReplaceQuotaWindows(ctx, legacy.ID, "", staleAt, []accountdomain.QuotaWindow{{
+		Mode: "console", Remaining: 20, Total: 20, SyncedAt: &staleAt, Source: accountdomain.QuotaSourceDefault,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &consoleQuotaSnapshotAdapter{}
+	service := NewService(accounts, nil, nil, nil, provider.NewRegistry(adapter), nil, nil)
+	succeeded, failed, nextAfterID, err := service.SyncStaleConsoleQuotas(ctx, now.Add(-6*time.Hour), 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if succeeded != 1 || failed != 0 || adapter.fullCalls.Load() != 1 {
+		t.Fatalf("catch-up succeeded=%d failed=%d calls=%d", succeeded, failed, adapter.fullCalls.Load())
+	}
+	if nextAfterID != staleID {
+		t.Fatalf("first scan cursor = %d, want %d", nextAfterID, staleID)
+	}
+	succeeded, failed, nextAfterID, err = service.SyncStaleConsoleQuotas(ctx, now.Add(-6*time.Hour), nextAfterID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if succeeded != 1 || failed != 0 || adapter.fullCalls.Load() != 2 {
+		t.Fatalf("second catch-up succeeded=%d failed=%d calls=%d", succeeded, failed, adapter.fullCalls.Load())
+	}
+	if nextAfterID != secondStaleID {
+		t.Fatalf("second scan cursor = %d, want %d", nextAfterID, secondStaleID)
+	}
+	stored, err := accounts.GetQuotaWindows(ctx, []uint64{staleID, secondStaleID, freshID, legacy.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleWindow, _ := quotaWindowByMode(stored[staleID], "console")
+	secondStaleWindow, _ := quotaWindowByMode(stored[secondStaleID], "console")
+	freshWindow, _ := quotaWindowByMode(stored[freshID], "console")
+	if staleWindow.SyncedAt == nil || !staleWindow.SyncedAt.After(now.Add(-6*time.Hour)) {
+		t.Fatalf("stale snapshot was not refreshed: %#v", staleWindow)
+	}
+	if secondStaleWindow.SyncedAt == nil || !secondStaleWindow.SyncedAt.After(now.Add(-6*time.Hour)) {
+		t.Fatalf("second stale snapshot was not refreshed: %#v", secondStaleWindow)
+	}
+	if freshWindow.SyncedAt == nil || !freshWindow.SyncedAt.Equal(now) {
+		t.Fatalf("fresh snapshot was unexpectedly refreshed: %#v", freshWindow)
+	}
+	if completeConsoleUsageSnapshot(stored[legacy.ID]) {
+		t.Fatalf("legacy snapshot must remain owned by migration: %#v", stored[legacy.ID])
 	}
 }
 
@@ -939,6 +1225,24 @@ func (deniedQuotaRefreshLock) Acquire(context.Context, string, time.Duration) (f
 	return nil, false, nil
 }
 
+type recordingQuotaRefreshLock struct {
+	mu   sync.Mutex
+	keys []string
+}
+
+func (l *recordingQuotaRefreshLock) Acquire(_ context.Context, key string, _ time.Duration) (func(), bool, error) {
+	l.mu.Lock()
+	l.keys = append(l.keys, key)
+	l.mu.Unlock()
+	return func() {}, true, nil
+}
+
+func (l *recordingQuotaRefreshLock) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.keys...)
+}
+
 type quotaCountingAdapter struct {
 	modeCalls     atomic.Int64
 	fullCalls     atomic.Int64
@@ -1025,6 +1329,40 @@ type consoleQuotaSnapshotAdapter struct {
 	modeCalls   atomic.Int64
 	fullStarted chan struct{}
 	fullRelease chan struct{}
+}
+
+type rateLimitConsoleQuotaAdapter struct {
+	calls     atomic.Int64
+	remaining int
+	err       error
+}
+
+func (a *rateLimitConsoleQuotaAdapter) Provider() accountdomain.Provider {
+	return accountdomain.ProviderConsole
+}
+
+func (a *rateLimitConsoleQuotaAdapter) Definition() provider.Definition {
+	return provider.Definition{
+		Provider: accountdomain.ProviderConsole, ModelNamespace: accountdomain.ProviderConsole.ModelNamespace(),
+		Quota: provider.QuotaRemoteWindow, Credential: provider.CredentialSurface{AuthType: accountdomain.AuthTypeSSO},
+	}
+}
+
+func (a *rateLimitConsoleQuotaAdapter) SyncQuota(_ context.Context, credential accountdomain.Credential) (provider.QuotaSnapshot, error) {
+	a.calls.Add(1)
+	if a.err != nil {
+		return provider.QuotaSnapshot{}, a.err
+	}
+	now := time.Now().UTC()
+	return provider.QuotaSnapshot{SyncedAt: now, Windows: []accountdomain.QuotaWindow{
+		{AccountID: credential.ID, Mode: "console", Remaining: a.remaining, Total: 10, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream, UpdatedAt: now},
+		{AccountID: credential.ID, Mode: "console_image", Remaining: 5, Total: 5, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream, UpdatedAt: now},
+		{AccountID: credential.ID, Mode: "console_video", Remaining: 2, Total: 2, SyncedAt: &now, Source: accountdomain.QuotaSourceUpstream, UpdatedAt: now},
+	}}, nil
+}
+
+func (a *rateLimitConsoleQuotaAdapter) SyncQuotaMode(context.Context, accountdomain.Credential, string) (accountdomain.QuotaWindow, error) {
+	return accountdomain.QuotaWindow{}, errors.New("unexpected single-mode Console sync")
 }
 
 func (a *consoleQuotaSnapshotAdapter) Provider() accountdomain.Provider {

--- a/backend/internal/application/account/service.go
+++ b/backend/internal/application/account/service.go
@@ -46,6 +46,15 @@ var (
 var ErrCredentialRefreshPermanent = errors.New("OAuth refresh token 已永久失效")
 var errQuotaRefreshBusy = errors.New("额度同步已由其他实例执行")
 
+type RateLimitReconcileState string
+
+const (
+	RateLimitReconcileInconclusive RateLimitReconcileState = "inconclusive"
+	RateLimitReconcileRefreshing   RateLimitReconcileState = "refreshing"
+	RateLimitReconcileAvailable    RateLimitReconcileState = "available"
+	RateLimitReconcileExhausted    RateLimitReconcileState = "exhausted"
+)
+
 const (
 	// estimatedFreeTokenLimit is only a fallback until an upstream exhaustion
 	// response supplies the account-specific actual/limit pair.
@@ -3019,14 +3028,35 @@ func preserveActiveQuotaWindows(existing, incoming []accountdomain.QuotaWindow, 
 	return result
 }
 
-// ReconcileRateLimit 根据额度模式核实 429；Web 周池继续以上游快照为准。
-func (s *Service) ReconcileRateLimit(ctx context.Context, id uint64, mode string, retryAfter time.Duration) (bool, error) {
-	if mode == "weekly" {
-		window, err := s.RefreshQuotaMode(ctx, id, mode)
-		if err != nil {
-			return false, err
+// ReconcileRateLimit 根据额度模式核实 429。Web 周池和 Console
+// 均以上游快照为准；Console 的 resource-exhausted 还可能表示瞬时
+// RPS/RPM 限流，不能在未查询 /usage 时直接将账号冻结 24 小时。
+func (s *Service) ReconcileRateLimit(ctx context.Context, id uint64, mode string, retryAfter time.Duration) (RateLimitReconcileState, error) {
+	if mode == "weekly" || isConsoleUsageQuotaMode(mode) {
+		var window accountdomain.QuotaWindow
+		var err error
+		if isConsoleUsageQuotaMode(mode) {
+			window, err = s.refreshConsoleQuotaModeLocked(ctx, id, mode)
+		} else {
+			window, err = s.RefreshQuotaMode(ctx, id, mode)
 		}
-		return window.Remaining == 0 || window.UsagePercent >= 100, nil
+		if err != nil {
+			if isConsoleUsageQuotaMode(mode) {
+				if errors.Is(err, errQuotaRefreshBusy) {
+					return RateLimitReconcileRefreshing, nil
+				}
+				// Keep the last known snapshot on an inconclusive probe and let the
+				// bounded refresh worker retry. The gateway will still apply its normal
+				// account cooldown and rotate this request to another account.
+				s.QueueQuotaRefresh(id, mode)
+				s.logger.Warn("console_rate_limit_quota_probe_failed", "account_id", id, "mode", mode, "error", err)
+			}
+			return RateLimitReconcileInconclusive, err
+		}
+		if window.Remaining == 0 || window.UsagePercent >= 100 {
+			return RateLimitReconcileExhausted, nil
+		}
+		return RateLimitReconcileAvailable, nil
 	}
 	var resetAt *time.Time
 	if retryAfter > 0 {
@@ -3034,13 +3064,14 @@ func (s *Service) ReconcileRateLimit(ctx context.Context, id uint64, mode string
 		resetAt = &value
 	}
 	if err := s.ExhaustQuota(ctx, id, mode, resetAt); err != nil {
-		return false, err
+		return RateLimitReconcileInconclusive, err
 	}
-	return true, nil
+	return RateLimitReconcileExhausted, nil
 }
 
 func (s *Service) ReconcileWebRateLimit(ctx context.Context, id uint64, mode string, retryAfter time.Duration) (bool, error) {
-	return s.ReconcileRateLimit(ctx, id, mode, retryAfter)
+	state, err := s.ReconcileRateLimit(ctx, id, mode, retryAfter)
+	return state == RateLimitReconcileExhausted, err
 }
 
 func (s *Service) RefreshQuotaMode(ctx context.Context, id uint64, mode string) (accountdomain.QuotaWindow, error) {
@@ -3501,13 +3532,13 @@ func (s *Service) runQuotaRefresh(parent context.Context, request quotaRefreshRe
 		acquired := true
 		var release func()
 		if !skipUpstream && s.refreshLock != nil {
-			effectiveKey := strconv.FormatUint(request.accountID, 10) + ":" + refreshMode
+			lockKey := "quota-refresh:" + strconv.FormatUint(request.accountID, 10) + ":" + refreshMode
 			if consoleMode {
 				// Every Console mode reads the same /usage snapshot. Serialize all
 				// three kinds across instances to avoid duplicate upstream probes.
-				effectiveKey = "console:" + strconv.FormatUint(request.accountID, 10)
+				lockKey = consoleQuotaRefreshLockKey(request.accountID)
 			}
-			release, acquired, refreshErr = s.refreshLock.Acquire(ctx, "quota-refresh:"+effectiveKey, quotaRefreshTimeout)
+			release, acquired, refreshErr = s.refreshLock.Acquire(ctx, lockKey, quotaRefreshTimeout)
 		}
 		if !skipUpstream && refreshErr == nil && acquired {
 			if err := s.syncPool.Do(ctx, func(workCtx context.Context) error {
@@ -3856,23 +3887,7 @@ func (s *Service) SyncIncompleteConsoleQuotas(ctx context.Context) (int, int, er
 		}
 		var batchSucceeded, batchFailed int
 		if len(pending) > 0 {
-			batchSucceeded, batchFailed, err = s.runAccountBatch(ctx, "console_usage_migration", pending, s.syncPool, nil, func(workCtx context.Context, id uint64) error {
-				var release func()
-				if s.refreshLock != nil {
-					var acquired bool
-					var lockErr error
-					release, acquired, lockErr = s.refreshLock.Acquire(workCtx, "quota-refresh:"+strconv.FormatUint(id, 10)+":console", 2*quotaRefreshTimeout)
-					if lockErr != nil {
-						return lockErr
-					}
-					if !acquired {
-						return errQuotaRefreshBusy
-					}
-					defer release()
-				}
-				_, refreshErr := s.RefreshQuotaMode(workCtx, id, "console")
-				return refreshErr
-			})
+			batchSucceeded, batchFailed, err = s.syncConsoleQuotaAccounts(ctx, "console_usage_migration", pending)
 		}
 		succeeded += batchSucceeded
 		failed += batchFailed
@@ -3884,6 +3899,110 @@ func (s *Service) SyncIncompleteConsoleQuotas(ctx context.Context) (int, int, er
 			return succeeded, failed, nil
 		}
 	}
+}
+
+// SyncStaleConsoleQuotas refreshes a bounded batch of complete but old /usage
+// snapshots. Active accounts are already refreshed after successful requests;
+// this catch-up covers idle pools without turning a large deployment into a
+// periodic upstream request burst.
+func (s *Service) SyncStaleConsoleQuotas(ctx context.Context, before time.Time, afterID uint64, limit int) (int, int, uint64, error) {
+	if limit <= 0 || limit > accountTaskBatchSize {
+		limit = 50
+	}
+	pending := make([]uint64, 0, limit)
+	nextAfterID := afterID
+	reachedEnd := false
+	for len(pending) < limit {
+		values, _, err := s.accounts.ListProviderAccountBatch(ctx, accountdomain.ProviderConsole, nextAfterID, accountTaskBatchSize)
+		if err != nil {
+			return 0, 0, nextAfterID, err
+		}
+		if len(values) == 0 {
+			reachedEnd = true
+			break
+		}
+		ids := make([]uint64, 0, len(values))
+		for _, value := range values {
+			if value.Enabled && value.AuthStatus == accountdomain.AuthStatusActive {
+				ids = append(ids, value.ID)
+			}
+		}
+		windows, err := s.accounts.GetQuotaWindows(ctx, ids)
+		if err != nil {
+			return 0, 0, nextAfterID, err
+		}
+		for _, value := range values {
+			nextAfterID = value.ID
+			if value.Enabled && value.AuthStatus == accountdomain.AuthStatusActive && staleCompleteConsoleUsageSnapshot(windows[value.ID], before) {
+				pending = append(pending, value.ID)
+				if len(pending) == limit {
+					break
+				}
+			}
+		}
+		if len(values) < accountTaskBatchSize {
+			reachedEnd = len(pending) < limit
+			break
+		}
+	}
+	if reachedEnd {
+		nextAfterID = 0
+	}
+	if len(pending) == 0 {
+		return 0, 0, nextAfterID, nil
+	}
+	succeeded, failed, err := s.syncConsoleQuotaAccounts(ctx, "console_quota_stale_catchup", pending)
+	return succeeded, failed, nextAfterID, err
+}
+
+func staleCompleteConsoleUsageSnapshot(windows []accountdomain.QuotaWindow, before time.Time) bool {
+	if !completeConsoleUsageSnapshot(windows) {
+		return false
+	}
+	for _, window := range windows {
+		if !isConsoleUsageQuotaMode(window.Mode) {
+			continue
+		}
+		if window.SyncedAt == nil || window.SyncedAt.Before(before) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) syncConsoleQuotaAccounts(ctx context.Context, operation string, ids []uint64) (int, int, error) {
+	return s.runAccountBatch(ctx, operation, ids, s.syncPool, nil, func(workCtx context.Context, id uint64) error {
+		_, refreshErr := s.refreshConsoleQuotaModeLocked(workCtx, id, "console")
+		if errors.Is(refreshErr, errQuotaRefreshBusy) {
+			// Another replica already owns the refresh. Treat that as accepted work:
+			// queuing the same account locally only creates a trailing duplicate probe.
+			return nil
+		}
+		if refreshErr != nil && workCtx.Err() == nil {
+			s.QueueQuotaRefresh(id, "console")
+		}
+		return refreshErr
+	})
+}
+
+func (s *Service) refreshConsoleQuotaModeLocked(ctx context.Context, id uint64, mode string) (accountdomain.QuotaWindow, error) {
+	var release func()
+	if s.refreshLock != nil {
+		acquiredRelease, acquired, err := s.refreshLock.Acquire(ctx, consoleQuotaRefreshLockKey(id), 2*quotaRefreshTimeout)
+		if err != nil {
+			return accountdomain.QuotaWindow{}, err
+		}
+		if !acquired {
+			return accountdomain.QuotaWindow{}, errQuotaRefreshBusy
+		}
+		release = acquiredRelease
+		defer release()
+	}
+	return s.RefreshQuotaMode(ctx, id, mode)
+}
+
+func consoleQuotaRefreshLockKey(id uint64) string {
+	return "quota-refresh:console:" + strconv.FormatUint(id, 10)
 }
 
 func completeConsoleUsageSnapshot(windows []accountdomain.QuotaWindow) bool {

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	accountapp "github.com/chenyme/grok2api/backend/internal/application/account"
 	"github.com/chenyme/grok2api/backend/internal/domain/account"
 	clientkeydomain "github.com/chenyme/grok2api/backend/internal/domain/clientkey"
 	egressdomain "github.com/chenyme/grok2api/backend/internal/domain/egress"
@@ -1705,6 +1706,74 @@ func TestMarkFailureSoftNetworkCooldown(t *testing.T) {
 	cooldown = reset.CooldownUntil.Sub(before)
 	if cooldown < 4*time.Second || cooldown > 6*time.Second {
 		t.Fatalf("after-success soft cooldown = %s, want ~5s", cooldown)
+	}
+}
+
+func TestConsoleRateLimitReconciliationUsesNonAccumulatingCooldown(t *testing.T) {
+	tests := []struct {
+		name             string
+		status           int
+		state            accountapp.RateLimitReconcileState
+		err              error
+		wantFailureCount int
+	}{
+		{name: "quota confirmed available", status: http.StatusTooManyRequests, state: accountapp.RateLimitReconcileAvailable, wantFailureCount: 3},
+		{name: "another replica refreshing", status: http.StatusTooManyRequests, state: accountapp.RateLimitReconcileRefreshing, wantFailureCount: 3},
+		{name: "quota probe inconclusive", status: http.StatusTooManyRequests, state: accountapp.RateLimitReconcileInconclusive, err: errors.New("usage probe failed"), wantFailureCount: 3},
+		{name: "payment failure keeps hard penalty", status: http.StatusPaymentRequired, state: accountapp.RateLimitReconcileAvailable, wantFailureCount: 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "console-rate-limit-soft.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = database.Close() })
+			if err := database.InitializeSchema(ctx); err != nil {
+				t.Fatal(err)
+			}
+			accounts := relational.NewAccountRepository(database)
+			credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+				Provider: account.ProviderConsole, AuthType: account.AuthTypeSSO,
+				Name: "console-soft", SourceKey: "console-soft", EncryptedAccessToken: "encrypted",
+				Enabled: true, AuthStatus: account.AuthStatusActive,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := accounts.UpdateHealth(ctx, credential.ID, credential.Provider, 3, nil, "prior failures", false); err != nil {
+				t.Fatal(err)
+			}
+			credential, err = accounts.Get(ctx, credential.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, 30*time.Second, 30*time.Minute, 500*time.Millisecond)
+			service := &Service{selector: selector}
+			before := time.Now().UTC()
+
+			service.applyRateLimitReconciliation(ctx, credential, test.status, 12*time.Second, test.state, test.err)
+
+			updated, err := accounts.Get(ctx, credential.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.FailureCount != test.wantFailureCount {
+				t.Fatalf("failure count = %d, want %d", updated.FailureCount, test.wantFailureCount)
+			}
+			if updated.CooldownUntil == nil {
+				t.Fatal("expected Console 429 cooldown")
+			}
+			cooldown := updated.CooldownUntil.Sub(before)
+			if test.status == http.StatusTooManyRequests {
+				if cooldown < 11*time.Second || cooldown > 13*time.Second {
+					t.Fatalf("cooldown = %s, want ~12s", cooldown)
+				}
+			} else if cooldown < 2*time.Minute {
+				t.Fatalf("hard failure cooldown = %s, want at least 2m", cooldown)
+			}
+		})
 	}
 }
 

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1498,9 +1498,9 @@ attemptLoop:
 			}
 			failureHandled := false
 			if lease.QuotaMode != "" && response.StatusCode == http.StatusTooManyRequests {
-				exhausted, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, retryAfter)
-				s.selector.MarkQuotaStateChanged(credential.Provider, credential.ID)
-				failureHandled = reconcileErr == nil && exhausted
+				state, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, retryAfter)
+				s.applyRateLimitReconciliation(ctx, credential, response.StatusCode, retryAfter, state, reconcileErr)
+				failureHandled = true
 			} else if used, limit, exhausted := parseFreeQuotaExhaustion(body); exhausted {
 				// The Free subscription signal is account-scoped, but its billing
 				// period is not a reliable reset promise. Probe again after 24 hours.
@@ -2083,6 +2083,23 @@ func isTerminalRequestForbidden(upstreamProvider accountdomain.Provider, failure
 func forcesAccountFailover(status int, upstreamProvider accountdomain.Provider) bool {
 	return upstreamProvider == accountdomain.ProviderBuild &&
 		(status == http.StatusPaymentRequired || status == http.StatusForbidden || status == http.StatusTooManyRequests)
+}
+
+func (s *Service) applyRateLimitReconciliation(ctx context.Context, credential accountdomain.Credential, status int, retryAfter time.Duration, state accountapp.RateLimitReconcileState, reconcileErr error) {
+	s.selector.MarkQuotaStateChanged(credential.Provider, credential.ID)
+	if reconcileErr == nil && state == accountapp.RateLimitReconcileExhausted {
+		return
+	}
+	if credential.Provider == accountdomain.ProviderConsole && status == http.StatusTooManyRequests {
+		// A Console 429 with available quota, an in-progress cross-instance probe,
+		// or an inconclusive /usage request is transient. Isolate the account for
+		// this Retry-After window without growing its durable failure count.
+		if err := s.selector.markSoftFailure(ctx, credential, status, retryAfter); err != nil {
+			s.logger.Warn("console_rate_limit_soft_cooldown_failed", "account_id", credential.ID, "state", state, "error", err)
+		}
+		return
+	}
+	s.selector.MarkFailure(ctx, credential, status, retryAfter)
 }
 
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/backend/internal/application/gateway/video.go
+++ b/backend/internal/application/gateway/video.go
@@ -669,11 +669,8 @@ func (s *Service) runVideoJob(parent context.Context, job media.Job, route model
 				failureHandled = true
 				retriableCreate = safeCreateFailure && !account.IsBuildSuper(lease.Credential, lease.Billing)
 			case (status == http.StatusPaymentRequired || status == http.StatusTooManyRequests) && lease.QuotaMode != "":
-				exhausted, reconcileErr := s.accounts.ReconcileRateLimit(failureCtx, lease.Credential.ID, lease.QuotaMode, 0)
-				s.selector.MarkQuotaStateChanged(lease.Credential.Provider, lease.Credential.ID)
-				if reconcileErr != nil || !exhausted {
-					s.selector.MarkFailure(failureCtx, lease.Credential, status, 0)
-				}
+				state, reconcileErr := s.accounts.ReconcileRateLimit(failureCtx, lease.Credential.ID, lease.QuotaMode, 0)
+				s.applyRateLimitReconciliation(failureCtx, lease.Credential, status, 0, state, reconcileErr)
 				failureHandled = true
 				retriableCreate = safeCreateFailure
 			case status == http.StatusTooManyRequests || status == http.StatusPaymentRequired:

--- a/backend/internal/application/gateway/voice.go
+++ b/backend/internal/application/gateway/voice.go
@@ -440,11 +440,8 @@ func (s *Service) executeVoice(
 		if response.StatusCode == http.StatusPaymentRequired || response.StatusCode == http.StatusTooManyRequests {
 			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"), time.Now().UTC())
 			if quotaKind, _ := s.providers.QuotaKind(credential.Provider); quotaKind == provider.QuotaRemoteWindow && lease.QuotaMode != "" {
-				exhausted, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, retryAfter)
-				s.selector.MarkQuotaStateChanged(credential.Provider, credential.ID)
-				if reconcileErr != nil || !exhausted {
-					s.selector.MarkFailure(ctx, credential, response.StatusCode, retryAfter)
-				}
+				state, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, retryAfter)
+				s.applyRateLimitReconciliation(ctx, credential, response.StatusCode, retryAfter, state, reconcileErr)
 			} else {
 				s.selector.MarkFailure(ctx, credential, response.StatusCode, retryAfter)
 			}

--- a/backend/internal/application/gateway/voice_ws.go
+++ b/backend/internal/application/gateway/voice_ws.go
@@ -179,11 +179,8 @@ func (s *Service) OpenVoiceWebSocket(ctx context.Context, input VoiceWebSocketIn
 					continue
 				case status == http.StatusPaymentRequired || status == http.StatusTooManyRequests:
 					if quotaKind, _ := s.providers.QuotaKind(credential.Provider); quotaKind == provider.QuotaRemoteWindow && lease.QuotaMode != "" {
-						exhausted, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, failure.RetryAfter)
-						s.selector.MarkQuotaStateChanged(credential.Provider, credential.ID)
-						if reconcileErr != nil || !exhausted {
-							s.selector.MarkFailure(ctx, credential, status, failure.RetryAfter)
-						}
+						state, reconcileErr := s.accounts.ReconcileRateLimit(ctx, credential.ID, lease.QuotaMode, failure.RetryAfter)
+						s.applyRateLimitReconciliation(ctx, credential, status, failure.RetryAfter, state, reconcileErr)
 					} else {
 						s.selector.MarkFailure(ctx, credential, status, failure.RetryAfter)
 					}


### PR DESCRIPTION
## Summary

- Reconcile Grok Console 429 responses against the upstream `/usage` snapshot before treating an account as quota-exhausted.
- Distinguish available, exhausted, refreshing, and inconclusive reconciliation results.
- Apply a non-accumulating `Retry-After` cooldown when Console quota remains available.
- Preserve the last valid snapshot and enqueue a bounded retry when the usage probe fails.
- Refresh complete Console quota snapshots older than 6 hours in batches of 10 accounts per minute.
- Use one distributed-lock namespace for immediate, queued, migration, and stale-quota refresh paths.

## Why

A Console `resource_exhausted` 429 does not always mean the account has depleted its weekly quota. It may also represent a transient upstream rate limit.

Previously, routing could continue using an old quota snapshot while repeatedly applying account failure penalties. This caused accounts with remaining quota to enter increasingly long cooldowns, and switching accounts could reproduce the same failure across the pool.

## Behavior

- Confirmed remaining quota: temporarily cool the account down without increasing `failure_count`, then allow normal account rotation.
- Confirmed exhausted quota: persist the refreshed quota window and exclude the account through quota routing.
- Probe failure: preserve the previous snapshot and queue a retry.
- Refresh already running on another replica: do not enqueue duplicate work or report a synchronization failure.
- HTTP 402 behavior is unchanged and continues to use the existing hard-failure policy.

## Tests

Added coverage for:

- Console 429 with remaining quota
- confirmed quota exhaustion
- failed usage probes preserving the previous snapshot
- retry scheduling after probe failures
- distributed-lock contention without duplicate queuing
- identical lock keys across immediate and queued refresh paths
- bounded stale-snapshot catch-up
- non-accumulating Console 429 cooldowns
- unchanged hard-failure handling for HTTP 402

Verified with:

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`