### PR TITLE
fix: withhold fake encrypted thinking (ciphertext floor + burst dump)

### DIFF
--- a/backend/internal/app/application.go
+++ b/backend/internal/app/application.go
@@ -491,13 +491,15 @@ func accountAutoCleanConfig(value config.AccountsConfig) accountapp.AutoCleanCon
 
 func qualityRetryRuntime(value config.QualityGuardRequestRetryConfig) gateway.QualityRetryRuntime {
 	return gateway.QualityRetryRuntime{
-		Enabled:             value.Enabled,
-		MaxAttempts:         value.MaxAttempts,
-		HoldTimeout:         value.HoldTimeout.Value(),
-		MinOutputTokens:     int64(value.MinOutputTokens),
-		OnExhausted:         value.OnExhausted,
-		AccountCooldown:     value.AccountCooldown.Value(),
-		IdleAccountCooldown: value.IdleAccountCooldown.Value(),
+		Enabled:                         value.Enabled,
+		MaxAttempts:                     value.MaxAttempts,
+		HoldTimeout:                     value.HoldTimeout.Value(),
+		MinOutputTokens:                 int64(value.MinOutputTokens),
+		OnExhausted:                     value.OnExhausted,
+		AccountCooldown:                 value.AccountCooldown.Value(),
+		IdleAccountCooldown:             value.IdleAccountCooldown.Value(),
+		MinEncryptedBytes:               value.MinEncryptedBytes,
+		EncryptedBytesPerReasoningToken: value.EncryptedBytesPerReasoningToken,
 	}
 }
 

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -17,15 +17,20 @@ import (
 )
 
 const (
-	ErrorQualityDegraded             = "quality_degraded"
-	qualityRetryFailOpen             = "fail_open"
-	qualityRetryFailClosed           = "fail_closed"
-	defaultQualityMaxAttempts        = 6
-	defaultQualityHoldTimeout        = 30 * time.Second
-	defaultQualityMinOutput          = int64(8)
-	defaultMissingThinkingCooldown   = 12 * time.Hour
-	lastErrorMissingThinking         = accountdomain.LastErrorMissingThinking
-	lastErrorMissingThinkingDisabled = accountdomain.LastErrorMissingThinkingDisabled
+	ErrorQualityDegraded                   = "quality_degraded"
+	qualityRetryFailOpen                   = "fail_open"
+	qualityRetryFailClosed                 = "fail_closed"
+	defaultQualityMaxAttempts              = 6
+	defaultQualityHoldTimeout              = 30 * time.Second
+	defaultQualityMinOutput                = int64(8)
+	defaultMinEncryptedBytes               = 256
+	defaultEncryptedBytesPerReasoningToken = 4
+	defaultBurstFlushMS                    = int64(1000)
+	defaultBurstMaxVisible                 = int64(32)
+	defaultBurstMinReasoning               = int64(80)
+	defaultMissingThinkingCooldown         = 12 * time.Hour
+	lastErrorMissingThinking               = accountdomain.LastErrorMissingThinking
+	lastErrorMissingThinkingDisabled       = accountdomain.LastErrorMissingThinkingDisabled
 	// An empty stream that idles while held is treated as an account-quality
 	// failure: the request can still rotate before any bytes reach the client.
 	qualityIdleAccountCooldown = 15 * time.Minute
@@ -47,7 +52,9 @@ type QualityRetryRuntime struct {
 	AccountCooldown time.Duration
 	// IdleAccountCooldown is applied to truly empty upstream streams
 	// (idle timeout / empty peek). Missing-thinking still uses AccountCooldown.
-	IdleAccountCooldown time.Duration
+	IdleAccountCooldown             time.Duration
+	MinEncryptedBytes               int
+	EncryptedBytesPerReasoningToken int
 }
 
 // QualityStreamSignals is the hold classifier input. Tests drive this
@@ -61,6 +68,9 @@ type QualityStreamSignals struct {
 	VisibleTokens    int64
 	ReasoningTokens  int64
 	OutputTokens     int64
+	EncryptedBytes   int
+	FirstVisible     bool
+	VisibleFlushMS   int64
 	Terminal         bool
 	HoldExpired      bool
 }
@@ -100,6 +110,12 @@ func normalizeQualityRetry(cfg QualityRetryRuntime) QualityRetryRuntime {
 	if cfg.IdleAccountCooldown <= 0 {
 		cfg.IdleAccountCooldown = qualityIdleAccountCooldown
 	}
+	if cfg.MinEncryptedBytes <= 0 {
+		cfg.MinEncryptedBytes = defaultMinEncryptedBytes
+	}
+	if cfg.EncryptedBytesPerReasoningToken <= 0 {
+		cfg.EncryptedBytesPerReasoningToken = defaultEncryptedBytesPerReasoningToken
+	}
 	cfg.OnExhausted = normalizeQualityExhaustionPolicy(cfg.OnExhausted)
 	return cfg
 }
@@ -119,12 +135,47 @@ func (s *Service) qualityRetryConfig() QualityRetryRuntime {
 	return normalizeQualityRetry(QualityRetryRuntime{})
 }
 
+// encryptedThinkingFloor is max(minBytes, reasoningTokens*bytesPerToken).
+// A non-empty stub such as "gAAAA-cipher" is not thinking.
+func encryptedThinkingFloor(minBytes, bytesPerToken int, reasoningTokens int64) int {
+	if minBytes <= 0 {
+		minBytes = defaultMinEncryptedBytes
+	}
+	if bytesPerToken <= 0 {
+		bytesPerToken = defaultEncryptedBytesPerReasoningToken
+	}
+	floor := minBytes
+	if reasoningTokens > 0 {
+		need := int(reasoningTokens) * bytesPerToken
+		if need > floor {
+			floor = need
+		}
+	}
+	return floor
+}
+
+func qualityIsBurstDump(sig QualityStreamSignals, minOutput int64) bool {
+	visible := sig.VisibleTokens
+	floor := encryptedThinkingFloor(0, 0, sig.ReasoningTokens)
+	barelyCipher := sig.EncryptedBytes > 0 && sig.EncryptedBytes < floor*2
+	flushed := sig.FirstVisible && sig.VisibleFlushMS >= 0 && sig.VisibleFlushMS < defaultBurstFlushMS
+	// Hold timed out, then a short greeting dumped with a large reasoning bill
+	// (TUI "你好" after 30s / 954 thinking tokens).
+	if sig.HoldExpired && visible > 0 && visible < defaultBurstMaxVisible && sig.ReasoningTokens >= defaultBurstMinReasoning {
+		return true
+	}
+	if barelyCipher && flushed && (visible >= minOutput || sig.ReasoningTokens >= defaultBurstMinReasoning) {
+		return true
+	}
+	return false
+}
+
 // ClassifyQualityHold decides whether a held stream may be forwarded.
-// Streamed thinking always delivers: reasoning/summary deltas, or a
-// reasoning item with encrypted_content. Usage.reasoning_tokens alone
-// does not — degraded upstreams fill that field without ciphertext or
-// deltas. A finished sample with enough visible output and no streamed
-// thinking is withheld.
+// Streamed thinking delivers: reasoning/summary deltas, or a reasoning item
+// whose encrypted_content meets the ciphertext floor. A non-empty stub such
+// as "gAAAA-cipher" is not thinking. Usage.reasoning_tokens alone does not —
+// degraded upstreams fill that field without ciphertext or deltas. A finished
+// sample with enough visible output and no streamed thinking is withheld.
 // Short replies below minOutput are delivered so "ok"/"yes" is not retried.
 // A hold timeout with no visible output is not fail-open: keep waiting for
 // more bytes or a stream abort so an empty hang is not flushed as HTTP 200.
@@ -135,11 +186,16 @@ func (s *Service) qualityRetryConfig() QualityRetryRuntime {
 // release it without penalizing the account. A stub-only empty stream keeps
 // waiting for idle/terminal handling. This keeps HoldTimeout a real latency
 // bound without reopening the empty-stream 200 response path.
+// HasThinking that is only a thin ciphertext dump after the hold (or a
+// barely-over-floor flush in <1s) is still withheld.
 func ClassifyQualityHold(sig QualityStreamSignals, minOutput int64) QualityVerdict {
 	if minOutput <= 0 {
 		minOutput = defaultQualityMinOutput
 	}
 	if sig.HasThinking {
+		if qualityIsBurstDump(sig, minOutput) {
+			return QualityWithhold
+		}
 		return QualityDeliver
 	}
 	// Prefer observed/derived visible output. Total output includes reasoning

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -60,7 +61,8 @@ type QualityRetryRuntime struct {
 // QualityStreamSignals is the hold classifier input. Tests drive this
 // directly and via ObserveQualityChunk on SSE fixtures.
 type QualityStreamSignals struct {
-	HasThinking bool
+	HasThinking       bool
+	HasReasoningDelta bool
 	// ReasoningStarted is an empty reasoning item or the Chat SSE stub
 	// `: grok2api-reasoning-start`. That is not proof of thinking: 降智
 	// still emits the stub, then dumps visible tokens with usage 0.
@@ -69,6 +71,8 @@ type QualityStreamSignals struct {
 	ReasoningTokens  int64
 	OutputTokens     int64
 	EncryptedBytes   int
+	EncryptedFloor   int64
+	UsageReported    bool
 	FirstVisible     bool
 	VisibleFlushMS   int64
 	Terminal         bool
@@ -137,16 +141,19 @@ func (s *Service) qualityRetryConfig() QualityRetryRuntime {
 
 // encryptedThinkingFloor is max(minBytes, reasoningTokens*bytesPerToken).
 // A non-empty stub such as "gAAAA-cipher" is not thinking.
-func encryptedThinkingFloor(minBytes, bytesPerToken int, reasoningTokens int64) int {
+func encryptedThinkingFloor(minBytes, bytesPerToken int, reasoningTokens int64) int64 {
 	if minBytes <= 0 {
 		minBytes = defaultMinEncryptedBytes
 	}
 	if bytesPerToken <= 0 {
 		bytesPerToken = defaultEncryptedBytesPerReasoningToken
 	}
-	floor := minBytes
+	floor := int64(minBytes)
 	if reasoningTokens > 0 {
-		need := int(reasoningTokens) * bytesPerToken
+		if reasoningTokens > math.MaxInt64/int64(bytesPerToken) {
+			return math.MaxInt64
+		}
+		need := reasoningTokens * int64(bytesPerToken)
 		if need > floor {
 			floor = need
 		}
@@ -156,8 +163,15 @@ func encryptedThinkingFloor(minBytes, bytesPerToken int, reasoningTokens int64) 
 
 func qualityIsBurstDump(sig QualityStreamSignals, minOutput int64) bool {
 	visible := sig.VisibleTokens
-	floor := encryptedThinkingFloor(0, 0, sig.ReasoningTokens)
-	barelyCipher := sig.EncryptedBytes > 0 && sig.EncryptedBytes < floor*2
+	floor := sig.EncryptedFloor
+	if floor <= 0 {
+		floor = encryptedThinkingFloor(0, 0, sig.ReasoningTokens)
+	}
+	barelyCeiling := int64(math.MaxInt64)
+	if floor <= math.MaxInt64/2 {
+		barelyCeiling = floor * 2
+	}
+	barelyCipher := sig.EncryptedBytes > 0 && int64(sig.EncryptedBytes) < barelyCeiling
 	flushed := sig.FirstVisible && sig.VisibleFlushMS >= 0 && sig.VisibleFlushMS < defaultBurstFlushMS
 	// Hold timed out, then a short greeting dumped with a large reasoning bill
 	// (TUI "你好" after 30s / 954 thinking tokens).
@@ -192,9 +206,27 @@ func ClassifyQualityHold(sig QualityStreamSignals, minOutput int64) QualityVerdi
 	if minOutput <= 0 {
 		minOutput = defaultQualityMinOutput
 	}
+	// Readable reasoning deltas are direct proof and can preserve the original
+	// low-latency release path. Ciphertext-only evidence remains provisional so
+	// the classifier can observe visible output and terminal usage regardless of
+	// how the SSE events were split across transport reads.
+	if sig.HasReasoningDelta {
+		return QualityDeliver
+	}
 	if sig.HasThinking {
+		if !sig.FirstVisible && !sig.Terminal {
+			return QualityWait
+		}
 		if qualityIsBurstDump(sig, minOutput) {
-			return QualityWithhold
+			if sig.Terminal {
+				return QualityWithhold
+			}
+			return QualityWait
+		}
+		// The token-relative floor cannot be final until usage arrives. Preserve
+		// HoldTimeout as the fail-open latency bound for still-open streams.
+		if !sig.Terminal && !sig.HoldExpired && !sig.UsageReported {
+			return QualityWait
 		}
 		return QualityDeliver
 	}

--- a/backend/internal/application/gateway/quality_retry_scan.go
+++ b/backend/internal/application/gateway/quality_retry_scan.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -153,23 +154,26 @@ func (s *qualityScanState) signals() QualityStreamSignals {
 	// the ciphertext floor (default 256 bytes, or 4 bytes per reasoning token).
 	reasoningTokens := max(s.reasoningTokens, s.usage.ReasoningTokens)
 	floor := encryptedThinkingFloor(s.minEncryptedBytes, s.encryptedBytesPerReasoningToken, reasoningTokens)
-	hasThinking := s.hasThinking || s.encryptedBytes >= floor
+	hasThinking := s.hasThinking || int64(s.encryptedBytes) >= floor
 	firstVisible := !s.firstVisibleAt.IsZero()
 	var flushMS int64
 	if firstVisible {
 		flushMS = time.Since(s.firstVisibleAt).Milliseconds()
 	}
 	return QualityStreamSignals{
-		HasThinking:      hasThinking,
-		ReasoningStarted: s.reasoningStarted || hasThinking,
-		VisibleTokens:    visible,
-		ReasoningTokens:  reasoningTokens,
-		OutputTokens:     output,
-		EncryptedBytes:   s.encryptedBytes,
-		FirstVisible:     firstVisible,
-		VisibleFlushMS:   flushMS,
-		Terminal:         s.terminal,
-		HoldExpired:      s.holdExpired,
+		HasThinking:       hasThinking,
+		HasReasoningDelta: s.hasThinking,
+		ReasoningStarted:  s.reasoningStarted || hasThinking,
+		VisibleTokens:     visible,
+		ReasoningTokens:   reasoningTokens,
+		OutputTokens:      output,
+		EncryptedBytes:    s.encryptedBytes,
+		EncryptedFloor:    floor,
+		UsageReported:     s.usage.Reported,
+		FirstVisible:      firstVisible,
+		VisibleFlushMS:    flushMS,
+		Terminal:          s.terminal,
+		HoldExpired:       s.holdExpired,
 	}
 }
 
@@ -198,11 +202,15 @@ func ObserveQualityChunk(state *qualityScanState, chunk []byte) {
 			state.reasoningStarted = true
 			continue
 		}
-		if bytes.Equal(line, []byte(qualityReasoningEvidenceSSEComment)) {
+		if bytes.HasPrefix(line, []byte(qualityReasoningEvidenceSSEComment)) {
 			// Protocol converters cannot expose encrypted_content in every public
-			// JSON contract. This internal SSE comment preserves that evidence.
+			// JSON contract. This internal SSE comment preserves its byte length so
+			// short stubs cannot bypass the ciphertext floor.
 			state.reasoningStarted = true
-			state.hasThinking = true
+			value := strings.TrimSpace(strings.TrimPrefix(string(line), qualityReasoningEvidenceSSEComment))
+			if count, err := strconv.Atoi(value); err == nil && count > state.encryptedBytes {
+				state.encryptedBytes = count
+			}
 			continue
 		}
 		if !bytes.HasPrefix(line, []byte("data:")) {

--- a/backend/internal/application/gateway/quality_retry_scan.go
+++ b/backend/internal/application/gateway/quality_retry_scan.go
@@ -23,18 +23,23 @@ const (
 )
 
 type qualityScanState struct {
-	protocol         string
-	pending          []byte
-	hasThinking      bool
-	reasoningStarted bool
-	visibleRunes     int
-	aggregateRunes   int
-	semanticOutput   bool
-	reasoningTokens  int64
-	outputTokens     int64
-	usage            Usage
-	responseID       string
-	terminal         bool
+	protocol                        string
+	pending                         []byte
+	hasThinking                     bool
+	reasoningStarted                bool
+	visibleRunes                    int
+	aggregateRunes                  int
+	semanticOutput                  bool
+	reasoningTokens                 int64
+	outputTokens                    int64
+	encryptedBytes                  int
+	minEncryptedBytes               int
+	encryptedBytesPerReasoningToken int
+	usage                           Usage
+	responseID                      string
+	terminal                        bool
+	holdExpired                     bool
+	firstVisibleAt                  time.Time
 }
 
 type qualityReadResult struct {
@@ -144,13 +149,27 @@ func (s *qualityScanState) signals() QualityStreamSignals {
 	// Usage.reasoning_tokens is not proof of thinking. 降智 accounts report
 	// hundreds of reasoning tokens on completed while the stream never sent
 	// reasoning_text / reasoning_summary deltas (TUI shows no thoughts).
+	// A non-empty encrypted_content stub is also not thinking until it meets
+	// the ciphertext floor (default 256 bytes, or 4 bytes per reasoning token).
+	reasoningTokens := max(s.reasoningTokens, s.usage.ReasoningTokens)
+	floor := encryptedThinkingFloor(s.minEncryptedBytes, s.encryptedBytesPerReasoningToken, reasoningTokens)
+	hasThinking := s.hasThinking || s.encryptedBytes >= floor
+	firstVisible := !s.firstVisibleAt.IsZero()
+	var flushMS int64
+	if firstVisible {
+		flushMS = time.Since(s.firstVisibleAt).Milliseconds()
+	}
 	return QualityStreamSignals{
-		HasThinking:      s.hasThinking,
-		ReasoningStarted: s.reasoningStarted || s.hasThinking,
+		HasThinking:      hasThinking,
+		ReasoningStarted: s.reasoningStarted || hasThinking,
 		VisibleTokens:    visible,
-		ReasoningTokens:  max(s.reasoningTokens, s.usage.ReasoningTokens),
+		ReasoningTokens:  reasoningTokens,
 		OutputTokens:     output,
+		EncryptedBytes:   s.encryptedBytes,
+		FirstVisible:     firstVisible,
+		VisibleFlushMS:   flushMS,
 		Terminal:         s.terminal,
+		HoldExpired:      s.holdExpired,
 	}
 }
 
@@ -277,6 +296,12 @@ type qualityResponsesOutputItem struct {
 	} `json:"content"`
 }
 
+func noteEncryptedBytes(state *qualityScanState, blob string) {
+	if n := len(strings.TrimSpace(blob)); n > state.encryptedBytes {
+		state.encryptedBytes = n
+	}
+}
+
 func noteResponsesReasoningItem(state *qualityScanState, item qualityResponsesOutputItem) {
 	if !strings.EqualFold(strings.TrimSpace(item.Type), "reasoning") {
 		return
@@ -284,9 +309,7 @@ func noteResponsesReasoningItem(state *qualityScanState, item qualityResponsesOu
 	if strings.TrimSpace(item.ID) != "" {
 		state.reasoningStarted = true
 	}
-	if strings.TrimSpace(item.EncryptedContent) != "" {
-		state.hasThinking = true
-	}
+	noteEncryptedBytes(state, item.EncryptedContent)
 }
 
 func observeQualityResponses(state *qualityScanState, payload []byte) {
@@ -420,9 +443,7 @@ func observeQualityAnthropic(state *qualityScanState, payload []byte) {
 			state.reasoningStarted = true
 		case "redacted_thinking":
 			state.reasoningStarted = true
-			if strings.TrimSpace(event.ContentBlock.Data) != "" {
-				state.hasThinking = true
-			}
+			noteEncryptedBytes(state, event.ContentBlock.Data)
 		case "text":
 			if event.ContentBlock.Text != "" {
 				noteVisibleContent(state, event.ContentBlock.Text)
@@ -438,9 +459,9 @@ func observeQualityAnthropic(state *qualityScanState, payload []byte) {
 		}
 		if event.Delta.Type == "signature_delta" && strings.TrimSpace(event.Delta.Signature) != "" {
 			// Anthropic Messages represents Responses encrypted_content as a
-			// signature delta. A non-empty signature is encrypted thinking proof.
+			// signature delta. Length is judged against the ciphertext floor.
 			state.reasoningStarted = true
-			state.hasThinking = true
+			noteEncryptedBytes(state, event.Delta.Signature)
 		}
 		if event.Delta.Type == "text_delta" && event.Delta.Text != "" {
 			noteVisibleContent(state, event.Delta.Text)
@@ -462,6 +483,9 @@ func noteVisibleContent(state *qualityScanState, text string) {
 	if text == "" {
 		return
 	}
+	if state.firstVisibleAt.IsZero() {
+		state.firstVisibleAt = time.Now()
+	}
 	state.visibleRunes += utf8.RuneCountInString(text)
 }
 
@@ -471,7 +495,11 @@ func peekQualityStream(ctx context.Context, body io.ReadCloser, protocol string,
 		return io.NopCloser(bytes.NewReader(nil)), QualityWait, Usage{}, "", errQualityEmptyStream
 	}
 	pump := newQualityReadPump(body)
-	state := qualityScanState{protocol: protocol}
+	state := qualityScanState{
+		protocol:                        protocol,
+		minEncryptedBytes:               cfg.MinEncryptedBytes,
+		encryptedBytesPerReasoningToken: cfg.EncryptedBytesPerReasoningToken,
+	}
 	var held bytes.Buffer
 	holdTimer := time.NewTimer(cfg.HoldTimeout)
 	defer holdTimer.Stop()
@@ -492,6 +520,7 @@ func peekQualityStream(ctx context.Context, body io.ReadCloser, protocol string,
 			_ = pump.Close()
 			return io.NopCloser(bytes.NewReader(held.Bytes())), QualityWait, state.usage, state.responseID, qualityPeekAbortError(ctx, ctx.Err())
 		case <-holdTimer.C:
+			state.holdExpired = true
 			sig.HoldExpired = true
 			if verdict := ClassifyQualityHold(sig, cfg.MinOutputTokens); verdict != QualityWait {
 				return newPrefixReplay(&held, pump), verdict, state.usage, state.responseID, nil

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func TestClassifyQualityHold(t *testing.T) {
 		sig  QualityStreamSignals
 		want QualityVerdict
 	}{
-		{name: "thinking delivers", sig: QualityStreamSignals{HasThinking: true, VisibleTokens: 10}, want: QualityDeliver},
+		{name: "thinking delivers", sig: QualityStreamSignals{HasThinking: true, HasReasoningDelta: true, VisibleTokens: 10}, want: QualityDeliver},
 		{name: "usage reasoning tokens alone withhold", sig: QualityStreamSignals{ReasoningTokens: 40, VisibleTokens: 80, Terminal: true}, want: QualityWithhold},
 		{name: "visible 32 no think withhold", sig: QualityStreamSignals{VisibleTokens: 32, Terminal: true}, want: QualityWithhold},
 		{name: "output 40 no think withhold", sig: QualityStreamSignals{OutputTokens: 40, Terminal: true}, want: QualityWithhold},
@@ -67,23 +68,28 @@ func TestClassifyQualityHoldBurst(t *testing.T) {
 		want QualityVerdict
 	}{
 		{
-			name: "hold-expired hello dump withholds",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 2, ReasoningTokens: 954, EncryptedBytes: 4000, HoldExpired: true},
+			name: "terminal hold-expired hello dump withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 2, ReasoningTokens: 954, EncryptedBytes: 4000, EncryptedFloor: 3816, UsageReported: true, FirstVisible: true, HoldExpired: true, Terminal: true},
 			want: QualityWithhold,
 		},
 		{
 			name: "hold-expired long answer delivers",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 200, ReasoningTokens: 954, EncryptedBytes: 8000, HoldExpired: true},
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 200, ReasoningTokens: 954, EncryptedBytes: 8000, EncryptedFloor: 3816, UsageReported: true, FirstVisible: true, HoldExpired: true},
 			want: QualityDeliver,
 		},
 		{
-			name: "barely-over-floor flush withholds",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 300, FirstVisible: true, VisibleFlushMS: 100},
+			name: "non-terminal barely-over-floor flush keeps observing",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 300, EncryptedFloor: 256, UsageReported: true, FirstVisible: true, VisibleFlushMS: 100},
+			want: QualityWait,
+		},
+		{
+			name: "terminal barely-over-floor flush withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 300, EncryptedFloor: 256, UsageReported: true, FirstVisible: true, VisibleFlushMS: 100, Terminal: true},
 			want: QualityWithhold,
 		},
 		{
 			name: "large cipher flush delivers",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 100},
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 2000, EncryptedFloor: 256, UsageReported: true, FirstVisible: true, VisibleFlushMS: 100},
 			want: QualityDeliver,
 		},
 	}
@@ -94,6 +100,33 @@ func TestClassifyQualityHoldBurst(t *testing.T) {
 				t.Fatalf("ClassifyQualityHold() = %s, want %s (%#v)", got, test.want, test.sig)
 			}
 		})
+	}
+}
+
+func TestClassifyQualityHoldBurstUsesConfiguredFloor(t *testing.T) {
+	t.Parallel()
+	configuredHigh := QualityStreamSignals{
+		HasThinking: true, VisibleTokens: 40, ReasoningTokens: 100,
+		EncryptedBytes: 1100, EncryptedFloor: 1024, UsageReported: true,
+		FirstVisible: true, VisibleFlushMS: 100, Terminal: true,
+	}
+	if got := ClassifyQualityHold(configuredHigh, 8); got != QualityWithhold {
+		t.Fatalf("configured high floor verdict = %s, want withhold", got)
+	}
+	configuredLow := QualityStreamSignals{
+		HasThinking: true, VisibleTokens: 40, ReasoningTokens: 60,
+		EncryptedBytes: 300, EncryptedFloor: 64, UsageReported: true,
+		FirstVisible: true, VisibleFlushMS: 100, Terminal: true,
+	}
+	if got := ClassifyQualityHold(configuredLow, 8); got != QualityDeliver {
+		t.Fatalf("configured low floor verdict = %s, want deliver", got)
+	}
+}
+
+func TestEncryptedThinkingFloorSaturates(t *testing.T) {
+	t.Parallel()
+	if got := encryptedThinkingFloor(256, 16, math.MaxInt64); got != math.MaxInt64 {
+		t.Fatalf("overflowing floor = %d, want %d", got, int64(math.MaxInt64))
 	}
 }
 
@@ -365,6 +398,45 @@ func TestObserveQualityConvertedEncryptedThinking(t *testing.T) {
 	}
 }
 
+func TestObserveQualityConvertedShortEncryptedStubDoesNotBypassFloor(t *testing.T) {
+	t.Parallel()
+	const stub = "gAAAA-cipher"
+	source := sse(
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6"}}`,
+		`data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}`,
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"`+stub+`"}}`,
+		`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("word ", 40)+`"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.6","usage":{"output_tokens":90,"output_tokens_details":{"reasoning_tokens":60}}}}`,
+	)
+	for _, test := range []struct {
+		name      string
+		operation string
+		protocol  string
+		options   conversation.ResponseOptions
+	}{
+		{name: "chat", operation: conversation.OperationChat, protocol: qualityProtocolChat},
+		{name: "messages", operation: conversation.OperationMessages, protocol: qualityProtocolAnthropic, options: conversation.ResponseOptions{AnthropicThinking: true}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			converted, err := io.ReadAll(conversation.ConvertResponseStreamWithOptions(
+				io.NopCloser(strings.NewReader(source)), test.operation, test.options,
+			))
+			if err != nil {
+				t.Fatal(err)
+			}
+			state := qualityScanState{protocol: test.protocol}
+			ObserveQualityChunk(&state, converted)
+			sig := state.signals()
+			if sig.HasThinking || sig.EncryptedBytes != len(stub) || !sig.ReasoningStarted {
+				t.Fatalf("converted short stub signals = %#v\n%s", sig, converted)
+			}
+			if got := ClassifyQualityHold(sig, 32); got != QualityWithhold {
+				t.Fatalf("converted short stub verdict = %s, want withhold", got)
+			}
+		})
+	}
+}
+
 func TestObserveQualityChunkWhitespaceIsNotThinking(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -557,6 +629,80 @@ func TestPeekQualityStreamThinkingDeliversRemainder(t *testing.T) {
 	got, _ := io.ReadAll(replay)
 	if !strings.Contains(string(got), "answer after think") || !strings.Contains(string(got), "thinking_content") {
 		t.Fatalf("replay lost frames: %s", got)
+	}
+}
+
+func TestPeekQualityStreamCipherBurstWaitsAcrossEventSplits(t *testing.T) {
+	t.Parallel()
+	cipher := strings.Repeat("A", 400)
+	createdAndCipher := sse(
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6","usage":{"output_tokens":80,"output_tokens_details":{"reasoning_tokens":80}}}}`,
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"`+cipher+`"}}`,
+	)
+	visible := sse(`data: {"type":"response.output_text.delta","delta":"你好"}`)
+	completed := sse(`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.6","usage":{"output_tokens":82,"output_tokens_details":{"reasoning_tokens":80}}}}`)
+	cfg := QualityRetryRuntime{MinOutputTokens: 8, HoldTimeout: 2 * time.Second}
+
+	coalesced, coalescedVerdict, _, _, err := peekQualityStream(
+		context.Background(), io.NopCloser(strings.NewReader(createdAndCipher+visible+completed)), qualityProtocolResponses, cfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = coalesced.Close()
+	if coalescedVerdict != QualityWithhold {
+		t.Fatalf("coalesced verdict = %s, want withhold", coalescedVerdict)
+	}
+
+	reader, writer := io.Pipe()
+	type peekResult struct {
+		replay  io.ReadCloser
+		verdict QualityVerdict
+		err     error
+	}
+	done := make(chan peekResult, 1)
+	go func() {
+		replay, verdict, _, _, peekErr := peekQualityStream(context.Background(), reader, qualityProtocolResponses, cfg)
+		done <- peekResult{replay: replay, verdict: verdict, err: peekErr}
+	}()
+	if _, err := io.WriteString(writer, createdAndCipher); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-done:
+		if result.replay != nil {
+			_ = result.replay.Close()
+		}
+		t.Fatalf("ciphertext-only partial stream returned early: verdict=%s err=%v", result.verdict, result.err)
+	case <-time.After(40 * time.Millisecond):
+	}
+	if _, err := io.WriteString(writer, visible); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-done:
+		if result.replay != nil {
+			_ = result.replay.Close()
+		}
+		t.Fatalf("non-terminal burst was finalized early: verdict=%s err=%v", result.verdict, result.err)
+	case <-time.After(40 * time.Millisecond):
+	}
+	if _, err := io.WriteString(writer, completed); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-done:
+		if result.replay != nil {
+			_ = result.replay.Close()
+		}
+		if result.err != nil || result.verdict != QualityWithhold {
+			t.Fatalf("split verdict=%s err=%v, want withhold", result.verdict, result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("split terminal stream did not finish")
 	}
 }
 

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -59,6 +59,44 @@ func TestClassifyQualityHold(t *testing.T) {
 	}
 }
 
+func TestClassifyQualityHoldBurst(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		sig  QualityStreamSignals
+		want QualityVerdict
+	}{
+		{
+			name: "hold-expired hello dump withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 2, ReasoningTokens: 954, EncryptedBytes: 4000, HoldExpired: true},
+			want: QualityWithhold,
+		},
+		{
+			name: "hold-expired long answer delivers",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 200, ReasoningTokens: 954, EncryptedBytes: 8000, HoldExpired: true},
+			want: QualityDeliver,
+		},
+		{
+			name: "barely-over-floor flush withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 300, FirstVisible: true, VisibleFlushMS: 100},
+			want: QualityWithhold,
+		},
+		{
+			name: "large cipher flush delivers",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 100},
+			want: QualityDeliver,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyQualityHold(test.sig, 8); got != test.want {
+				t.Fatalf("ClassifyQualityHold() = %s, want %s (%#v)", got, test.want, test.sig)
+			}
+		})
+	}
+}
+
 func TestDecideQualityRetry(t *testing.T) {
 	t.Parallel()
 	if got := DecideQualityRetry(QualityDeliver, 0, 2, qualityRetryFailOpen); got != QualityActionDeliver {
@@ -289,10 +327,11 @@ func TestObserveQualityChunkShortNoThinkIgnoresFakeReasoningUsage(t *testing.T) 
 
 func TestObserveQualityConvertedEncryptedThinking(t *testing.T) {
 	t.Parallel()
+	cipher := strings.Repeat("A", defaultMinEncryptedBytes*8)
 	source := sse(
 		`data: {"type":"response.created","response":{"id":"resp_1","model":"grok-4.6"}}`,
 		`data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}`,
-		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"gAAAA-cipher"}}`,
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"`+cipher+`"}}`,
 		`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("word ", 40)+`"}`,
 		`data: {"type":"response.completed","response":{"id":"resp_1","model":"grok-4.6","usage":{"output_tokens":90,"output_tokens_details":{"reasoning_tokens":60}}}}`,
 	)
@@ -350,12 +389,21 @@ func TestObserveQualityChunkWhitespaceIsNotThinking(t *testing.T) {
 
 func TestObserveQualityChunkAnthropicSignatureIsThinking(t *testing.T) {
 	t.Parallel()
-	state := qualityScanState{protocol: qualityProtocolAnthropic}
-	ObserveQualityChunk(&state, []byte(sse(
+	short := qualityScanState{protocol: qualityProtocolAnthropic}
+	ObserveQualityChunk(&short, []byte(sse(
 		`data: {"type":"content_block_delta","delta":{"type":"signature_delta","signature":"gAAAA-cipher"}}`,
 	)))
+	if sig := short.signals(); sig.HasThinking || !sig.ReasoningStarted || sig.EncryptedBytes == 0 {
+		t.Fatalf("short Anthropic signature stub must not count as thinking: %#v", sig)
+	}
+
+	cipher := strings.Repeat("A", defaultMinEncryptedBytes)
+	state := qualityScanState{protocol: qualityProtocolAnthropic}
+	ObserveQualityChunk(&state, []byte(sse(
+		`data: {"type":"content_block_delta","delta":{"type":"signature_delta","signature":"`+cipher+`"}}`,
+	)))
 	if sig := state.signals(); !sig.HasThinking || !sig.ReasoningStarted {
-		t.Fatalf("non-empty Anthropic signature must count as encrypted thinking: %#v", sig)
+		t.Fatalf("floor-sized Anthropic signature must count as encrypted thinking: %#v", sig)
 	}
 }
 
@@ -392,19 +440,53 @@ func TestObserveQualityChunkResponsesReasoningItem(t *testing.T) {
 		t.Fatalf("streamed reasoning summary should deliver: %#v", realSig)
 	}
 
+	short := qualityScanState{protocol: qualityProtocolResponses}
+	ObserveQualityChunk(&short, []byte(sse(
+		`data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}`,
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"gAAAA-cipher"}}`,
+		`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("word ", 40)+`"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":90,"output_tokens_details":{"reasoning_tokens":60}}}}`,
+	)))
+	shortSig := short.signals()
+	if shortSig.HasThinking {
+		t.Fatalf("short encrypted stub must not count as thinking: %#v", shortSig)
+	}
+	if shortSig.EncryptedBytes == 0 || !shortSig.ReasoningStarted || shortSig.ReasoningTokens != 60 {
+		t.Fatalf("short encrypted stub signals = %#v", shortSig)
+	}
+	if ClassifyQualityHold(shortSig, 32) != QualityWithhold {
+		t.Fatalf("short encrypted stub must withhold: %#v", shortSig)
+	}
+
+	cipher := strings.Repeat("A", defaultMinEncryptedBytes*8)
 	encrypted := qualityScanState{protocol: qualityProtocolResponses}
 	ObserveQualityChunk(&encrypted, []byte(sse(
 		`data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}`,
-		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"gAAAA-cipher"}}`,
-		`data: {"type":"response.output_text.delta","delta":"hello hello hello hello hello hello hello hello"}`,
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"`+cipher+`"}}`,
+		`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("word ", 40)+`"}`,
 		`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":90,"output_tokens_details":{"reasoning_tokens":60}}}}`,
 	)))
 	encSig := encrypted.signals()
-	if !encSig.HasThinking || encSig.ReasoningTokens != 60 {
+	if !encSig.HasThinking || encSig.ReasoningTokens != 60 || encSig.EncryptedBytes < defaultMinEncryptedBytes {
 		t.Fatalf("encrypted reasoning item must count as thinking: %#v", encSig)
 	}
 	if ClassifyQualityHold(encSig, 32) != QualityDeliver {
 		t.Fatalf("encrypted thinking should deliver: %#v", encSig)
+	}
+
+	floorCipher := strings.Repeat("A", defaultMinEncryptedBytes)
+	undersized := qualityScanState{protocol: qualityProtocolResponses}
+	ObserveQualityChunk(&undersized, []byte(sse(
+		`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"`+floorCipher+`"}}`,
+		`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("word ", 40)+`"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","usage":{"output_tokens":1200,"output_tokens_details":{"reasoning_tokens":1000}}}}`,
+	)))
+	underSig := undersized.signals()
+	if underSig.HasThinking {
+		t.Fatalf("256B cipher must not satisfy 1000 reasoning tokens: %#v", underSig)
+	}
+	if ClassifyQualityHold(underSig, 32) != QualityWithhold {
+		t.Fatalf("undersized cipher vs usage must withhold: %#v", underSig)
 	}
 }
 
@@ -1409,7 +1491,7 @@ func TestAttemptLoopQualityFailOpenFallbackAndTotalAttemptCap(t *testing.T) {
 func TestNormalizeQualityRetryDefaults(t *testing.T) {
 	t.Parallel()
 	got := normalizeQualityRetry(QualityRetryRuntime{Enabled: true})
-	if !got.Enabled || got.MaxAttempts != 6 || got.MinOutputTokens != 8 || got.OnExhausted != qualityRetryFailClosed || got.HoldTimeout != 30*time.Second || got.AccountCooldown != 12*time.Hour || got.IdleAccountCooldown != 15*time.Minute {
+	if !got.Enabled || got.MaxAttempts != 6 || got.MinOutputTokens != 8 || got.OnExhausted != qualityRetryFailClosed || got.HoldTimeout != 30*time.Second || got.AccountCooldown != 12*time.Hour || got.IdleAccountCooldown != 15*time.Minute || got.MinEncryptedBytes != defaultMinEncryptedBytes || got.EncryptedBytesPerReasoningToken != defaultEncryptedBytesPerReasoningToken {
 		t.Fatalf("defaults = %#v", got)
 	}
 }

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -297,7 +297,9 @@ type QualityGuardRequestRetryConfig struct {
 	AccountCooldown Duration `yaml:"accountCooldown"`
 	// IdleAccountCooldown cools an account after a truly empty upstream
 	// stream. Independent of accountCooldown (missing-thinking). Zero uses 15m.
-	IdleAccountCooldown Duration `yaml:"idleAccountCooldown"`
+	IdleAccountCooldown             Duration `yaml:"idleAccountCooldown"`
+	MinEncryptedBytes               int      `yaml:"minEncryptedBytes"`
+	EncryptedBytesPerReasoningToken int      `yaml:"encryptedBytesPerReasoningToken"`
 }
 
 type ClientKeyDefaultsConfig struct {
@@ -809,6 +811,12 @@ func validateQualityGuardRequestRetry(value QualityGuardRequestRetryConfig) erro
 	if d := value.IdleAccountCooldown.Value(); d != 0 && (d < time.Minute || d > 168*time.Hour) {
 		return errors.New("qualityGuard.requestRetry.idleAccountCooldown 必须在 1m 到 168h 之间")
 	}
+	if value.MinEncryptedBytes != 0 && (value.MinEncryptedBytes < 64 || value.MinEncryptedBytes > 4096) {
+		return errors.New("qualityGuard.requestRetry.minEncryptedBytes 必须在 64 到 4096 之间")
+	}
+	if value.EncryptedBytesPerReasoningToken != 0 && (value.EncryptedBytesPerReasoningToken < 1 || value.EncryptedBytesPerReasoningToken > 16) {
+		return errors.New("qualityGuard.requestRetry.encryptedBytesPerReasoningToken 必须在 1 到 16 之间")
+	}
 	return nil
 }
 
@@ -944,6 +952,7 @@ func defaultConfig() Config {
 			RequestRetry: QualityGuardRequestRetryConfig{
 				MaxAttempts: 6, HoldTimeout: Duration(30 * time.Second), MinOutputTokens: 8, OnExhausted: "fail_closed",
 				AccountCooldown: Duration(12 * time.Hour), IdleAccountCooldown: Duration(15 * time.Minute),
+				MinEncryptedBytes: 256, EncryptedBytesPerReasoningToken: 4,
 			},
 		},
 		ClientKeyDefaults: ClientKeyDefaultsConfig{RPMLimit: clientkeydomain.DefaultRPMLimit, MaxConcurrent: clientkeydomain.DefaultMaxConcurrent},

--- a/backend/internal/infra/config/config_test.go
+++ b/backend/internal/infra/config/config_test.go
@@ -223,7 +223,7 @@ qualityGuard:
 func TestDefaultQualityGuardRequestRetryContract(t *testing.T) {
 	t.Parallel()
 	got := defaultConfig().QualityGuard.RequestRetry
-	if got.Enabled || got.MaxAttempts != 6 || got.HoldTimeout.Value() != 30*time.Second || got.MinOutputTokens != 8 || got.OnExhausted != "fail_closed" || got.AccountCooldown.Value() != 12*time.Hour || got.IdleAccountCooldown.Value() != 15*time.Minute {
+	if got.Enabled || got.MaxAttempts != 6 || got.HoldTimeout.Value() != 30*time.Second || got.MinOutputTokens != 8 || got.OnExhausted != "fail_closed" || got.AccountCooldown.Value() != 12*time.Hour || got.IdleAccountCooldown.Value() != 15*time.Minute || got.MinEncryptedBytes != 256 || got.EncryptedBytesPerReasoningToken != 4 {
 		t.Fatalf("requestRetry defaults = %#v", got)
 	}
 }

--- a/backend/internal/infra/provider/conversation/conversation_test.go
+++ b/backend/internal/infra/provider/conversation/conversation_test.go
@@ -944,7 +944,7 @@ func TestConvertResponsesStreamMarksEncryptedChatReasoningEvidence(t *testing.T)
 		t.Fatal(err)
 	}
 	text := string(converted)
-	if strings.Count(text, ": grok2api-reasoning-start\n\n") != 1 || strings.Count(text, ": grok2api-reasoning-evidence\n\n") != 1 {
+	if strings.Count(text, ": grok2api-reasoning-start\n\n") != 1 || strings.Count(text, ": grok2api-reasoning-evidence 9\n\n") != 1 {
 		t.Fatalf("encrypted reasoning markers missing or duplicated: %s", text)
 	}
 	if strings.Contains(text, "signature") || strings.Contains(text, "encrypted_content") {
@@ -964,7 +964,7 @@ func TestConvertResponsesStreamMarksFinalEnvelopeReasoningEvidence(t *testing.T)
 		t.Fatal(err)
 	}
 	text := string(converted)
-	if strings.Count(text, ": grok2api-reasoning-evidence\n\n") != 1 {
+	if strings.Count(text, ": grok2api-reasoning-evidence 9\n\n") != 1 {
 		t.Fatalf("final-envelope reasoning evidence missing or duplicated: %s", text)
 	}
 	if strings.Contains(text, "signature") || strings.Contains(text, "encrypted_content") {

--- a/backend/internal/infra/provider/conversation/stream.go
+++ b/backend/internal/infra/provider/conversation/stream.go
@@ -52,36 +52,36 @@ func ConvertResponseStreamWithOptions(source io.ReadCloser, operation string, op
 }
 
 type streamConverter struct {
-	writer            io.Writer
-	operation         string
-	id                string
-	model             string
-	created           int64
-	started           bool
-	finished          bool
-	textStarted       bool
-	textIndex         int
-	thinkingStarted   bool
-	thinkingClosed    bool
-	thinkingIndex     int
-	thinkingItemID    string
-	chatReasoningMark bool
-	evidenceMarked    bool
-	reasoningItems    map[string]*reasoningStreamState
-	reasoningOrder    []string
-	activeReasoningID string
-	nextIndex         int
-	tools             map[string]streamTool
-	webSearch         []webSearchCall
-	webSearchEmitted  map[string]bool
-	deferSearchText   bool
-	pendingSearchText strings.Builder
-	usage             responseUsage
-	options           ResponseOptions
-	stopFilter        *anthropicStreamStopFilter
-	stopSequence      string
-	refused           bool
-	repeatTracker     streamRepeatTracker
+	writer                 io.Writer
+	operation              string
+	id                     string
+	model                  string
+	created                int64
+	started                bool
+	finished               bool
+	textStarted            bool
+	textIndex              int
+	thinkingStarted        bool
+	thinkingClosed         bool
+	thinkingIndex          int
+	thinkingItemID         string
+	chatReasoningMark      bool
+	reasoningEvidenceBytes int
+	reasoningItems         map[string]*reasoningStreamState
+	reasoningOrder         []string
+	activeReasoningID      string
+	nextIndex              int
+	tools                  map[string]streamTool
+	webSearch              []webSearchCall
+	webSearchEmitted       map[string]bool
+	deferSearchText        bool
+	pendingSearchText      strings.Builder
+	usage                  responseUsage
+	options                ResponseOptions
+	stopFilter             *anthropicStreamStopFilter
+	stopSequence           string
+	refused                bool
+	repeatTracker          streamRepeatTracker
 }
 
 // streamRepeatTracker 在协议转换、缓冲和 stop filter 之前跟踪上游增量，
@@ -148,20 +148,21 @@ func newStreamConverter(writer io.Writer, operation string, options ResponseOpti
 	}
 }
 
-// markReasoningEvidence preserves non-empty upstream encrypted_content for the
-// request-path quality scanner after protocol conversion. SSE clients ignore
-// comments, so Chat and Messages public event payloads remain unchanged.
-func (c *streamConverter) markReasoningEvidence() error {
-	if c.evidenceMarked {
+// markReasoningEvidence preserves the upstream encrypted_content byte length
+// for the request-path quality scanner after protocol conversion. SSE clients
+// ignore comments, so Chat and Messages public event payloads remain unchanged.
+func (c *streamConverter) markReasoningEvidence(encrypted string) error {
+	byteCount := len(strings.TrimSpace(encrypted))
+	if byteCount <= c.reasoningEvidenceBytes {
 		return nil
 	}
 	if err := c.start(); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(c.writer, ": grok2api-reasoning-evidence\n\n"); err != nil {
+	if _, err := fmt.Fprintf(c.writer, ": grok2api-reasoning-evidence %d\n\n", byteCount); err != nil {
 		return err
 	}
-	c.evidenceMarked = true
+	c.reasoningEvidenceBytes = byteCount
 	return nil
 }
 
@@ -381,7 +382,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 				}
 			}
 			if strings.TrimSpace(item.Encrypted) != "" {
-				if err := c.markReasoningEvidence(); err != nil {
+				if err := c.markReasoningEvidence(item.Encrypted); err != nil {
 					return err
 				}
 			}
@@ -398,7 +399,7 @@ func (c *streamConverter) handle(event string, data []byte) error {
 		c.setResponse(response)
 		for _, item := range response.Output {
 			if item.Type == "reasoning" && strings.TrimSpace(item.Encrypted) != "" {
-				if err := c.markReasoningEvidence(); err != nil {
+				if err := c.markReasoningEvidence(item.Encrypted); err != nil {
 					return err
 				}
 			}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -150,6 +150,8 @@ qualityGuard:
   nodeIDs: []
   rotatableNodeIDs: []
   # Optional request-path withhold/retry for thinking models.
+  # Recommended lab values are filled in; enabled stays false so stock
+  # installs do not intercept. Set enabled: true to turn the hold on.
   # Observe up to 30s for real reasoning evidence. If upstream has announced
   # a reasoning item and visible output but proof arrives later, the still-open
   # stream is released at the deadline without penalizing the account. Empty or
@@ -158,8 +160,10 @@ qualityGuard:
   # account is tried (up to maxAttempts). fail_closed returns 503 instead
   # of the last body. Sidecar qualityGuard.enabled stays false until you
   # start the quality-guard profile.
+  # Non-empty encrypted_content stubs are not thinking. The ciphertext floor
+  # is max(minEncryptedBytes, reasoning_tokens * encryptedBytesPerReasoningToken).
   requestRetry:
-    enabled: true
+    enabled: false
     maxAttempts: 6
     holdTimeout: 30s
     minOutputTokens: 8
@@ -171,3 +175,5 @@ qualityGuard:
     # Single-account pools should set this lower; toggling enabled does not
     # clear cooldown — use POST /api/admin/v1/accounts/:id/clear-cooldown.
     idleAccountCooldown: 15m
+    minEncryptedBytes: 256
+    encryptedBytesPerReasoningToken: 4


### PR DESCRIPTION
## Summary

`encrypted_content != \"\"` is not proof of thinking. Degraded upstreams emit a short stub (`gAAAA-cipher`), fill `usage.reasoning_tokens`, then dump a greeting. Grok TUI `include: reasoning.encrypted_content` makes that look like a real thought.

This PR keeps the current hold (30s / minOutput 8 / 6 attempts / fail_closed / 12h / 15m idle) and adds:

1. **Ciphertext floor** — `HasThinking` requires `encrypted_content` / Anthropic `signature` / `redacted_thinking` data to meet `max(minEncryptedBytes, reasoning_tokens * encryptedBytesPerReasoningToken)` (defaults 256 / 4). Usage numbers and empty reasoning shells still do not count.
2. **Burst withhold** — even when the floor is met, withhold a hold-expired short greeting billed as heavy thinking (TUI 「你好」 after 30s / 954 tokens), or a barely-over-floor flush in under a second.

The stub + hold-timeout inconclusive deliver path is unchanged: if a reasoning item has started and visible output is already present when the deadline fires, the still-open stream is released without penalizing the account so late ciphertext can still reach the client.

## Defaults

Recommended values are filled in `config.example.yaml` and `defaultConfig`. **`requestRetry.enabled` stays `false`** so stock installs do not intercept. Set `enabled: true` to turn the hold on.

```yaml
requestRetry:
  enabled: false
  maxAttempts: 6
  holdTimeout: 30s
  minOutputTokens: 8
  onExhausted: fail_closed
  accountCooldown: 12h
  idleAccountCooldown: 15m
  minEncryptedBytes: 256
  encryptedBytesPerReasoningToken: 4
```

Does not decrypt `encrypted_content`. Does not treat `usage.reasoning_tokens` as thinking.

## Test plan

- [x] `go test ./internal/application/gateway/ ./internal/infra/config/ ./internal/infra/provider/conversation/ ./internal/transport/http/inference/ ./internal/app/`
- [x] Short `gAAAA-cipher` stub → not `HasThinking`, withhold when visible ≥ minOutput
- [x] Floor-sized cipher delivers; 256B vs 1000 reasoning tokens withholds
- [x] Hold-expired 2-token dump with 954 reasoning tokens withholds
- [x] Existing stub + hold-timeout late-proof replay still delivers