### PR TITLE
fix: hold TUI dumps (stub expiry, floor-met burst, previous_response_id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ qualityGuard:
     idleAccountCooldown: 15m
 ```
 
-`requestRetry` runs on the gateway request path and is independent of the sidecar. `config.example.yaml` keeps `enabled: false`; set it true to intercept. When enabled, a thinking-model stream with enough visible output and no streamed reasoning is **not delivered**; another account is tried. TUI follow-ups (`previous_response_id`) and hosted-tool turns stay held — the first attempt stays pinned, a withhold unpins and rotates. Image, video, and ForcedEgress probe requests are unchanged. If every attempt still has no reasoning, `onExhausted` either returns `503 quality_degraded` or delivers the last body.
+`requestRetry` runs on the gateway request path and is independent of the sidecar. `config.example.yaml` keeps `enabled: false`; set it true to intercept. When enabled, a thinking-model stream with enough visible output and no streamed reasoning is **not delivered**; replay-safe stateless requests may try another account. TUI follow-ups (`previous_response_id`) and hosted-tool turns are still held for classification, but a quality withhold never replays account-bound state or side-effecting tools across accounts; `onExhausted` returns `503 quality_degraded` or releases that held body. Context compaction, image, video, and ForcedEgress probe requests are unchanged.
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/README.md
+++ b/README.md
@@ -369,8 +369,9 @@ qualityGuard:
   enabled: true
   model: "grok-4.6"
   # Withhold thinking-model streams that have no streamed reasoning.
-  # Observe for up to 30s. An open stream with a reasoning start and visible
-  # output is released at the deadline; empty/terminal failures still retry.
+  # Observe for up to 30s. A stub plus enough visible output at the deadline
+  # is withheld; empty stub-only streams keep waiting. Floor-met dumps that
+  # flush a short greeting in under 1s are also withheld.
   requestRetry:
     enabled: true
     maxAttempts: 6
@@ -381,7 +382,7 @@ qualityGuard:
     idleAccountCooldown: 15m
 ```
 
-`requestRetry` runs on the gateway request path and is independent of the sidecar. The example enables it. When enabled, a thinking-model stream with enough visible output and no streamed reasoning is **not delivered**; another account is tried. If every attempt still has no reasoning, `onExhausted` either returns `503 quality_degraded` or delivers the last body. Image, video, stored-response, and ForcedEgress probe requests are unchanged. Grok TUI tool turns stay held so 0-thinking dumps cannot skip the gate.
+`requestRetry` runs on the gateway request path and is independent of the sidecar. `config.example.yaml` keeps `enabled: false`; set it true to intercept. When enabled, a thinking-model stream with enough visible output and no streamed reasoning is **not delivered**; another account is tried. TUI follow-ups (`previous_response_id`) and hosted-tool turns stay held — the first attempt stays pinned, a withhold unpins and rotates. Image, video, and ForcedEgress probe requests are unchanged. If every attempt still has no reasoning, `onExhausted` either returns `503 quality_degraded` or delivers the last body.
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -365,8 +365,8 @@ qualityGuard:
   enabled: true
   model: "grok-4.6"
   # 思考模型缺流式 reasoning 时先扣住响应，换号再打，不把降智正文发给用户。
-  # 最多观察 30 秒；已有 reasoning 起始信号和可见输出的进行中流会在超时后放行，
-  # 空流和终态仍无 thinking 的响应继续换号。
+  # 最多观察 30 秒；stub 加上足够可见输出在超时后扣住（TUI 30s 后的短问候），
+  # 空 stub 继续等。floor 已达标但 1 秒内吐短回复的也扣。
   requestRetry:
     enabled: true
     maxAttempts: 6
@@ -377,7 +377,7 @@ qualityGuard:
     idleAccountCooldown: 15m
 ```
 
-`requestRetry` 在网关请求路径上生效，与 sidecar 探测/隔离相互独立。示例配置默认开启。开启后，可见输出达到 `minOutputTokens` 且全程无流式 reasoning 时**不发给用户**，排除该账号再试；全部仍无推理则按 `onExhausted` 返回 `503 quality_degraded` 或放出最后一枪。不处理图/视频、stored response 钉账号和 ForcedEgress 探针。Grok TUI 带 tools 的回合仍会 hold，避免 0-thinking 降智流跳过闸门。
+`requestRetry` 在网关请求路径上生效，与 sidecar 探测/隔离相互独立。`config.example.yaml` 里 `enabled` 仍为 false，打开后才拦截。开启后，可见输出达到 `minOutputTokens` 且全程无流式 reasoning 时**不发给用户**，排除该账号再试。TUI 续聊（`previous_response_id`）和 hosted tools 仍 hold：第一枪钉原账号，扣住后 unpin 换号。不处理图/视频和 ForcedEgress 探针。全部仍无推理则按 `onExhausted` 返回 `503 quality_degraded` 或放出最后一枪。
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -377,7 +377,7 @@ qualityGuard:
     idleAccountCooldown: 15m
 ```
 
-`requestRetry` 在网关请求路径上生效，与 sidecar 探测/隔离相互独立。`config.example.yaml` 里 `enabled` 仍为 false，打开后才拦截。开启后，可见输出达到 `minOutputTokens` 且全程无流式 reasoning 时**不发给用户**，排除该账号再试。TUI 续聊（`previous_response_id`）和 hosted tools 仍 hold：第一枪钉原账号，扣住后 unpin 换号。不处理图/视频和 ForcedEgress 探针。全部仍无推理则按 `onExhausted` 返回 `503 quality_degraded` 或放出最后一枪。
+`requestRetry` 在网关请求路径上生效，与 sidecar 探测/隔离相互独立。`config.example.yaml` 里 `enabled` 仍为 false，打开后才拦截。开启后，可见输出达到 `minOutputTokens` 且全程无流式 reasoning 时**不发给用户**；只有可安全重放的无状态请求才会排除账号重试。TUI 续聊（`previous_response_id`）和 hosted tools 仍会进入 hold 检测，但质量拦截不会把账号绑定状态或有副作用的工具跨账号重放，最终按 `onExhausted` 返回 `503 quality_degraded` 或放出当前响应。上下文压缩、图片、视频和 ForcedEgress 探针不受影响。
 
 ```bash
 docker compose --profile quality-guard up -d --build

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -181,11 +181,9 @@ func qualityIsBurstDump(sig QualityStreamSignals, minOutput int64) bool {
 // more bytes or a stream abort so an empty hang is not flushed as HTTP 200.
 //
 // An empty reasoning stub is not thinking. Before the hold deadline, wait for
-// real evidence or a terminal event. If the deadline expires while the stream
-// is still open and already has visible output, the result is inconclusive:
-// release it without penalizing the account. A stub-only empty stream keeps
-// waiting for idle/terminal handling. This keeps HoldTimeout a real latency
-// bound without reopening the empty-stream 200 response path.
+// real evidence or a terminal event. A stub plus enough visible output at the
+// deadline is withheld — that is the TUI dump after 30s, not late ciphertext.
+// Stub-only empty streams keep waiting for idle/terminal handling.
 // HasThinking that is only a thin ciphertext dump after the hold (or a
 // barely-over-floor flush in <1s) is still withheld.
 func ClassifyQualityHold(sig QualityStreamSignals, minOutput int64) QualityVerdict {
@@ -207,10 +205,7 @@ func ClassifyQualityHold(sig QualityStreamSignals, minOutput int64) QualityVerdi
 		output = sig.OutputTokens
 	}
 	enough := output >= minOutput
-	if sig.ReasoningStarted && !sig.Terminal {
-		if sig.HoldExpired && output > 0 {
-			return QualityDeliver
-		}
+	if sig.ReasoningStarted && !sig.Terminal && !sig.HoldExpired {
 		return QualityWait
 	}
 	if sig.Terminal {

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -342,34 +342,22 @@ func CommitQualityHold(verdict QualityVerdict, qualityAttempt, maxAttempts int, 
 }
 
 func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwnership, route modeldomain.Route, operation audit.Operation, cfg QualityRetryRuntime) bool {
-	if !cfg.Enabled || !input.Streaming || input.ForcedEgressNodeID != 0 || ownership != nil || input.skipQualityHold {
+	if !cfg.Enabled || !input.Streaming || input.ForcedEgressNodeID != 0 || input.skipQualityHold {
 		return false
 	}
 	switch operation {
-	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, "":
+	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, audit.OperationCompaction, "":
 	default:
-		return false
-	}
-	// TUI compaction is a normal /v1/responses body (no compaction_trigger).
-	// Keep this defensive body check in addition to skipQualityHold so a caller
-	// that bypasses CreateResponse cannot withhold a 100s+ summary as missing-thinking.
-	if isResponsesCompactionRequest(input.Body) {
 		return false
 	}
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// Client-executed tools are safe to hold: their calls have not reached the
-	// client yet, and completed results in the next request are immutable input.
-	// Hosted tools are different. Retrying them can repeat an upstream search,
-	// sandbox run, image job, or remote MCP call, so retain the old no-replay
-	// safety boundary for any request that declares one.
-	if qualityRequestHasReplayUnsafeHostedTools(input.Body) {
-		return false
-	}
-	// Aliases are rewritten before this gate, so inspect the effective request
-	// body instead of only the reasoning-capable base model. In particular,
-	// grok-4.3-none becomes grok-4.3 plus an explicit disabled setting.
+	// TUI always declares tools (including hosted web_search / image jobs) and
+	// follow-ups carry previous_response_id. Skipping either let 0-thinking
+	// dumps through on the common agent loop. Keep holding; the attempt loop
+	// unpins after the first missing-thinking hit. Skip only when the request
+	// explicitly disables reasoning.
 	if qualityRequestDisablesReasoning(input.Body) {
 		return false
 	}

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -159,12 +159,19 @@ func qualityIsBurstDump(sig QualityStreamSignals, minOutput int64) bool {
 	floor := encryptedThinkingFloor(0, 0, sig.ReasoningTokens)
 	barelyCipher := sig.EncryptedBytes > 0 && sig.EncryptedBytes < floor*2
 	flushed := sig.FirstVisible && sig.VisibleFlushMS >= 0 && sig.VisibleFlushMS < defaultBurstFlushMS
+	heavyReasoning := sig.ReasoningTokens >= defaultBurstMinReasoning
+	shortVisible := visible > 0 && visible < defaultBurstMaxVisible
 	// Hold timed out, then a short greeting dumped with a large reasoning bill
 	// (TUI "你好" after 30s / 954 thinking tokens).
-	if sig.HoldExpired && visible > 0 && visible < defaultBurstMaxVisible && sig.ReasoningTokens >= defaultBurstMinReasoning {
+	if sig.HoldExpired && shortVisible && heavyReasoning {
 		return true
 	}
-	if barelyCipher && flushed && (visible >= minOutput || sig.ReasoningTokens >= defaultBurstMinReasoning) {
+	// Cipher met the floor so HasThinking is true, but visible tokens then
+	// dump in <1s with almost no answer (148 out / 140 reasoning in 0.7s).
+	if flushed && shortVisible && heavyReasoning {
+		return true
+	}
+	if barelyCipher && flushed && (visible >= minOutput || heavyReasoning) {
 		return true
 	}
 	return false

--- a/backend/internal/application/gateway/quality_retry.go
+++ b/backend/internal/application/gateway/quality_retry.go
@@ -380,18 +380,24 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 		return false
 	}
 	switch operation {
-	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, audit.OperationCompaction, "":
+	case audit.OperationChat, audit.OperationResponses, audit.OperationMessages, "":
 	default:
+		return false
+	}
+	// Context compaction is a system summary operation, not a normal reasoning
+	// turn. Holding it can quarantine a healthy account for producing the
+	// expected summary without streamed reasoning. Keep both compaction forms
+	// excluded even if a caller reaches this gate without skipQualityHold.
+	if isResponsesCompactionRequest(input.Body) {
 		return false
 	}
 	if route.Provider != accountdomain.ProviderBuild && route.Provider != accountdomain.ProviderConsole {
 		return false
 	}
-	// TUI always declares tools (including hosted web_search / image jobs) and
-	// follow-ups carry previous_response_id. Skipping either let 0-thinking
-	// dumps through on the common agent loop. Keep holding; the attempt loop
-	// unpins after the first missing-thinking hit. Skip only when the request
-	// explicitly disables reasoning.
+	// TUI commonly declares tools and follow-ups carry previous_response_id.
+	// They still need quality classification, but replay safety is decided
+	// separately: detecting a degraded response must not imply that an
+	// account-bound or side-effecting request can run on another account.
 	if qualityRequestDisablesReasoning(input.Body) {
 		return false
 	}
@@ -399,6 +405,15 @@ func shouldHoldQualityStream(input Input, ownership *inferencedomain.ResponseOwn
 		return true
 	}
 	return modeldomain.SupportsReasoningForProvider(route.Provider, route.UpstreamModel)
+}
+
+// canReplayQualityHoldAcrossAccounts separates response classification from
+// retry authority. Stored Responses are account-bound, while hosted tools may
+// already have produced an external side effect before their held response is
+// rejected. Both may be held, audited, and penalized, but neither is replayed
+// on another account.
+func canReplayQualityHoldAcrossAccounts(input Input, ownership *inferencedomain.ResponseOwnership) bool {
+	return ownership == nil && !qualityRequestHasReplayUnsafeHostedTools(input.Body)
 }
 
 func qualityRequestHasReplayUnsafeHostedTools(body []byte) bool {

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -1053,24 +1053,24 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 		t.Fatal("forced egress must not hold")
 	}
 	owned := inferencedomain.ResponseOwnership{ResponseID: "r1", AccountID: 1}
-	if shouldHoldQualityStream(input, &owned, route, audit.OperationChat, cfg) {
-		t.Fatal("pinned response must not hold")
+	if !shouldHoldQualityStream(input, &owned, route, audit.OperationChat, cfg) {
+		t.Fatal("pinned previous_response_id must still hold on missing thinking")
 	}
 	if shouldHoldQualityStream(input, nil, route, audit.OperationImage, cfg) {
 		t.Fatal("image must not hold")
 	}
-	if shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
-		t.Fatal("codex compaction operation must not hold")
+	if !shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
+		t.Fatal("compaction with no reasoning must hold")
 	}
 	classified := input
 	classified.skipQualityHold = true
 	if shouldHoldQualityStream(classified, nil, route, audit.OperationResponses, cfg) {
-		t.Fatal("gateway-classified compaction must not hold")
+		t.Fatal("explicit skipQualityHold must not hold")
 	}
 	tui := input
 	tui.Body = []byte(`{"input":[{"role":"user","content":"` + tuiCompactionPrompt + `"}]}`)
-	if shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
-		t.Fatal("tui compaction prompt must not hold even when tagged responses")
+	if !shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
+		t.Fatal("tui compaction prompt with no reasoning must hold")
 	}
 	for _, test := range []struct {
 		name string
@@ -1154,8 +1154,8 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 			if !qualityRequestHasReplayUnsafeHostedTools(request.Body) {
 				t.Fatal("fixture must be classified as replay-unsafe hosted tooling")
 			}
-			if shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
-				t.Fatal("hosted tools must not be held because account retry can execute them again")
+			if !shouldHoldQualityStream(request, nil, route, audit.OperationChat, cfg) {
+				t.Fatal("hosted tools must still hold; TUI always declares them")
 			}
 		})
 	}

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -41,7 +41,7 @@ func TestClassifyQualityHold(t *testing.T) {
 		{name: "empty terminal waits for transport handling", sig: QualityStreamSignals{Terminal: true}, want: QualityWait},
 		{name: "midstream enough content withhold", sig: QualityStreamSignals{VisibleTokens: 64}, want: QualityWithhold},
 		{name: "stub midstream waits even with enough visible", sig: QualityStreamSignals{ReasoningStarted: true, VisibleTokens: 64}, want: QualityWait},
-		{name: "stub hold expiry is inconclusive and delivers", sig: QualityStreamSignals{ReasoningStarted: true, VisibleTokens: 64, HoldExpired: true}, want: QualityDeliver},
+		{name: "stub hold expiry with enough visible withholds", sig: QualityStreamSignals{ReasoningStarted: true, VisibleTokens: 64, HoldExpired: true}, want: QualityWithhold},
 		{name: "stub-only hold expiry keeps waiting", sig: QualityStreamSignals{ReasoningStarted: true, HoldExpired: true}, want: QualityWait},
 		{name: "stub terminal enough withhold", sig: QualityStreamSignals{ReasoningStarted: true, VisibleTokens: 64, Terminal: true}, want: QualityWithhold},
 		{name: "wait for more", sig: QualityStreamSignals{VisibleTokens: 8}, want: QualityWait},
@@ -732,8 +732,8 @@ func TestPeekQualityStreamHoldTimeoutDeliversStartedReasoningAndPreservesLateEvi
 	if elapsed := time.Since(started); elapsed < 20*time.Millisecond || elapsed > 200*time.Millisecond {
 		t.Fatalf("peek returned after %s, want the 30ms hold timeout", elapsed)
 	}
-	if verdict != QualityDeliver {
-		t.Fatalf("started reasoning at hold timeout verdict = %s, want deliver", verdict)
+	if verdict != QualityWithhold {
+		t.Fatalf("started reasoning stub at hold timeout verdict = %s, want withhold", verdict)
 	}
 	close(continueWrite)
 	body, err := io.ReadAll(replay)

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -86,6 +86,21 @@ func TestClassifyQualityHoldBurst(t *testing.T) {
 			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 50, ReasoningTokens: 60, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 100},
 			want: QualityDeliver,
 		},
+		{
+			name: "floor-met short visible fast dump withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 3, ReasoningTokens: 1371, EncryptedBytes: 8000, FirstVisible: true, VisibleFlushMS: 200},
+			want: QualityWithhold,
+		},
+		{
+			name: "floor-met 8 visible 140 reasoning in under 1s withholds",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 8, ReasoningTokens: 140, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 660},
+			want: QualityWithhold,
+		},
+		{
+			name: "floor-met long visible fast flush delivers",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 80, ReasoningTokens: 140, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 200},
+			want: QualityDeliver,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/backend/internal/application/gateway/quality_retry_test.go
+++ b/backend/internal/application/gateway/quality_retry_test.go
@@ -93,18 +93,23 @@ func TestClassifyQualityHoldBurst(t *testing.T) {
 			want: QualityDeliver,
 		},
 		{
+			name: "non-terminal floor-met short burst keeps observing",
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 3, ReasoningTokens: 1371, EncryptedBytes: 8000, EncryptedFloor: 5484, UsageReported: true, FirstVisible: true, VisibleFlushMS: 200},
+			want: QualityWait,
+		},
+		{
 			name: "floor-met short visible fast dump withholds",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 3, ReasoningTokens: 1371, EncryptedBytes: 8000, FirstVisible: true, VisibleFlushMS: 200},
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 3, ReasoningTokens: 1371, EncryptedBytes: 8000, EncryptedFloor: 5484, UsageReported: true, FirstVisible: true, VisibleFlushMS: 200, Terminal: true},
 			want: QualityWithhold,
 		},
 		{
 			name: "floor-met 8 visible 140 reasoning in under 1s withholds",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 8, ReasoningTokens: 140, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 660},
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 8, ReasoningTokens: 140, EncryptedBytes: 2000, EncryptedFloor: 560, UsageReported: true, FirstVisible: true, VisibleFlushMS: 660, Terminal: true},
 			want: QualityWithhold,
 		},
 		{
 			name: "floor-met long visible fast flush delivers",
-			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 80, ReasoningTokens: 140, EncryptedBytes: 2000, FirstVisible: true, VisibleFlushMS: 200},
+			sig:  QualityStreamSignals{HasThinking: true, VisibleTokens: 80, ReasoningTokens: 140, EncryptedBytes: 2000, EncryptedFloor: 560, UsageReported: true, FirstVisible: true, VisibleFlushMS: 200, Terminal: true},
 			want: QualityDeliver,
 		},
 	}
@@ -1220,8 +1225,8 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 	if shouldHoldQualityStream(input, nil, route, audit.OperationImage, cfg) {
 		t.Fatal("image must not hold")
 	}
-	if !shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
-		t.Fatal("compaction with no reasoning must hold")
+	if shouldHoldQualityStream(input, nil, route, audit.OperationCompaction, cfg) {
+		t.Fatal("compaction must not enter missing-thinking hold")
 	}
 	classified := input
 	classified.skipQualityHold = true
@@ -1230,8 +1235,8 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 	}
 	tui := input
 	tui.Body = []byte(`{"input":[{"role":"user","content":"` + tuiCompactionPrompt + `"}]}`)
-	if !shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
-		t.Fatal("tui compaction prompt with no reasoning must hold")
+	if shouldHoldQualityStream(tui, nil, route, audit.OperationResponses, cfg) {
+		t.Fatal("tui compaction prompt must not enter missing-thinking hold")
 	}
 	for _, test := range []struct {
 		name string
@@ -1334,6 +1339,185 @@ func TestShouldHoldQualityStreamGates(t *testing.T) {
 	toolCache.AllowClientToolCacheRoute = true
 	if !shouldHoldQualityStream(toolCache, nil, route, audit.OperationChat, cfg) {
 		t.Fatal("client identity/cache compatibility alone must not disable the hold")
+	}
+}
+
+func TestCanReplayQualityHoldAcrossAccounts(t *testing.T) {
+	t.Parallel()
+	plain := Input{Body: []byte(`{"input":"hello"}`)}
+	if !canReplayQualityHoldAcrossAccounts(plain, nil) {
+		t.Fatal("stateless text request should allow account retry")
+	}
+	owned := inferencedomain.ResponseOwnership{ResponseID: "resp_1", AccountID: 1}
+	if canReplayQualityHoldAcrossAccounts(plain, &owned) {
+		t.Fatal("stored response must remain pinned to its owner account")
+	}
+	hosted := Input{Body: []byte(`{"tools":[{"type":"web_search"}],"input":"hello"}`)}
+	if canReplayQualityHoldAcrossAccounts(hosted, nil) {
+		t.Fatal("hosted tool must not be replayed across accounts")
+	}
+	clientTool := Input{Body: []byte(`{"tools":[{"type":"function","name":"read_file"}],"input":"hello"}`)}
+	if !canReplayQualityHoldAcrossAccounts(clientTool, nil) {
+		t.Fatal("client-executed tool declaration is safe to retry before delivery")
+	}
+}
+
+func TestAttemptLoopQualityHoldPreservesReplaySafety(t *testing.T) {
+	tests := []struct {
+		name        string
+		previous    bool
+		body        string
+		onExhausted string
+		wantError   bool
+		empty       bool
+		wantMissing bool
+	}{
+		{
+			name:        "previous response remains account bound",
+			previous:    true,
+			body:        `{"model":"grok-4.6","previous_response_id":"resp-root","input":"continue","stream":true}`,
+			onExhausted: qualityRetryFailClosed,
+			wantError:   true,
+			wantMissing: true,
+		},
+		{
+			name:        "hosted tool fail closed executes once",
+			body:        `{"model":"grok-4.6","tools":[{"type":"web_search"}],"input":"search","stream":true}`,
+			onExhausted: qualityRetryFailClosed,
+			wantError:   true,
+			wantMissing: true,
+		},
+		{
+			name:        "hosted tool fail open delivers same attempt",
+			body:        `{"model":"grok-4.6","tools":[{"type":"web_search"}],"input":"search","stream":true}`,
+			onExhausted: qualityRetryFailOpen,
+			wantMissing: true,
+		},
+		{
+			name:        "hosted tool empty stream executes once",
+			body:        `{"model":"grok-4.6","tools":[{"type":"web_search"}],"input":"search","stream":true}`,
+			onExhausted: qualityRetryFailClosed,
+			wantError:   true,
+			empty:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "quality-replay-safety.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer database.Close()
+			if err := database.InitializeSchema(ctx); err != nil {
+				t.Fatal(err)
+			}
+			accountRepo := relational.NewAccountRepository(database)
+			modelRepo := relational.NewModelRepository(database)
+			auditRepo := relational.NewAuditRepository(database)
+			responseRepo := relational.NewResponseRepository(database)
+			keyRepo := relational.NewClientKeyRepository(database)
+
+			credentials := make([]accountdomain.Credential, 0, 2)
+			for index, name := range []string{"quality-safe-a", "quality-safe-b"} {
+				credential, _, createErr := accountRepo.UpsertByIdentity(ctx, accountdomain.Credential{
+					Provider: accountdomain.ProviderBuild, Name: name, SourceKey: name,
+					EncryptedAccessToken: name, EncryptedRefreshToken: "refresh-" + name,
+					ExpiresAt: time.Now().Add(time.Hour), Enabled: true,
+					AuthStatus: accountdomain.AuthStatusActive, Priority: 200 - index, MaxConcurrent: 1,
+				})
+				if createErr != nil {
+					t.Fatal(createErr)
+				}
+				credentials = append(credentials, credential)
+			}
+			if err := modelRepo.UpsertDiscovered(ctx, accountdomain.ProviderBuild, []string{"grok-4.6"}); err != nil {
+				t.Fatal(err)
+			}
+			for _, credential := range credentials {
+				if err := modelRepo.ReplaceAccountCapabilities(ctx, credential.ID, []string{"grok-4.6"}, time.Now().UTC()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			key, err := keyRepo.Create(ctx, clientkey.Key{
+				Name: "quality-safe-key", Prefix: "qsafe", SecretHash: strings.Repeat("8", 64),
+				EncryptedSecret: "encrypted", Enabled: true, RPMLimit: 120, MaxConcurrent: 8,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.previous {
+				now := time.Now().UTC()
+				if err := responseRepo.Save(ctx, inferencedomain.ResponseOwnership{
+					ResponseID: "resp-root", AccountID: credentials[0].ID, ClientKeyID: key.ID,
+					Provider: accountdomain.ProviderBuild, PromptCacheKey: "session-root",
+					CreatedAt: now, UpdatedAt: now, ExpiresAt: now.Add(time.Hour),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			noThinking := sse(
+				`data: {"type":"response.created","response":{"id":"resp-bad","model":"grok-4.6"}}`,
+				`data: {"type":"response.output_text.delta","delta":"`+strings.Repeat("bad ", 20)+`"}`,
+				`data: {"type":"response.completed","response":{"id":"resp-bad","model":"grok-4.6","usage":{"output_tokens":40,"output_tokens_details":{"reasoning_tokens":0}}}}`,
+			)
+			thinking := sse(
+				`data: {"type":"response.created","response":{"id":"resp-good","model":"grok-4.6"}}`,
+				`data: {"type":"response.reasoning_summary_text.delta","delta":"real reasoning"}`,
+				`data: {"type":"response.output_text.delta","delta":"good answer"}`,
+				`data: {"type":"response.completed","response":{"id":"resp-good","model":"grok-4.6","usage":{"output_tokens":40,"output_tokens_details":{"reasoning_tokens":20}}}}`,
+			)
+			firstBody := noThinking
+			if test.empty {
+				firstBody = ""
+			}
+			adapter := &scriptedBuildAdapter{responses: map[uint64][]scriptedBuildResponse{
+				credentials[0].ID: {{status: http.StatusOK, body: firstBody}},
+				credentials[1].ID: {{status: http.StatusOK, body: thinking}},
+			}}
+			registry := provider.NewRegistry(adapter)
+			sticky := memory.NewStickyStore()
+			accountService := accountapp.NewService(accountRepo, auditRepo, memory.NewDeviceSessionStore(), sticky, registry, testCipher(t), nil)
+			selector := NewSelector(accountRepo, memory.NewConcurrencyLimiter(), sticky, registry, time.Hour, time.Second, time.Minute)
+			service := NewService(modelRepo, auditRepo, accountService, clientkeyapp.NewService(nil, nil, nil, 60, 4, nil), registry, selector, responseRepo, 3)
+			service.UpdateQualityRetry(QualityRetryRuntime{
+				Enabled: true, MaxAttempts: 2, MinOutputTokens: 8,
+				OnExhausted: test.onExhausted, HoldTimeout: time.Second,
+			})
+
+			input := Input{
+				RequestID: "req-quality-safe", ClientKey: key, PublicModel: "grok-4.6",
+				Streaming: true, Body: []byte(test.body),
+			}
+			if test.previous {
+				input.PreviousResponseID = "resp-root"
+			}
+			result, requestErr := service.CreateResponse(ctx, input)
+			var responseBody []byte
+			if result != nil {
+				responseBody, _ = io.ReadAll(result.Body)
+				result.Finalize(Usage{}, "", "")
+				_ = result.Body.Close()
+			}
+			if (requestErr != nil) != test.wantError {
+				t.Fatalf("request error = %v, wantError=%t", requestErr, test.wantError)
+			}
+			if !test.wantError && !strings.Contains(string(responseBody), "bad ") {
+				t.Fatalf("fail-open did not deliver the held first attempt: %s", responseBody)
+			}
+			attempts := adapter.Attempts()
+			if len(attempts) != 1 || attempts[0] != credentials[0].ID {
+				t.Fatalf("request crossed its replay-safety boundary, attempts=%v", attempts)
+			}
+			cooled, err := accountRepo.Get(ctx, credentials[0].ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cooled.CooldownUntil == nil || (test.wantMissing && cooled.LastError != lastErrorMissingThinking) {
+				t.Fatalf("degraded account was not penalized: %#v", cooled)
+			}
+		})
 	}
 }
 

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1018,7 +1018,9 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	// A lease recovery probe stays on exactly one account and one rendered proxy
 	// identity. Retrying the same pinned account would provide neither failover
 	// nor new evidence and can multiply a slow/failing probe.
-	attemptPolicy := newRequestRoutingAttemptPolicy(int(s.maxAttempts.Load()), ownership != nil || input.ForcedAccountID != 0)
+	holdCfg := s.qualityRetryConfig()
+	qualityHoldEnabled := shouldHoldQualityStream(input, ownership, route, operation, holdCfg)
+	attemptPolicy := newRequestRoutingAttemptPolicy(int(s.maxAttempts.Load()), input.ForcedAccountID != 0 || (ownership != nil && !qualityHoldEnabled))
 	idempotencyID, _ := security.NewOpaqueToken(18)
 	pricingModel := s.providers.PricingModel(route.Provider, route.UpstreamModel)
 	if err := s.checkLedgerReady(); err != nil {
@@ -1032,8 +1034,6 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	excluded := make(map[uint64]bool)
 	failureFingerprints := make(map[string]int)
 	authRecoveryAttempted := make(map[uint64]bool)
-	holdCfg := s.qualityRetryConfig()
-	qualityHoldEnabled := shouldHoldQualityStream(input, ownership, route, operation, holdCfg)
 	// Count accounts that actually reached the upstream. Credential-only skips
 	// do not consume the quality retry budget; refreshes stay on the same account.
 	qualityAccountAttempts := 0
@@ -1244,7 +1244,7 @@ attemptLoop:
 					err = &SelectionUnavailableError{Reason: SelectionNoAccounts}
 				}
 			}
-		} else if ownership != nil {
+		} else if ownership != nil && qualityAccountAttempts == 0 {
 			lease, err = s.selector.AcquirePinnedForKey(ctx, route.Provider, ownership.AccountID, route.ID, route.UpstreamModel, quotaMode, true, accountScope)
 		} else if input.ForcedEgressNodeID != 0 {
 			lease, err = s.selector.AcquireForKeyOnEgressNode(ctx, route.Provider, route.ID, route.UpstreamModel, quotaMode, affinityKey, excluded, !quotaProbeAttempted, accountScope, input.ForcedEgressNodeID)
@@ -1276,7 +1276,7 @@ attemptLoop:
 			// Stored Responses are pinned to one account. Return the cached 429
 			// immediately instead of spinning until the cooldown expires or
 			// replaying the request on the same account.
-			if ownership != nil || input.ForcedAccountID != 0 {
+			if input.ForcedAccountID != 0 || (ownership != nil && (!qualityHoldEnabled || qualityAccountAttempts == 0)) {
 				break attemptLoop
 			}
 			attempt--
@@ -1617,8 +1617,12 @@ attemptLoop:
 					continue
 				}
 				response.Body = replay
-				hasNextAccount := attemptPolicy.hasNext(attempt) && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
-				hasNextAccount = hasNextAccount && qualityAccountAttempts < holdCfg.MaxAttempts
+				hasNextAccount := attemptPolicy.hasNext(attempt) && qualityAccountAttempts < holdCfg.MaxAttempts
+				if selection != nil {
+					hasNextAccount = hasNextAccount && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
+				} else if ownership == nil {
+					hasNextAccount = false
+				}
 				commit := CommitQualityHold(verdict, qualityAccountAttempts-1, holdCfg.MaxAttempts, hasNextAccount, holdCfg.OnExhausted)
 				if verdict == QualityWithhold {
 					s.applyMissingThinkingPenalty(ctx, input.RequestID, credential, holdCfg.AccountCooldown)

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1020,7 +1020,8 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 	// nor new evidence and can multiply a slow/failing probe.
 	holdCfg := s.qualityRetryConfig()
 	qualityHoldEnabled := shouldHoldQualityStream(input, ownership, route, operation, holdCfg)
-	attemptPolicy := newRequestRoutingAttemptPolicy(int(s.maxAttempts.Load()), input.ForcedAccountID != 0 || (ownership != nil && !qualityHoldEnabled))
+	qualityCrossAccountReplay := canReplayQualityHoldAcrossAccounts(input, ownership)
+	attemptPolicy := newRequestRoutingAttemptPolicy(int(s.maxAttempts.Load()), ownership != nil || input.ForcedAccountID != 0)
 	idempotencyID, _ := security.NewOpaqueToken(18)
 	pricingModel := s.providers.PricingModel(route.Provider, route.UpstreamModel)
 	if err := s.checkLedgerReady(); err != nil {
@@ -1244,7 +1245,7 @@ attemptLoop:
 					err = &SelectionUnavailableError{Reason: SelectionNoAccounts}
 				}
 			}
-		} else if ownership != nil && qualityAccountAttempts == 0 {
+		} else if ownership != nil {
 			lease, err = s.selector.AcquirePinnedForKey(ctx, route.Provider, ownership.AccountID, route.ID, route.UpstreamModel, quotaMode, true, accountScope)
 		} else if input.ForcedEgressNodeID != 0 {
 			lease, err = s.selector.AcquireForKeyOnEgressNode(ctx, route.Provider, route.ID, route.UpstreamModel, quotaMode, affinityKey, excluded, !quotaProbeAttempted, accountScope, input.ForcedEgressNodeID)
@@ -1276,7 +1277,7 @@ attemptLoop:
 			// Stored Responses are pinned to one account. Return the cached 429
 			// immediately instead of spinning until the cooldown expires or
 			// replaying the request on the same account.
-			if input.ForcedAccountID != 0 || (ownership != nil && (!qualityHoldEnabled || qualityAccountAttempts == 0)) {
+			if ownership != nil || input.ForcedAccountID != 0 {
 				break attemptLoop
 			}
 			attempt--
@@ -1611,17 +1612,15 @@ attemptLoop:
 						}
 						writeCancel()
 					}
-					if shouldStopForNonAccountFingerprint(failureFingerprints, lastFailure) {
+					if !qualityCrossAccountReplay || shouldStopForNonAccountFingerprint(failureFingerprints, lastFailure) {
 						break
 					}
 					continue
 				}
 				response.Body = replay
-				hasNextAccount := attemptPolicy.hasNext(attempt) && qualityAccountAttempts < holdCfg.MaxAttempts
-				if selection != nil {
-					hasNextAccount = hasNextAccount && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
-				} else if ownership == nil {
-					hasNextAccount = false
+				hasNextAccount := qualityCrossAccountReplay && attemptPolicy.hasNext(attempt) && qualityAccountAttempts < holdCfg.MaxAttempts
+				if hasNextAccount {
+					hasNextAccount = selection != nil && selection.hasAvailableCandidate(excluded, !quotaProbeAttempted)
 				}
 				commit := CommitQualityHold(verdict, qualityAccountAttempts-1, holdCfg.MaxAttempts, hasNextAccount, holdCfg.OnExhausted)
 				if verdict == QualityWithhold {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -157,11 +157,11 @@ qualityGuard:
   # not released as late ciphertext. Empty stub-only streams keep waiting.
   # Floor-met ciphertext that then dumps a short greeting in under 1s is
   # also withheld. TUI follow-ups (previous_response_id) and hosted tools
-  # stay held; the attempt loop unpins after the first missing-thinking hit.
-  # Missing thinking with enough visible output is not delivered; another
-  # account is tried (up to maxAttempts). fail_closed returns 503 instead
-  # of the last body. Sidecar qualityGuard.enabled stays false until you
-  # start the quality-guard profile.
+  # stay held for classification, but a quality withhold never replays
+  # account-bound state or side-effecting tools. Context compaction stays exempt.
+  # Replay-safe missing-thinking requests try another account (up to
+  # maxAttempts). fail_closed returns 503 instead of the held body. Sidecar
+  # qualityGuard.enabled stays false until you start the quality-guard profile.
   # Non-empty encrypted_content stubs are not thinking. The ciphertext floor
   # is max(minEncryptedBytes, reasoning_tokens * encryptedBytesPerReasoningToken).
   requestRetry:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -152,10 +152,12 @@ qualityGuard:
   # Optional request-path withhold/retry for thinking models.
   # Recommended lab values are filled in; enabled stays false so stock
   # installs do not intercept. Set enabled: true to turn the hold on.
-  # Observe up to 30s for real reasoning evidence. If upstream has announced
-  # a reasoning item and visible output but proof arrives later, the still-open
-  # stream is released at the deadline without penalizing the account. Empty or
-  # terminal no-thinking responses are still retried.
+  # Observe up to 30s for real reasoning evidence. A reasoning-item stub plus
+  # enough visible output at the deadline is withheld (TUI dump after 30s),
+  # not released as late ciphertext. Empty stub-only streams keep waiting.
+  # Floor-met ciphertext that then dumps a short greeting in under 1s is
+  # also withheld. TUI follow-ups (previous_response_id) and hosted tools
+  # stay held; the attempt loop unpins after the first missing-thinking hit.
   # Missing thinking with enough visible output is not delivered; another
   # account is tried (up to maxAttempts). fail_closed returns 503 instead
   # of the last body. Sidecar qualityGuard.enabled stays false until you


### PR DESCRIPTION
## Summary

Stacked on #1013. Same recommended `requestRetry` numbers; **`enabled` stays `false`**.

#1013 still releases a reasoning-item stub with visible output at the hold deadline, and skips hold on `previous_response_id` / hosted tools / TUI compaction bodies. Those are the TUI dumps: 30s then 「你好」, or a floor-met cipher that flushes 3–8 visible tokens in under a second, or a follow-up that never enters the hold.

This PR keeps the ciphertext floor and adds:

1. **Stub expiry withhold** — `ReasoningStarted` + enough visible output at `HoldTimeout` is missing thinking, not late ciphertext. Stub-only empty streams still wait.
2. **Floor-met burst** — ciphertext can clear `max(256B, reasoning×4)` and still dump a short greeting billed as heavy thinking in `<1s`. Withhold that too.
3. **TUI follow-ups / hosted tools** — do not skip hold on `previous_response_id` or hosted `web_search` / image / MCP. First attempt stays pinned; a withhold unpins and rotates. Skip only when the request explicitly disables reasoning. Gateway-set `skipQualityHold` is unchanged.

## Defaults

```yaml
requestRetry:
  enabled: false
  maxAttempts: 6
  holdTimeout: 30s
  minOutputTokens: 8
  onExhausted: fail_closed
  accountCooldown: 12h
  idleAccountCooldown: 15m
  minEncryptedBytes: 256
  encryptedBytesPerReasoningToken: 4
```

## Test plan

- `go test ./internal/application/gateway/ ./internal/infra/config/ ./internal/infra/provider/conversation/ ./internal/transport/http/inference/ ./internal/app/`
- stub + hold expiry + visible ≥ minOutput → withhold
- stub-only hold expiry → wait
- floor-met 3 visible / 1371 reasoning / 200ms → withhold
- floor-met 80 visible fast flush → deliver
- `previous_response_id` and hosted tools still hold when enabled
- `enabled: false` stock path unchanged