### PR TITLE
fix(audit): record stream failure after a prior 429 retry

### DIFF
--- a/backend/internal/application/gateway/attempt.go
+++ b/backend/internal/application/gateway/attempt.go
@@ -181,11 +181,10 @@ func (r *failureAttemptRecorder) hasStreamFailureFor(accountID uint64) bool {
 	return false
 }
 
-// ensureStreamFailureAttempt records the handed-off 2xx stream when it later
-// fails. Prior 4xx/transport attempts must not suppress this row — otherwise
-// diagnostics only show the first 429 while the list account is the retry.
+// ensureStreamFailureAttempt 补记已完成 2xx 响应头握手、但随后失败的流式尝试。
+// 既有 4xx 或传输失败记录不能屏蔽该尝试；同一账号已有 response_stream 时不重复追加。
 func (r *failureAttemptRecorder) ensureStreamFailureAttempt(credential accountdomain.Credential, startedAt time.Time, response *provider.Response, errorCode string) {
-	if response == nil || r.hasStreamFailureFor(credential.ID) {
+	if response == nil || response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices || r.hasStreamFailureFor(credential.ID) {
 		return
 	}
 	statusCode := response.StatusCode

--- a/backend/internal/application/gateway/attempt.go
+++ b/backend/internal/application/gateway/attempt.go
@@ -171,6 +171,41 @@ func (r *failureAttemptRecorder) captureStreamFailure(credential accountdomain.C
 	})
 }
 
+func (r *failureAttemptRecorder) hasStreamFailureFor(accountID uint64) bool {
+	for _, attempt := range r.attempts {
+		if attempt.Stage != "response_stream" || attempt.AccountID == nil || *attempt.AccountID != accountID {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// ensureStreamFailureAttempt records the handed-off 2xx stream when it later
+// fails. Prior 4xx/transport attempts must not suppress this row — otherwise
+// diagnostics only show the first 429 while the list account is the retry.
+func (r *failureAttemptRecorder) ensureStreamFailureAttempt(credential accountdomain.Credential, startedAt time.Time, response *provider.Response, errorCode string) {
+	if response == nil || r.hasStreamFailureFor(credential.ID) {
+		return
+	}
+	statusCode := response.StatusCode
+	r.append(audit.Attempt{
+		Source:             audit.AttemptSourceUpstreamHTTP,
+		Stage:              "response_stream",
+		AccountID:          auditAccountID(credential.ID),
+		AccountName:        credential.Name,
+		Method:             r.method,
+		RequestPath:        r.path,
+		UpstreamURL:        sanitizeUpstreamURL(response.UpstreamURL),
+		StartedAt:          startedAt.UTC(),
+		DurationMS:         time.Since(startedAt).Milliseconds(),
+		UpstreamStatusCode: &statusCode,
+		UpstreamStatus:     response.Status,
+		ResponseHeaders:    sanitizeDiagnosticHeaders(response.Header),
+		TransportError:     errorCode,
+	})
+}
+
 func (r *failureAttemptRecorder) captureQualityDegraded(credential accountdomain.Credential, startedAt time.Time) {
 	status := http.StatusOK
 	r.append(audit.Attempt{

--- a/backend/internal/application/gateway/attempt_test.go
+++ b/backend/internal/application/gateway/attempt_test.go
@@ -124,6 +124,16 @@ func TestEnsureStreamFailureAttemptKeepsPrior429AndSkipsDuplicate(t *testing.T) 
 	}
 }
 
+func TestEnsureStreamFailureAttemptSkipsNon2xx(t *testing.T) {
+	recorder := newFailureAttemptRecorder(http.MethodPost, "/responses")
+	credential := account.Credential{ID: 12, Name: "retry-b"}
+	forbidden := &provider.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden"}
+	recorder.ensureStreamFailureAttempt(credential, time.Now(), forbidden, "upstream_forbidden")
+	if got := recorder.snapshot(); len(got) != 0 {
+		t.Fatalf("non-2xx stream attempt = %#v", got)
+	}
+}
+
 func TestFailureAttemptRecorderClassifiesTransportErrorChain(t *testing.T) {
 	dnsErr := &net.DNSError{Err: "no such host", Name: "api.example.test", IsNotFound: true}
 	requestErr := &url.Error{Op: "Post", URL: "https://user:password@api.example.test/v1/responses?token=secret", Err: dnsErr}

--- a/backend/internal/application/gateway/attempt_test.go
+++ b/backend/internal/application/gateway/attempt_test.go
@@ -95,6 +95,35 @@ func TestFailureAttemptRecorderCapturesStreamFailure(t *testing.T) {
 	}
 }
 
+func TestEnsureStreamFailureAttemptKeepsPrior429AndSkipsDuplicate(t *testing.T) {
+	recorder := newFailureAttemptRecorder(http.MethodPost, "/responses")
+	first := account.Credential{ID: 11, Name: "retry-a"}
+	second := account.Credential{ID: 12, Name: "retry-b"}
+	exhausted := &provider.Response{StatusCode: http.StatusTooManyRequests, Status: "Too Many Requests", Body: io.NopCloser(strings.NewReader(`{"code":"subscription:free-usage-exhausted"}`))}
+	if err := recorder.captureResponse(first, time.Now(), exhausted, nil); err != nil {
+		t.Fatal(err)
+	}
+	stream := &provider.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: http.Header{"Content-Type": {"text/event-stream"}}, UpstreamURL: "https://cli-chat-proxy.grok.com/v1/responses"}
+	recorder.ensureStreamFailureAttempt(second, time.Now().Add(-time.Second), stream, "upstream_stream_interrupted")
+	stored := recorder.snapshot()
+	if len(stored) != 2 || stored[0].Stage != "upstream_response" || stored[1].Stage != "response_stream" {
+		t.Fatalf("attempts = %#v", stored)
+	}
+	if stored[1].AccountID == nil || *stored[1].AccountID != second.ID || stored[1].TransportError != "upstream_stream_interrupted" {
+		t.Fatalf("retry stream attempt = %#v", stored[1])
+	}
+	recorder.ensureStreamFailureAttempt(second, time.Now(), stream, "upstream_stream_interrupted")
+	if got := recorder.snapshot(); len(got) != 2 {
+		t.Fatalf("duplicate stream attempt = %#v", got)
+	}
+	inStream := newFailureAttemptRecorder(http.MethodPost, "/responses")
+	inStream.captureStreamFailure(second, time.Now(), stream, StreamFailureDiagnostic{Body: []byte(`{"type":"response.failed"}`)})
+	inStream.ensureStreamFailureAttempt(second, time.Now(), stream, "upstream_stream_error")
+	if got := inStream.snapshot(); len(got) != 1 || got[0].Stage != "response_stream" {
+		t.Fatalf("ensure after in-stream capture = %#v", got)
+	}
+}
+
 func TestFailureAttemptRecorderClassifiesTransportErrorChain(t *testing.T) {
 	dnsErr := &net.DNSError{Err: "no such host", Name: "api.example.test", IsNotFound: true}
 	requestErr := &url.Error{Op: "Post", URL: "https://user:password@api.example.test/v1/responses?token=secret", Err: dnsErr}

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1118,26 +1118,10 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 				}
 				record.DurationMS = time.Since(startedAt).Milliseconds()
 				record.ErrorCode = errorCode
-				attempts := failureAttempts.snapshot()
-				if !successful && len(attempts) == 0 {
-					statusCode := response.StatusCode
-					failureAttempts.append(audit.Attempt{
-						Source:             audit.AttemptSourceUpstreamHTTP,
-						Stage:              "response_stream",
-						AccountID:          auditAccountID(credential.ID),
-						AccountName:        credential.Name,
-						Method:             http.MethodPost,
-						RequestPath:        sanitizeRequestPath(path),
-						UpstreamURL:        sanitizeUpstreamURL(response.UpstreamURL),
-						StartedAt:          upstreamStartedAt.UTC(),
-						DurationMS:         time.Since(upstreamStartedAt).Milliseconds(),
-						UpstreamStatusCode: &statusCode,
-						UpstreamStatus:     response.Status,
-						ResponseHeaders:    sanitizeDiagnosticHeaders(response.Header),
-						TransportError:     errorCode,
-					})
-					attempts = failureAttempts.snapshot()
+				if !successful {
+					failureAttempts.ensureStreamFailureAttempt(credential, upstreamStartedAt, response, errorCode)
 				}
+				attempts := failureAttempts.snapshot()
 				if !successful || len(attempts) > 0 {
 					record.Attempts = attempts
 				}

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -1118,7 +1118,7 @@ func (s *Service) createResponseAt(ctx context.Context, input Input, path string
 				}
 				record.DurationMS = time.Since(startedAt).Milliseconds()
 				record.ErrorCode = errorCode
-				if !successful {
+				if !successful && response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
 					failureAttempts.ensureStreamFailureAttempt(credential, upstreamStartedAt, response, errorCode)
 				}
 				attempts := failureAttempts.snapshot()

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -3064,6 +3064,17 @@ func TestGatewaySafetyRejectionDoesNotTouchAccountState(t *testing.T) {
 			}
 		}
 	}
+	logs, total, err := auditRepo.List(ctx, 0, 10)
+	if err != nil || total != 1 || len(logs) != 1 {
+		t.Fatalf("audit list = %#v, total=%d, err=%v", logs, total, err)
+	}
+	detail, err := auditRepo.Get(ctx, logs[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.AttemptCount != 1 || len(detail.Attempts) != 1 || detail.Attempts[0].Stage != "upstream_response" || detail.Attempts[0].UpstreamStatusCode == nil || *detail.Attempts[0].UpstreamStatusCode != http.StatusForbidden {
+		t.Fatalf("terminal 403 attempts = %#v", detail.Attempts)
+	}
 }
 
 func TestGatewayConsoleDPoPRequirementStopsAfterOneAccount(t *testing.T) {

--- a/backend/internal/application/gateway/service_test.go
+++ b/backend/internal/application/gateway/service_test.go
@@ -3492,6 +3492,96 @@ func TestGatewayGeneric429CoolsAccountAndRotates(t *testing.T) {
 	}
 }
 
+func TestGatewayRetryStreamFailureRecordsPrior429AndRetryStream(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "retry-stream-failure.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accountRepo := relational.NewAccountRepository(database)
+	modelRepo := relational.NewModelRepository(database)
+	auditRepo := relational.NewAuditRepository(database)
+	responseRepo := relational.NewResponseRepository(database)
+	keyRepo := relational.NewClientKeyRepository(database)
+
+	credentials := make([]account.Credential, 0, 2)
+	for index, name := range []string{"retry-a", "retry-b"} {
+		credential, _, createErr := accountRepo.UpsertByIdentity(ctx, account.Credential{
+			Provider: account.ProviderBuild, Name: name, SourceKey: name, EncryptedAccessToken: name,
+			ExpiresAt: time.Now().Add(time.Hour), Enabled: true, AuthStatus: account.AuthStatusActive,
+			Priority: 200 - index, MaxConcurrent: 1,
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		credentials = append(credentials, credential)
+	}
+	if err := modelRepo.UpsertDiscovered(ctx, account.ProviderBuild, []string{"grok-retry-stream"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, credential := range credentials {
+		if err := modelRepo.ReplaceAccountCapabilities(ctx, credential.ID, []string{"grok-retry-stream"}, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	clientKey, err := keyRepo.Create(ctx, clientkey.Key{
+		Name: "retry-stream-key", Prefix: "retrystream", SecretHash: strings.Repeat("4", 64), EncryptedSecret: "encrypted",
+		Enabled: true, RPMLimit: 120, MaxConcurrent: 8,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exhausted := `{"code":"subscription:free-usage-exhausted","error":"You've used all the included free usage for model grok-4.6 for now. Usage resets over a rolling 24-hour window — tokens (actual/limit): 558975/500000."}`
+	adapter := &scriptedBuildAdapter{responses: map[uint64][]scriptedBuildResponse{
+		credentials[0].ID: {{status: http.StatusTooManyRequests, body: exhausted}},
+		credentials[1].ID: {{status: http.StatusOK, header: http.Header{"Content-Type": {"text/event-stream"}}, body: "data: {\"type\":\"response.created\"}\n\n"}},
+	}}
+	registry := provider.NewRegistry(adapter)
+	sticky := memory.NewStickyStore()
+	accountService := accountapp.NewService(accountRepo, auditRepo, memory.NewDeviceSessionStore(), sticky, registry, testCipher(t), nil)
+	selector := NewSelector(accountRepo, memory.NewConcurrencyLimiter(), sticky, registry, time.Hour, time.Second, time.Minute)
+	service := NewService(modelRepo, auditRepo, accountService, clientkeyapp.NewService(nil, nil, nil, 60, 4, nil), registry, selector, responseRepo, 3)
+
+	result, err := service.CreateResponse(ctx, Input{
+		RequestID: "req-retry-stream", ClientKey: clientKey, PublicModel: "grok-retry-stream",
+		Body: []byte(`{"model":"grok-retry-stream","input":"hello"}`), Streaming: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Finalize(Usage{}, "", "upstream_stream_interrupted")
+	_ = result.Body.Close()
+	if attempts := adapter.Attempts(); len(attempts) != 2 || attempts[0] != credentials[0].ID || attempts[1] != credentials[1].ID {
+		t.Fatalf("429 must rotate before stream failure, attempts=%#v", attempts)
+	}
+
+	logs, _, err := auditRepo.List(ctx, 0, 10)
+	if err != nil || len(logs) == 0 {
+		t.Fatalf("audits = %#v, err = %v", logs, err)
+	}
+	detail, err := auditRepo.Get(ctx, logs[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.ErrorCode != "upstream_stream_interrupted" || detail.AccountID == nil || *detail.AccountID != credentials[1].ID {
+		t.Fatalf("audit = %#v", detail)
+	}
+	if detail.AttemptCount != 2 || len(detail.Attempts) != 2 {
+		t.Fatalf("attempt count = %d stored = %d, attempts=%#v", detail.AttemptCount, len(detail.Attempts), detail.Attempts)
+	}
+	first, second := detail.Attempts[0], detail.Attempts[1]
+	if first.Stage != "upstream_response" || first.UpstreamStatusCode == nil || *first.UpstreamStatusCode != http.StatusTooManyRequests || first.AccountID == nil || *first.AccountID != credentials[0].ID {
+		t.Fatalf("first attempt = %#v", first)
+	}
+	if second.Stage != "response_stream" || second.UpstreamStatusCode == nil || *second.UpstreamStatusCode != http.StatusOK || second.AccountID == nil || *second.AccountID != credentials[1].ID || second.TransportError != "upstream_stream_interrupted" {
+		t.Fatalf("retry stream attempt = %#v", second)
+	}
+}
+
 func TestGatewayNonAccount5xxSoftCoolsAndRotates(t *testing.T) {
 	ctx := context.Background()
 	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "soft-5xx.db"))


### PR DESCRIPTION
## Summary

- After a 429 handoff, a later 2xx stream failure is now recorded as its own `response_stream` attempt instead of leaving the audit stuck on the 429 row.
- The prior 429 row is kept. A duplicate stream-failure row is not added if one already exists for that account.

- 第一个号 429 换号之后，后一个号已经 2xx 但流失败时，审计会补记一条 `response_stream`，不再只剩 429。
- 原来的 429 行保留。同一账号若已有流失败记录，不会再插一条重复的。

## Context

Gateway retries on 429 by switching accounts. Diagnostics previously kept the first attempt only. When the next account opened a 2xx SSE stream and that stream later died, operators saw “rate limited” and not the real cut. That hid account-health signal and made stream failures look like they never happened.

网关遇到 429 会换号重试。诊断以前只留第一次尝试。下一个号已经握手成 2xx SSE、随后流被掐时，审计仍停在「被限流」，真正的流失败看不见。号健康信号被盖掉，看起来像这次请求从未流式失败过。

This is gateway audit bookkeeping. It does not change retry policy, status codes, or any of the three upstreams’ wire format.

这是网关审计记账，不改重试策略、不改对外状态码、也不改三条上游的报文。

## Test plan

- [x] `TestEnsureStreamFailureAttemptKeepsPrior429AndSkipsDuplicate`
- [x] `TestGatewayRetryStreamFailureRecordsPrior429AndRetryStream`
- [x] `go test ./internal/application/gateway/`
- [ ] Manual: force account A 429, account B 2xx then drop the stream → audit has 429 + stream-failure rows

- [x] 上述单测
- [x] gateway 包测试通过
- [ ] 手工：A 号 429，B 号 2xx 后掐流 → 审计同时有 429 和流失败
