### PR TITLE
fix(cli): share reasoning replay across accounts and omit content:null

### DIFF
--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -317,8 +317,9 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 	// Explicit mode wins; in auto mode only confirmed Super accounts with bot_flag_source/bfs in {1,2} default to XAI.
 	primaryBase := a.primaryBaseURL()
 	base := a.inferenceBaseForOperation(request.Credential, request.Billing, request.Method, request.Path)
-	// Cache affinity and reasoning replay use separate identities. Replay is also bound to the actual account and upstream plane,
-	// preventing opaque reasoning issued for one account or Build plane from reaching another scope.
+	// Cache affinity and reasoning replay use separate identities. Replay is bound to the
+	// upstream plane (Build vs XAI) so a blob captured on one API is not injected onto the other.
+	// Encrypted reasoning is portable across accounts, so the cache key is not account-scoped.
 	replayBaseBody := body
 	body, replayKey := a.applyReasoningReplay(ctx, request, replayBaseBody, base)
 	resp, reqURL, err := a.doResponseRequest(ctx, request, accessToken, body, base)
@@ -519,7 +520,7 @@ func (a *Adapter) scopedReasoningReplayKey(request provider.ResponseResourceRequ
 	if fallback := a.fallbackBaseURL(); fallback != "" && strings.EqualFold(strings.TrimRight(base, "/"), fallback) {
 		plane = "xai"
 	}
-	digest := sha256.Sum256([]byte(fmt.Sprintf("grok2api:reasoning-replay:v2:%s:%d:%s", seed, request.Credential.ID, plane)))
+	digest := sha256.Sum256([]byte(fmt.Sprintf("grok2api:reasoning-replay:v3:%s:%s", seed, plane)))
 	return hex.EncodeToString(digest[:])
 }
 

--- a/backend/internal/infra/provider/cli/adapter.go
+++ b/backend/internal/infra/provider/cli/adapter.go
@@ -513,7 +513,7 @@ func (a *Adapter) applyReasoningReplay(ctx context.Context, request provider.Res
 
 func (a *Adapter) scopedReasoningReplayKey(request provider.ResponseResourceRequest, base string) string {
 	seed := strings.TrimSpace(request.ReasoningReplayKey)
-	if seed == "" || request.Credential.ID == 0 {
+	if seed == "" {
 		return ""
 	}
 	plane := "build"

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -482,7 +482,7 @@ func TestForwardResponseReplaysReasoningAcrossMessagesTurns(t *testing.T) {
 	}
 }
 
-func TestReasoningReplayScopeSeparatesAccountAndPlane(t *testing.T) {
+func TestReasoningReplayScopeSharesAccountSeparatesPlane(t *testing.T) {
 	adapter := NewAdapter(Config{
 		BaseURL:         "https://build.example/v1",
 		FallbackBaseURL: "https://xai.example/v1",
@@ -497,8 +497,8 @@ func TestReasoningReplayScopeSeparatesAccountAndPlane(t *testing.T) {
 	}
 	otherAccount := request
 	otherAccount.Credential.ID = 8
-	if got := adapter.scopedReasoningReplayKey(otherAccount, "https://build.example/v1"); got == buildKey {
-		t.Fatal("reasoning replay scope was shared across accounts")
+	if got := adapter.scopedReasoningReplayKey(otherAccount, "https://build.example/v1"); got != buildKey {
+		t.Fatal("reasoning replay scope was not shared across accounts")
 	}
 	if got := adapter.scopedReasoningReplayKey(request, "https://xai.example/v1"); got == buildKey {
 		t.Fatal("reasoning replay scope was shared across Build and XAI")

--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -370,7 +370,7 @@ func TestGrokTurnIndexRequiresStableSession(t *testing.T) {
 	}
 }
 
-func TestForwardResponseReplaysReasoningAcrossMessagesTurns(t *testing.T) {
+func TestForwardResponseReplaysReasoningAcrossAccountsAndMessagesTurns(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {
 		t.Fatal(err)
@@ -413,6 +413,9 @@ func TestForwardResponseReplaysReasoningAcrossMessagesTurns(t *testing.T) {
 		case 3:
 			if len(payload.Input) != 4 || payload.Input[0]["role"] != "user" || payload.Input[1]["type"] != "reasoning" || payload.Input[1]["encrypted_content"] != replayEncrypted || payload.Input[2]["role"] != "assistant" || payload.Input[3]["role"] != "user" {
 				t.Fatalf("ordinary replay after WebSearch = %#v", payload.Input)
+			}
+			if _, exists := payload.Input[1]["content"]; exists {
+				t.Fatalf("cross-account replay included content: %#v", payload.Input[1])
 			}
 		}
 		body := `{"id":"resp_3","model":"grok-4.5","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"second"}]}]}`
@@ -465,8 +468,10 @@ func TestForwardResponseReplaysReasoningAcrossMessagesTurns(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	otherCredential := credential
+	otherCredential.ID = 8
 	second, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
-		Credential: credential, Method: http.MethodPost, Path: "/responses", Model: "grok-4.5",
+		Credential: otherCredential, Method: http.MethodPost, Path: "/responses", Model: "grok-4.5",
 		NormalizeBody: true, Operation: conversation.OperationMessages, PromptCacheKey: "messages-cache-key", ReasoningReplayKey: "messages-replay-key",
 		Body: []byte(`{"model":"public","max_tokens":128,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"first"},{"role":"user","content":"second"}]}`),
 	})
@@ -499,6 +504,11 @@ func TestReasoningReplayScopeSharesAccountSeparatesPlane(t *testing.T) {
 	otherAccount.Credential.ID = 8
 	if got := adapter.scopedReasoningReplayKey(otherAccount, "https://build.example/v1"); got != buildKey {
 		t.Fatal("reasoning replay scope was not shared across accounts")
+	}
+	zeroAccount := request
+	zeroAccount.Credential.ID = 0
+	if got := adapter.scopedReasoningReplayKey(zeroAccount, "https://build.example/v1"); got != buildKey {
+		t.Fatal("reasoning replay scope still depended on account identity")
 	}
 	if got := adapter.scopedReasoningReplayKey(request, "https://xai.example/v1"); got == buildKey {
 		t.Fatal("reasoning replay scope was shared across Build and XAI")

--- a/backend/internal/pkg/reasoningreplay/normalize.go
+++ b/backend/internal/pkg/reasoningreplay/normalize.go
@@ -105,10 +105,11 @@ func normalizeReasoningItem(raw map[string]json.RawMessage) ([]byte, bool) {
 	if !validGrokReplayEncryptedContent(encrypted) {
 		return nil, false
 	}
+	// xAI treats extra keys such as content:null as a modified compaction blob and 400s.
+	// Replay only the portable input shape: type, summary, encrypted_content.
 	out := map[string]any{
 		"type":              "reasoning",
 		"summary":           []any{},
-		"content":           nil,
 		"encrypted_content": encrypted,
 	}
 	data, err := json.Marshal(out)

--- a/backend/internal/pkg/reasoningreplay/reasoning_replay_test.go
+++ b/backend/internal/pkg/reasoningreplay/reasoning_replay_test.go
@@ -45,6 +45,9 @@ func TestNormalizeAndStoreRoundTrip(t *testing.T) {
 	if got.Input[0]["type"] != "reasoning" || got.Input[0]["encrypted_content"] != enc || got.Input[1]["role"] != "assistant" || got.Input[2]["role"] != "user" {
 		t.Fatalf("unexpected replay order: %s", updated)
 	}
+	if _, exists := got.Input[0]["content"]; exists {
+		t.Fatalf("replayed reasoning must omit content, got %s", updated)
+	}
 }
 
 func TestApplyInsertsReasoningBeforeMatchingAssistant(t *testing.T) {


### PR DESCRIPTION
## Summary

- Server-side encrypted-reasoning replay cache is keyed by **session + plane only**, not by account. Encrypted reasoning is portable across accounts.
- Injected replay items **omit `content: null`**. xAI treats that extra key as a modified compaction blob and 400s.

- 服务端密文 reasoning 的 replay 缓存只按 **session + plane** 记，不按账号。密文可以跨账号带。
- 注入的 replay 项**去掉 `content: null`**。xAI 把这个多余字段当成改过的 compaction blob，会 400。

| 上游 | 作用 | 本 PR |
|---|---|---|
| **Web** (`grok_web`) | grok.com 网页/App | ❌ 不动 |
| **Build** (`grok_build`) | Grok Build | ✅ 改这里 |
| **Console** (`grok_console`) | console.x.ai | ❌ 不动 |

## Context

Two separate 400/miss bugs on Build replay:

1. **Account-scoped cache.** After a retry or pin moved the next turn onto another account, the cache miss dropped encrypted reasoning. The ciphertext is not bound to the SSO that produced it; scoping the cache by account threw away a valid blob.
2. **`content: null` on inject.** JSON with `content: null` is not the same bytes as an omitted `content` key. Build’s compact/replay check treats that as a mutated blob and rejects it.

Build replay 上两件独立的 400/丢失：

1. **缓存按账号隔离。** 换号重试或下一轮钉到别的号时，缓存 miss，密文 reasoning 被丢掉。密文并不绑在签发它的那个 SSO 上；按账号做 key 等于把还能用的 blob 扔掉。
2. **注入时带 `content: null`。** JSON 里写 `content: null` 和省略 `content` 不是同一串字节。Build 的 compact/replay 校验会当成被改过的 blob 直接拒。

`previous_response_id` still pins the chain. This only stops the cache from refusing a valid blob just because the next attempt used a different account.

`previous_response_id` 仍然钉会话链。这里只是避免「换了个号」就把还能用的 blob 当成没有。

## Test plan

- [x] `TestReasoningReplayScopeSharesAccountSeparatesPlane`
- [x] `go test ./internal/pkg/reasoningreplay/ ./internal/infra/provider/cli/`
- [ ] Manual: compact/replay on account A, next turn on account B, same session+plane → reasoning still injected, no `content:null`
- [ ] Manual: different plane / different session → no cross-hit

- [x] 上述单测
- [x] 相关包测试通过
- [ ] 手工：A 号 compact/replay，同一 session+plane 换 B 号 → reasoning 仍注入，且没有 `content:null`
- [ ] 手工：不同 plane / 不同 session → 不会串缓存
