### PR TITLE
perf: paginate nodes and reduce status polling overhead

### DIFF
--- a/backend/internal/transport/http/egress/handler.go
+++ b/backend/internal/transport/http/egress/handler.go
@@ -28,6 +28,8 @@ type Handler struct {
 	guardStatePath  string
 	guardConfigPath string
 	guardProbe      egressapp.QualityProbeInput
+	guardStateMu    sync.Mutex
+	guardStateCache qualityGuardStateCache
 	profilesMu      sync.Mutex
 }
 
@@ -119,6 +121,20 @@ type qualityGuardState struct {
 	Nodes             map[string]qualityGuardNodeState `json:"nodes"`
 	RecentEvents      []qualityGuardEvent              `json:"recent_events"`
 	Statistics        qualityGuardStatistics           `json:"statistics"`
+	NodeSummary       qualityGuardNodeSummary          `json:"-"`
+}
+
+type qualityGuardNodeSummary struct {
+	Total             int
+	Quarantined       int
+	QuarantinedLeases int
+}
+
+type qualityGuardStateCache struct {
+	path     string
+	fileInfo os.FileInfo
+	state    qualityGuardState
+	valid    bool
 }
 
 type qualityGuardStatistics struct {
@@ -205,6 +221,14 @@ func (h *Handler) qualityGuardStatus(c *gin.Context) {
 		response.Error(c, http.StatusServiceUnavailable, "qualityGuardUnavailable", "质量守护状态暂不可用")
 		return
 	}
+	nodes := state.Nodes
+	if nodeIDs, filtered := c.GetQueryArray("nodeId"); filtered {
+		nodes, err = selectedQualityGuardNodes(state.Nodes, nodeIDs)
+		if err != nil {
+			response.Error(c, http.StatusBadRequest, "invalidNodeIds", err.Error())
+			return
+		}
+	}
 	payload := gin.H{
 		"available":         true,
 		"editable":          h.guardConfigPath != "",
@@ -221,7 +245,10 @@ func (h *Handler) qualityGuardStatus(c *gin.Context) {
 			"min_healthy_nodes": state.Guard.MinHealthyNodes, "max_output_tokens": state.Guard.MaxOutputTokens,
 			"fail_closed": state.Guard.FailClosed, "min_generation_ms": state.Guard.MinGenerationMS,
 		},
-		"nodes": state.Nodes, "protectedNodeIds": state.ProtectedNodeIDs, "recentEvents": state.RecentEvents,
+		"nodes": nodes, "protectedNodeIds": state.ProtectedNodeIDs, "recentEvents": state.RecentEvents,
+		"nodeSummary": gin.H{
+			"total": state.NodeSummary.Total, "quarantined": state.NodeSummary.Quarantined, "quarantinedLeases": state.NodeSummary.QuarantinedLeases,
+		},
 	}
 	if state.Statistics.StartedAt > 0 {
 		payload["statistics"] = state.Statistics
@@ -231,6 +258,26 @@ func (h *Handler) qualityGuardStatus(c *gin.Context) {
 		payload["profiles"] = profiles.summaries()
 	}
 	response.Success(c, http.StatusOK, payload)
+}
+
+func selectedQualityGuardNodes(values map[string]qualityGuardNodeState, ids []string) (map[string]qualityGuardNodeState, error) {
+	if len(ids) > 200 {
+		return nil, errors.New("质量守护节点筛选不能超过 200 个")
+	}
+	result := make(map[string]qualityGuardNodeState, len(ids))
+	for _, rawID := range ids {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		if _, err := strconv.ParseUint(id, 10, 64); err != nil {
+			return nil, errors.New("质量守护节点 ID 无效")
+		}
+		if value, ok := values[id]; ok {
+			result[id] = value
+		}
+	}
+	return result, nil
 }
 
 type qualityGuardConfigRequest struct {
@@ -361,11 +408,23 @@ func (h *Handler) readQualityGuardState() (qualityGuardState, bool, error) {
 	file, err := os.Open(h.guardStatePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			h.guardStateMu.Lock()
+			h.guardStateCache = qualityGuardStateCache{}
+			h.guardStateMu.Unlock()
 			return qualityGuardState{}, false, nil
 		}
 		return qualityGuardState{}, true, err
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return qualityGuardState{}, true, errors.New("质量守护状态不可读")
+	}
+	h.guardStateMu.Lock()
+	defer h.guardStateMu.Unlock()
+	if h.guardStateCache.valid && h.guardStateCache.path == h.guardStatePath && os.SameFile(h.guardStateCache.fileInfo, info) && h.guardStateCache.fileInfo.Size() == info.Size() && h.guardStateCache.fileInfo.ModTime().Equal(info.ModTime()) {
+		return h.guardStateCache.state, true, nil
+	}
 	data, err := io.ReadAll(io.LimitReader(file, maxQualityGuardStateBytes+1))
 	if err != nil || len(data) > maxQualityGuardStateBytes {
 		return qualityGuardState{}, true, errors.New("质量守护状态不可读")
@@ -379,6 +438,16 @@ func (h *Handler) readQualityGuardState() (qualityGuardState, bool, error) {
 	}
 	if state.ProtectedNodeIDs == nil {
 		state.ProtectedNodeIDs = []string{}
+	}
+	state.NodeSummary.Total = len(state.Nodes)
+	for _, node := range state.Nodes {
+		if node.DisabledByGuard {
+			state.NodeSummary.Quarantined++
+		}
+		state.NodeSummary.QuarantinedLeases += node.QuarantinedLeases
+	}
+	h.guardStateCache = qualityGuardStateCache{
+		path: h.guardStatePath, fileInfo: info, state: state, valid: true,
 	}
 	return state, true, nil
 }

--- a/backend/internal/transport/http/egress/handler_test.go
+++ b/backend/internal/transport/http/egress/handler_test.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -173,6 +174,70 @@ func TestQualityGuardStatusReadsOnlyPublicState(t *testing.T) {
 	}
 }
 
+func TestQualityGuardStatusFiltersNodeDetailsAndKeepsGlobalSummary(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	state := `{"version":1,"started_at":10,"updated_at":20,"guard":{"mode":"hybrid","model":"grok-4.5","node_ids":["8","9"],"active_interval_seconds":1800,"passive_poll_seconds":5,"soft_tps":500,"hard_tps":1000,"consecutive_soft":2,"consecutive_errors":2,"quarantine_seconds":300,"min_healthy_nodes":1,"max_output_tokens":384},"nodes":{"8":{"active_soft_strikes":0,"passive_soft_strikes":0,"error_strikes":0,"quarantined_until":0,"disabled_by_guard":false,"last_reason":"","last_probe_at":15,"last_observed_at":19,"last_source":"passive","last_classification":"healthy","last_output_tps":42.5,"last_output_tokens":100,"last_first_token_ms":900,"last_duration_ms":4000},"9":{"quarantined_lease_count":2,"active_soft_strikes":0,"passive_soft_strikes":0,"error_strikes":0,"quarantined_until":30,"disabled_by_guard":true,"last_reason":"hard_tps","last_probe_at":16,"last_observed_at":20,"last_source":"active","last_classification":"hard","last_output_tps":5,"last_output_tokens":20,"last_first_token_ms":1200,"last_duration_ms":5000}}}`
+	if err := os.WriteFile(path, []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest("GET", "/egress-quality-guard?nodeId=8", nil)
+	NewHandler(nil, path).qualityGuardStatus(context)
+	if recorder.Code != 200 {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	type statusPayload struct {
+		Data struct {
+			Nodes       map[string]qualityGuardNodeState `json:"nodes"`
+			NodeSummary struct {
+				Total             int `json:"total"`
+				Quarantined       int `json:"quarantined"`
+				QuarantinedLeases int `json:"quarantinedLeases"`
+			} `json:"nodeSummary"`
+		} `json:"data"`
+	}
+	var payload statusPayload
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data.Nodes) != 1 || payload.Data.Nodes["8"].LastClassification != "healthy" {
+		t.Fatalf("filtered nodes = %#v", payload.Data.Nodes)
+	}
+	if payload.Data.NodeSummary.Total != 2 || payload.Data.NodeSummary.Quarantined != 1 || payload.Data.NodeSummary.QuarantinedLeases != 2 {
+		t.Fatalf("node summary = %#v", payload.Data.NodeSummary)
+	}
+
+	emptyRecorder := httptest.NewRecorder()
+	emptyContext, _ := gin.CreateTestContext(emptyRecorder)
+	emptyContext.Request = httptest.NewRequest("GET", "/egress-quality-guard?nodeId=", nil)
+	NewHandler(nil, path).qualityGuardStatus(emptyContext)
+	if emptyRecorder.Code != 200 {
+		t.Fatalf("empty page status=%d body=%s", emptyRecorder.Code, emptyRecorder.Body.String())
+	}
+	var emptyPayload statusPayload
+	if err := json.Unmarshal(emptyRecorder.Body.Bytes(), &emptyPayload); err != nil {
+		t.Fatal(err)
+	}
+	if len(emptyPayload.Data.Nodes) != 0 || emptyPayload.Data.NodeSummary.Total != 2 {
+		t.Fatalf("empty page nodes=%#v summary=%#v", emptyPayload.Data.Nodes, emptyPayload.Data.NodeSummary)
+	}
+}
+
+func TestSelectedQualityGuardNodesRejectsInvalidOrOversizedFilters(t *testing.T) {
+	values := map[string]qualityGuardNodeState{"8": {LastClassification: "healthy"}}
+	if _, err := selectedQualityGuardNodes(values, []string{"not-a-number"}); err == nil {
+		t.Fatal("expected invalid node ID to be rejected")
+	}
+	oversized := make([]string, 201)
+	for index := range oversized {
+		oversized[index] = "8"
+	}
+	if _, err := selectedQualityGuardNodes(values, oversized); err == nil {
+		t.Fatal("expected oversized node filter to be rejected")
+	}
+}
+
 func TestQualityGuardStatusIsOptional(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)
@@ -213,6 +278,72 @@ func TestQualityGuardStateAcceptsBoundedMultiMegabyteState(t *testing.T) {
 	value, available, err := NewHandler(nil, path).readQualityGuardState()
 	if err != nil || !available || value.Guard.Mode != "active" {
 		t.Fatalf("available=%v mode=%q error=%v", available, value.Guard.Mode, err)
+	}
+}
+
+func TestQualityGuardStateCachesUnchangedFileAndRefreshesAfterUpdate(t *testing.T) {
+	path := t.TempDir() + "/state.json"
+	firstJSON := `{"version":1,"updated_at":20,"guard":{"mode":"active"},"nodes":{"8":{"disabled_by_guard":true,"quarantined_lease_count":2}},"recent_events":[{"ts":20,"event":"node_quarantined","node_id":"8"}]}`
+	if err := os.WriteFile(path, []byte(firstJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	handler := NewHandler(nil, path)
+	first, available, err := handler.readQualityGuardState()
+	if err != nil || !available || len(first.RecentEvents) != 1 {
+		t.Fatalf("first read available=%v state=%#v error=%v", available, first, err)
+	}
+	second, available, err := handler.readQualityGuardState()
+	if err != nil || !available || len(second.RecentEvents) != 1 {
+		t.Fatalf("second read available=%v state=%#v error=%v", available, second, err)
+	}
+	if &first.RecentEvents[0] != &second.RecentEvents[0] {
+		t.Fatal("unchanged state was decoded again instead of using the cache")
+	}
+	if second.NodeSummary.Total != 1 || second.NodeSummary.Quarantined != 1 || second.NodeSummary.QuarantinedLeases != 2 {
+		t.Fatalf("cached node summary = %#v", second.NodeSummary)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondJSON := `{"version":1,"updated_at":30,"guard":{"mode":"active"},"nodes":{"9":{"disabled_by_guard":false}},"recent_events":[{"ts":30,"event":"node_restored","node_id":"9"}]}`
+	if err := os.WriteFile(path, []byte(secondJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	updatedTime := info.ModTime().Add(time.Second)
+	if err := os.Chtimes(path, updatedTime, updatedTime); err != nil {
+		t.Fatal(err)
+	}
+	updated, available, err := handler.readQualityGuardState()
+	if err != nil || !available || updated.UpdatedAt != 30 {
+		t.Fatalf("updated read available=%v state=%#v error=%v", available, updated, err)
+	}
+	if updated.NodeSummary.Total != 1 || updated.NodeSummary.Quarantined != 0 || updated.NodeSummary.QuarantinedLeases != 0 {
+		t.Fatalf("updated node summary = %#v", updated.NodeSummary)
+	}
+
+	updatedInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementJSON := `{"version":1,"updated_at":40,"guard":{"mode":"active"},"nodes":{"7":{"disabled_by_guard":false}},"recent_events":[{"ts":40,"event":"node_restored","node_id":"7"}]}`
+	if len(replacementJSON) != len(secondJSON) {
+		t.Fatalf("replacement fixture size = %d, want %d", len(replacementJSON), len(secondJSON))
+	}
+	replacementPath := path + ".replacement"
+	if err := os.WriteFile(replacementPath, []byte(replacementJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(replacementPath, updatedInfo.ModTime(), updatedInfo.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacementPath, path); err != nil {
+		t.Fatal(err)
+	}
+	replaced, available, err := handler.readQualityGuardState()
+	if err != nil || !available || replaced.UpdatedAt != 40 {
+		t.Fatalf("replaced read available=%v state=%#v error=%v", available, replaced, err)
 	}
 }
 

--- a/frontend/src/features/quality-guard/quality-guard-api.ts
+++ b/frontend/src/features/quality-guard/quality-guard-api.ts
@@ -1,5 +1,6 @@
 import { apiRequest } from "@/shared/api/client";
 import { createObjectDecoder, hasShape, isArrayOf, isBoolean, isNumber, isObject, isOneOf, isOptional, isRecordOf, isString } from "@/shared/api/decoder";
+import { qualityGuardStatusPath } from "./quality-guard-query";
 
 export type QualityGuardPolicy = {
   mode: "active" | "passive" | "hybrid";
@@ -108,6 +109,7 @@ export type QualityGuardStatus = {
     min_generation_ms: number;
   };
   nodes?: Record<string, QualityGuardNodeState>;
+  nodeSummary?: { total: number; quarantined: number; quarantinedLeases: number };
   protectedNodeIds?: string[];
   recentEvents?: QualityGuardEvent[];
   statistics?: QualityGuardStatistics;
@@ -158,6 +160,9 @@ const statisticsValidator = hasShape({
   passive: detectionStatsValidator,
   actions: hasShape({ quarantined: isNumber, restored: isNumber, suppressed: isNumber }),
 });
+const nodeSummaryValidator = hasShape({
+  total: isNumber, quarantined: isNumber, quarantinedLeases: isNumber,
+});
 
 const decodeStatus = (value: unknown): QualityGuardStatus => {
   if (hasShape({ available: isBoolean })(value) && (value as QualityGuardStatus).available === false) {
@@ -170,7 +175,7 @@ const decodeStatus = (value: unknown): QualityGuardStatus => {
       id: isString, name: isString, built_in: isBoolean, match_mode: isString, has_expected: isBoolean,
       require_thinking: isBoolean,
     }))),
-    config: configValidator, nodes: isRecordOf(nodeStateValidator),
+    config: configValidator, nodes: isRecordOf(nodeStateValidator), nodeSummary: isOptional(nodeSummaryValidator),
     protectedNodeIds: isOptional(isArrayOf(isString)),
     recentEvents: isArrayOf(eventValidator), statistics: isOptional(statisticsValidator),
   })(value);
@@ -183,8 +188,8 @@ const decodeQualityTest = createObjectDecoder<QualityTestResult>("quality test",
   thinkingRequired: isBoolean,
 });
 
-export function getQualityGuardStatus(): Promise<QualityGuardStatus> {
-  return apiRequest("/api/admin/v1/egress-quality-guard", {}, decodeStatus);
+export function getQualityGuardStatus(nodeIds?: string[]): Promise<QualityGuardStatus> {
+  return apiRequest(qualityGuardStatusPath(nodeIds), {}, decodeStatus);
 }
 
 export function runQualityTest(nodeId: string, status: QualityGuardStatus, profileId?: string): Promise<QualityTestResult> {

--- a/frontend/src/features/quality-guard/quality-guard-page.tsx
+++ b/frontend/src/features/quality-guard/quality-guard-page.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMutation, useQuery, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
-import { Activity, AlertTriangle, BarChart3, Bot, Coins, Eye, Gauge, MoreHorizontal, Pencil, Plus, Power, PowerOff, RefreshCw, RotateCcw, RotateCw, Shield, ShieldCheck, ShieldX, TimerReset, Trash2, Zap } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Activity, AlertTriangle, BarChart3, Bot, Coins, Eye, Gauge, MoreHorizontal, Pencil, Plus, Power, PowerOff, RefreshCw, RotateCcw, RotateCw, Search, Shield, ShieldCheck, ShieldX, TimerReset, Trash2, Zap } from "lucide-react";
+import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -22,12 +22,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DegradeAccountsPanel } from "@/features/quality-guard/degrade-accounts-panel";
 import { ProbeProfilesPanel } from "@/features/quality-guard/probe-profiles-panel";
 import { getQualityGuardStatus, runQualityTest, updateQualityGuardPolicy, type QualityGuardEvent, type QualityGuardNodeState, type QualityGuardPolicy, type QualityGuardStatistics, type QualityGuardStatus, type QualityTestResult } from "@/features/quality-guard/quality-guard-api";
-import { createEgressNode, deleteEgressNodes, listAllEgressNodes, updateEgressNode, updateEgressNodesEnabled, type EgressNodeDTO, type EgressNodeInput } from "@/features/settings/settings-api";
-import { ErrorState } from "@/shared/components/data-state";
+import { createEgressNode, deleteEgressNodes, listEgressNodes, updateEgressNode, updateEgressNodesEnabled, type EgressNodeDTO, type EgressNodeInput } from "@/features/settings/settings-api";
+import { ErrorState, TableLoadingRow } from "@/shared/components/data-state";
+import { DataTableFilters } from "@/shared/components/data-table-filters";
 import { PageHeader } from "@/shared/components/page-header";
+import { Pagination } from "@/shared/components/pagination";
+import { useDebouncedValue } from "@/shared/hooks/use-debounced-value";
 import { cn } from "@/shared/lib/cn";
 
 const NODE_ACTION_TOAST_ID = "quality-guard-node-action";
+const QUALITY_GUARD_PAGE_SIZES = [20, 50, 100] as const;
+type QualityGuardTab = "nodes" | "profiles" | "accounts";
 
 export function QualityGuardPage() {
   const { t, i18n } = useTranslation();
@@ -38,15 +43,49 @@ export function QualityGuardPage() {
   const [nodeForm, setNodeForm] = useState<EgressNodeInput>(emptyNodeInput());
   const [deletingNodes, setDeletingNodes] = useState<EgressNodeDTO[]>([]);
   const [selectedNodeIDs, setSelectedNodeIDs] = useState<Set<string>>(() => new Set());
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [search, setSearch] = useState("");
+  const [enabledFilter, setEnabledFilter] = useState("");
+  const [probeFilter, setProbeFilter] = useState("");
+  const [assignmentFilter, setAssignmentFilter] = useState("");
+  const [activeTab, setActiveTab] = useState<QualityGuardTab>("nodes");
+  const nodesTabActive = activeTab === "nodes";
+  const debouncedSearch = useDebouncedValue(search);
+  const nodesQuery = useQuery({
+    queryKey: ["quality-guard-egress-nodes", "page", page, pageSize, debouncedSearch, enabledFilter, probeFilter, assignmentFilter],
+    queryFn: () => listEgressNodes({
+      page, pageSize, search: debouncedSearch, scope: "grok_build", enabled: enabledFilter,
+      probe: probeFilter, assignment: assignmentFilter,
+    }),
+    placeholderData: keepPreviousData,
+    enabled: nodesTabActive,
+    refetchInterval: nodesTabActive ? 15_000 : false,
+    staleTime: 10_000,
+  });
+  const nodeIDs = nodesTabActive ? nodesQuery.data?.items.map((node) => node.id) ?? [] : [];
   const statusQuery = useQuery({
-    queryKey: ["quality-guard"],
-    queryFn: getQualityGuardStatus,
+    queryKey: ["quality-guard", "nodes", nodeIDs],
+    queryFn: () => getQualityGuardStatus(nodeIDs),
+    placeholderData: keepPreviousData,
     refetchInterval: 5_000,
   });
-  const nodesQuery = useQuery({
-    queryKey: ["quality-guard-egress-nodes"],
-    queryFn: () => listAllEgressNodes({ scope: "grok_build" }),
-    refetchInterval: 15_000,
+  const statusRef = useRef<QualityGuardStatus | undefined>(statusQuery.data);
+  useEffect(() => {
+    statusRef.current = statusQuery.data;
+  }, [statusQuery.data]);
+  const nodeCountsQuery = useQuery({
+    queryKey: ["quality-guard-egress-nodes", "counts"],
+    queryFn: async () => {
+      const [allNodes, enabledNodes] = await Promise.all([
+        listEgressNodes({ page: 1, pageSize: 1, scope: "grok_build" }),
+        listEgressNodes({ page: 1, pageSize: 1, scope: "grok_build", enabled: "enabled" }),
+      ]);
+      return { total: allNodes.total, enabled: enabledNodes.total };
+    },
+    enabled: nodesTabActive,
+    refetchInterval: nodesTabActive ? 30_000 : false,
+    staleTime: 20_000,
   });
   const testMutation = useMutation({
     mutationFn: ({ nodeId, status }: { nodeId: string; status: QualityGuardStatus }) => runQualityTest(nodeId, status),
@@ -57,6 +96,7 @@ export function QualityGuardPage() {
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : t("qualityGuard.testFailed"), { id: NODE_ACTION_TOAST_ID }),
   });
+  const { mutate: mutateTestNode } = testMutation;
 
   const refreshNodeQueries = () => Promise.all([
     queryClient.invalidateQueries({ queryKey: ["quality-guard"] }),
@@ -90,6 +130,7 @@ export function QualityGuardPage() {
     },
     onError: (error) => toast.error(error instanceof Error ? error.message : t("settings.egress.operationFailed"), { id: NODE_ACTION_TOAST_ID }),
   });
+  const { mutate: mutateToggleNode } = toggleNodeMutation;
   const batchToggleMutation = useMutation({
     mutationFn: ({ nodes, enabled }: { nodes: EgressNodeDTO[]; enabled: boolean }) => updateEgressNodesEnabled(nodes.map((node) => node.id), enabled),
     onSuccess: (_, { enabled }) => {
@@ -114,7 +155,7 @@ export function QualityGuardPage() {
     setNodeForm(emptyNodeInput());
     setEditingNode(null);
   };
-  const openEditNode = (node: EgressNodeDTO) => {
+  const openEditNode = useCallback((node: EgressNodeDTO) => {
     setNodeForm({
       name: node.name,
       scope: "grok_build",
@@ -126,9 +167,26 @@ export function QualityGuardPage() {
       cloudflareCookies: "",
     });
     setEditingNode(node);
-  };
+  }, []);
+  const openDeleteNode = useCallback((node: EgressNodeDTO) => setDeletingNodes([node]), []);
+  const testNode = useCallback((nodeId: string) => {
+    const currentStatus = statusRef.current;
+    if (currentStatus?.config) mutateTestNode({ nodeId, status: currentStatus });
+  }, [mutateTestNode]);
+  const toggleNode = useCallback((node: EgressNodeDTO, enabled: boolean) => {
+    mutateToggleNode({ node, enabled });
+  }, [mutateToggleNode]);
+  const toggleSelectedNode = useCallback((nodeId: string, checked: boolean) => setSelectedNodeIDs((current) => {
+    const next = new Set(current);
+    if (checked) next.add(nodeId);
+    else next.delete(nodeId);
+    return next;
+  }), []);
 
-  const refresh = () => void Promise.all([statusQuery.refetch(), nodesQuery.refetch()]);
+  const refresh = () => void (nodesTabActive
+    ? Promise.all([statusQuery.refetch(), nodesQuery.refetch(), nodeCountsQuery.refetch()])
+    : statusQuery.refetch());
+  if (nodesTabActive && nodesQuery.isError && !nodesQuery.data) return <ErrorState message={nodesQuery.error.message} onRetry={refresh} />;
   if (statusQuery.isError && !statusQuery.data) return <ErrorState message={statusQuery.error.message} onRetry={refresh} />;
 
   const status = statusQuery.data;
@@ -138,17 +196,24 @@ export function QualityGuardPage() {
   const selectedNodes = selectableNodes.filter((node) => selectedNodeIDs.has(node.id));
   const allNodesSelected = selectableNodes.length > 0 && selectedNodes.length === selectableNodes.length;
   const toggleAllNodes = (checked: boolean) => setSelectedNodeIDs(checked ? new Set(selectableNodes.map((node) => node.id)) : new Set());
-  const toggleSelectedNode = (node: EgressNodeDTO, checked: boolean) => setSelectedNodeIDs((current) => {
-    const next = new Set(current);
-    if (checked) next.add(node.id);
-    else next.delete(node.id);
-    return next;
-  });
   const fresh = isFresh(status);
   const guardedNodes = status?.nodes ?? {};
-  const quarantined = Object.values(guardedNodes).filter((node) => node.disabled_by_guard).length;
-  const quarantinedLeases = Object.values(guardedNodes).reduce((total, node) => total + (node.quarantined_lease_count ?? 0), 0);
-  const enabled = nodes.filter((node) => node.enabled).length;
+  const quarantined = status?.nodeSummary?.quarantined ?? Object.values(guardedNodes).filter((node) => node.disabled_by_guard).length;
+  const quarantinedLeases = status?.nodeSummary?.quarantinedLeases ?? Object.values(guardedNodes).reduce((total, node) => total + (node.quarantined_lease_count ?? 0), 0);
+  const totalNodes = nodeCountsQuery.data?.total ?? nodesQuery.data?.total ?? nodes.length;
+  const enabledNodes = nodeCountsQuery.data?.enabled;
+  const hasNodeFilters = Boolean(debouncedSearch || enabledFilter || probeFilter || assignmentFilter);
+  const resetNodePage = () => {
+    setPage(1);
+    setSelectedNodeIDs(new Set());
+  };
+  const changeNodePage = (value: number) => {
+    setPage(value);
+    setSelectedNodeIDs(new Set());
+  };
+  const refreshing = statusQuery.isFetching || (nodesTabActive && (nodesQuery.isFetching || nodeCountsQuery.isFetching));
+  const testingNodeID = testMutation.isPending ? testMutation.variables?.nodeId : undefined;
+  const togglingNodeID = toggleNodeMutation.isPending ? toggleNodeMutation.variables?.node.id : undefined;
 
   return (
     <div className="space-y-6">
@@ -156,14 +221,14 @@ export function QualityGuardPage() {
         title={t("qualityGuard.title")}
         description={t("qualityGuard.description")}
         actions={(
-          <Button variant="secondary" size="sm" onClick={refresh} disabled={statusQuery.isFetching || nodesQuery.isFetching}>
-            <RefreshCw className={cn((statusQuery.isFetching || nodesQuery.isFetching) && "animate-spin")} />
+          <Button variant="secondary" size="sm" onClick={refresh} disabled={refreshing}>
+            <RefreshCw className={cn(refreshing && "animate-spin")} />
             {t("common.refresh")}
           </Button>
         )}
       />
 
-      <Tabs defaultValue="nodes">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as QualityGuardTab)}>
         <TabsList>
           <TabsTrigger value="nodes">{t("qualityGuard.nodesTab")}</TabsTrigger>
           <TabsTrigger value="profiles">{t("qualityGuard.profilesTab")}</TabsTrigger>
@@ -186,7 +251,7 @@ export function QualityGuardPage() {
           <section className="grid overflow-hidden rounded-lg bg-card sm:grid-cols-2 xl:grid-cols-4" aria-label={t("qualityGuard.overview")}>
             <Metric icon={fresh ? ShieldCheck : ShieldX} label={t("qualityGuard.serviceStatus")} value={fresh ? t("qualityGuard.running") : t("qualityGuard.stale")} tone={fresh ? "good" : "bad"} />
             <Metric icon={Activity} label={t("qualityGuard.mode")} value={t(`qualityGuard.modes.${status.config?.mode ?? "hybrid"}`)} />
-            <Metric icon={Gauge} label={t("qualityGuard.availableNodes")} value={`${enabled} / ${nodes.length}`} />
+            <Metric icon={Gauge} label={t("qualityGuard.availableNodes")} value={`${enabledNodes ?? "-"} / ${totalNodes}`} />
             <Metric icon={TimerReset} label={t("qualityGuard.quarantinedTargets")} value={String(quarantined + quarantinedLeases)} tone={quarantined || quarantinedLeases ? "bad" : "good"} />
           </section>
 
@@ -210,6 +275,27 @@ export function QualityGuardPage() {
                 <Button type="button" size="sm" onClick={openCreateNode}><Plus />{t("settings.egress.add")}</Button>
               </div>
             </div>
+            <div className="flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:px-5">
+              <div className="relative min-w-0 flex-1 sm:max-w-72">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input className="h-8 pl-9 text-xs" value={search} onChange={(event) => { setSearch(event.target.value); resetNodePage(); }} placeholder={t("settings.egress.search")} aria-label={t("settings.egress.search")} />
+              </div>
+              <DataTableFilters filters={[
+                { id: "enabled", label: t("settings.egress.enabled"), value: enabledFilter, onChange: (value) => { setEnabledFilter(value); resetNodePage(); }, options: [
+                  { value: "enabled", label: t("common.enable") },
+                  { value: "disabled", label: t("common.disable") },
+                ] },
+                { id: "probe", label: t("settings.egress.probe"), value: probeFilter, onChange: (value) => { setProbeFilter(value); resetNodePage(); }, options: [
+                  { value: "healthy", label: t("settings.egress.healthy") },
+                  { value: "unhealthy", label: t("settings.egress.unhealthy") },
+                  { value: "unknown", label: t("settings.egress.notTested") },
+                ] },
+                { id: "assignment", label: t("settings.egress.accounts"), value: assignmentFilter, onChange: (value) => { setAssignmentFilter(value); resetNodePage(); }, options: [
+                  { value: "bound", label: t("settings.egress.assigned") },
+                  { value: "unbound", label: t("settings.egress.unassigned") },
+                ] },
+              ]} />
+            </div>
             <div className="overflow-x-auto">
               <Table className="min-w-[1040px]">
                 <TableHeader><TableRow>
@@ -219,11 +305,14 @@ export function QualityGuardPage() {
                   <TableHead>{t("qualityGuard.source")}</TableHead><TableHead>{t("qualityGuard.strikes")}</TableHead>
                   <TableHead>{t("qualityGuard.lastObserved")}</TableHead><TableHead className="w-48 text-right">{t("common.actions")}</TableHead>
                 </TableRow></TableHeader>
-                <TableBody>
-                  {nodes.map((node) => <NodeRow key={node.id} node={node} protectedNode={protectedNodeIDs.has(node.id)} selected={selectedNodeIDs.has(node.id)} onSelect={(checked) => toggleSelectedNode(node, checked)} state={manualResults[node.id] ?? guardedNodes[node.id]} locale={i18n.language} status={status} testMutation={testMutation} toggleMutation={toggleNodeMutation} onEdit={openEditNode} onDelete={(value) => setDeletingNodes([value])} />)}
-                </TableBody>
+                {nodesQuery.isPending ? <TableBody><TableLoadingRow colSpan={10} /></TableBody> : null}
+                {!nodesQuery.isPending && nodes.length === 0 ? <TableBody><TableRow><TableCell colSpan={10} className="h-24 text-center text-xs text-muted-foreground">{hasNodeFilters ? t("settings.egress.noMatches") : t("common.noData")}</TableCell></TableRow></TableBody> : null}
+                {!nodesQuery.isPending && nodes.length > 0 ? <TableBody>
+                  {nodes.map((node) => <NodeRow key={node.id} node={node} protectedNode={protectedNodeIDs.has(node.id)} selected={selectedNodeIDs.has(node.id)} onSelect={toggleSelectedNode} state={manualResults[node.id] ?? guardedNodes[node.id]} locale={i18n.language} testEnabled={Boolean(status.config)} testing={testingNodeID === node.id} toggling={togglingNodeID === node.id} onTest={testNode} onToggle={toggleNode} onEdit={openEditNode} onDelete={openDeleteNode} />)}
+                </TableBody> : null}
               </Table>
             </div>
+            {nodesQuery.data && nodesQuery.data.total > 0 ? <div className="border-t px-4 py-3 sm:px-5"><Pagination page={nodesQuery.data.page} pageSize={nodesQuery.data.pageSize} total={nodesQuery.data.total} pageSizeOptions={QUALITY_GUARD_PAGE_SIZES} onPageChange={changeNodePage} onPageSizeChange={(value) => { setPageSize(value); resetNodePage(); }} /></div> : null}
           </section>
 
           <div className="grid gap-3 xl:grid-cols-[minmax(0,3fr)_minmax(300px,2fr)]">
@@ -285,13 +374,11 @@ function Metric({ icon: Icon, label, value, tone }: { icon: typeof Activity; lab
   </div>;
 }
 
-function NodeRow({ node, protectedNode, selected, onSelect, state, locale, status, testMutation, toggleMutation, onEdit, onDelete }: { node: EgressNodeDTO; protectedNode: boolean; selected: boolean; onSelect: (checked: boolean) => void; state?: QualityGuardNodeState; locale: string; status: QualityGuardStatus; testMutation: UseMutationResult<QualityTestResult, Error, { nodeId: string; status: QualityGuardStatus }>; toggleMutation: UseMutationResult<{ updated: number }, Error, { node: EgressNodeDTO; enabled: boolean }>; onEdit: (node: EgressNodeDTO) => void; onDelete: (node: EgressNodeDTO) => void }) {
+const NodeRow = memo(function NodeRow({ node, protectedNode, selected, onSelect, state, locale, testEnabled, testing, toggling, onTest, onToggle, onEdit, onDelete }: { node: EgressNodeDTO; protectedNode: boolean; selected: boolean; onSelect: (nodeId: string, checked: boolean) => void; state?: QualityGuardNodeState; locale: string; testEnabled: boolean; testing: boolean; toggling: boolean; onTest: (nodeId: string) => void; onToggle: (node: EgressNodeDTO, enabled: boolean) => void; onEdit: (node: EgressNodeDTO) => void; onDelete: (node: EgressNodeDTO) => void }) {
   const { t } = useTranslation();
-  const testing = testMutation.isPending && testMutation.variables?.nodeId === node.id;
-  const toggling = toggleMutation.isPending && toggleMutation.variables?.node.id === node.id;
   const classification = state?.last_classification || "unknown";
   return <TableRow>
-    <TableCell className="px-3"><Checkbox checked={selected} disabled={protectedNode} onCheckedChange={(checked) => onSelect(checked === true)} aria-label={t("common.selectItem", { name: node.name })} /></TableCell>
+    <TableCell className="px-3"><Checkbox checked={selected} disabled={protectedNode} onCheckedChange={(checked) => onSelect(node.id, checked === true)} aria-label={t("common.selectItem", { name: node.name })} /></TableCell>
     <TableCell><div className="font-medium">{node.name}</div><div className="mt-0.5 text-[11px] text-muted-foreground">ID {node.id}</div></TableCell>
     <TableCell><StateBadge node={node} state={state} protectedNode={protectedNode} /></TableCell>
     <TableCell className="text-right text-xs tabular-nums"><span className="font-medium">{node.assignedAccountCount}</span>{node.accountCapacity > 0 ? <span className="text-muted-foreground"> / {node.accountCapacity}</span> : null}</TableCell>
@@ -301,20 +388,20 @@ function NodeRow({ node, protectedNode, selected, onSelect, state, locale, statu
     <TableCell className="text-xs tabular-nums">{state ? `${state.passive_soft_strikes} / ${state.active_soft_strikes} / ${state.error_strikes}` : "-"}</TableCell>
     <TableCell className="text-xs text-muted-foreground">{formatTime(state?.last_observed_at, locale)}</TableCell>
     <TableCell className="text-right"><div className="flex items-center justify-end gap-1">
-      <Switch checked={node.enabled} disabled={toggling || protectedNode} onCheckedChange={(enabled) => toggleMutation.mutate({ node, enabled })} aria-label={t(node.enabled ? "qualityGuard.disableNode" : "qualityGuard.enableNode", { name: node.name })} />
-      <Button variant="ghost" size="sm" disabled={testing || !status.config || (!node.enabled && !state?.disabled_by_guard)} onClick={() => testMutation.mutate({ nodeId: node.id, status })}><RotateCw className={cn(testing && "animate-spin")} />{t("qualityGuard.test")}</Button>
+      <Switch checked={node.enabled} disabled={toggling || protectedNode} onCheckedChange={(enabled) => onToggle(node, enabled)} aria-label={t(node.enabled ? "qualityGuard.disableNode" : "qualityGuard.enableNode", { name: node.name })} />
+      <Button variant="ghost" size="sm" disabled={testing || !testEnabled || (!node.enabled && !state?.disabled_by_guard)} onClick={() => onTest(node.id)}><RotateCw className={cn(testing && "animate-spin")} />{t("qualityGuard.test")}</Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild><Button type="button" variant="ghost" size="icon" className="size-8" aria-label={t("common.actions")}><MoreHorizontal /></Button></DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={() => onEdit(node)}><Pencil />{t("common.edit")}</DropdownMenuItem>
-          <DropdownMenuItem disabled={toggling || protectedNode} onClick={() => toggleMutation.mutate({ node, enabled: !node.enabled })}>{node.enabled ? <PowerOff /> : <Power />}{t(node.enabled ? "common.disable" : "common.enable")}</DropdownMenuItem>
+          <DropdownMenuItem disabled={toggling || protectedNode} onClick={() => onToggle(node, !node.enabled)}>{node.enabled ? <PowerOff /> : <Power />}{t(node.enabled ? "common.disable" : "common.enable")}</DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem disabled={protectedNode} className="text-destructive focus:text-destructive" onClick={() => onDelete(node)}><Trash2 />{t("common.delete")}</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </div></TableCell>
   </TableRow>;
-}
+});
 
 function NodeEditor({ open, editingNode, form, onFormChange, onOpenChange, onSave, saving }: { open: boolean; editingNode: EgressNodeDTO | null | undefined; form: EgressNodeInput; onFormChange: (form: EgressNodeInput) => void; onOpenChange: (open: boolean) => void; onSave: () => void; saving: boolean }) {
   const { t } = useTranslation();

--- a/frontend/src/features/quality-guard/quality-guard-query.test.ts
+++ b/frontend/src/features/quality-guard/quality-guard-query.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { qualityGuardStatusPath } from "./quality-guard-query.ts";
+
+describe("qualityGuardStatusPath", () => {
+  it("keeps the legacy full-state request when no node filter is supplied", () => {
+    assert.equal(qualityGuardStatusPath(), "/api/admin/v1/egress-quality-guard");
+  });
+
+  it("requests no node details for an empty page", () => {
+    assert.equal(qualityGuardStatusPath([]), "/api/admin/v1/egress-quality-guard?nodeId=");
+  });
+
+  it("limits status details to the current page node IDs", () => {
+    assert.equal(qualityGuardStatusPath(["12", "34"]), "/api/admin/v1/egress-quality-guard?nodeId=12&nodeId=34");
+  });
+});

--- a/frontend/src/features/quality-guard/quality-guard-query.ts
+++ b/frontend/src/features/quality-guard/quality-guard-query.ts
@@ -1,0 +1,9 @@
+const QUALITY_GUARD_STATUS_PATH = "/api/admin/v1/egress-quality-guard";
+
+export function qualityGuardStatusPath(nodeIds?: string[]): string {
+  if (nodeIds === undefined) return QUALITY_GUARD_STATUS_PATH;
+  const query = new URLSearchParams();
+  if (nodeIds.length === 0) query.append("nodeId", "");
+  else nodeIds.forEach((nodeId) => query.append("nodeId", nodeId));
+  return `${QUALITY_GUARD_STATUS_PATH}?${query}`;
+}


### PR DESCRIPTION

## Summary

- Paginate the Quality Guard node table instead of loading every Grok Build egress node.
- Add server-side search and filters for enabled state, probe state, and account assignment.
- Limit Quality Guard status responses to the nodes on the current page while preserving global quarantine totals.
- Cache parsed sidecar state and its node summary until the state file changes.
- Pause node and count polling while a different Quality Guard tab is active.
- Memoize node rows and stabilize action callbacks to avoid unnecessary table-wide rerenders.

## Why

The Quality Guard page previously fetched and rendered the entire node pool. It also returned every node state every five seconds and repeatedly parsed the full sidecar state file.

With large proxy pools, this caused slow initial loading, expensive tab switching, oversized polling responses, and frequent table-wide rerenders.

## Compatibility

Requests without `nodeId` parameters retain the existing full-state response behavior. Existing clients remain compatible.

## Test plan

- [x] Verify pagination, search, and node filters.
- [x] Verify status responses contain only requested node details.
- [x] Verify global quarantine totals remain accurate when node details are filtered.
- [x] Verify empty, invalid, and oversized node filters are handled safely.
- [x] Verify unchanged state files use the parsed cache.
- [x] Verify timestamp changes and atomic file replacement invalidate the cache.
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `go test ./... -count=1`
- [x] Targeted `go test -race`
- [x] `go vet ./...`
- [x] `go build ./...`