### PR TITLE
fix(cli): alias Codex view_image tool for Grok Build

### DIFF
--- a/backend/internal/infra/provider/cli/adapter_test.go
+++ b/backend/internal/infra/provider/cli/adapter_test.go
@@ -1012,6 +1012,74 @@ func TestForwardResponseRestoresNamespaceResponse(t *testing.T) {
 	}
 }
 
+func TestForwardResponseAliasesTopLevelViewImageForBuild(t *testing.T) {
+	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := cipher.Encrypt("access-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewAdapter(Config{BaseURL: "https://cli-chat-proxy.grok.com/v1"}, cipher)
+	adapter.http.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		tools, ok := payload["tools"].([]any)
+		if !ok || len(tools) != 1 || tools[0].(map[string]any)["name"] != "grok2api_view_image" {
+			t.Fatalf("Build tools = %#v", payload["tools"])
+		}
+		if payload["tool_choice"] != "auto" {
+			t.Fatalf("Build tool_choice = %#v", payload["tool_choice"])
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Status: "200 OK",
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"resp_view_image",
+				"tools":[{"type":"function","name":"grok2api_view_image"}],
+				"output":[{"type":"function_call","call_id":"call_1","name":"grok2api_view_image","arguments":"{}"}]
+			}`)),
+			Request: request,
+		}, nil
+	})
+
+	response, err := adapter.ForwardResponse(context.Background(), provider.ResponseResourceRequest{
+		Credential: account.Credential{ID: 8, EncryptedAccessToken: encrypted},
+		Method:     http.MethodPost, Path: "/responses", Model: "grok-4.6",
+		NormalizeBody: true, Operation: conversation.OperationResponses,
+		Body: []byte(`{
+			"model":"grok-4.6","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}],
+			"tools":[{"type":"function","name":"view_image","description":"View a local image","parameters":{"type":"object","properties":{},"required":[]}}],
+			"tool_choice":"auto"
+		}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	if response.Header.Get("X-Grok2API-Compatibility-Warnings") != "view_image_name_normalized" {
+		t.Fatalf("compatibility warnings = %q", response.Header.Get("X-Grok2API-Compatibility-Warnings"))
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	call := payload["output"].([]any)[0].(map[string]any)
+	if call["name"] != "view_image" {
+		t.Fatalf("client function call = %#v", call)
+	}
+	visibleTools := payload["tools"].([]any)
+	if visibleTools[0].(map[string]any)["name"] != "view_image" {
+		t.Fatalf("client tools = %#v", visibleTools)
+	}
+}
+
 func TestForwardResponsePreservesClaudeCodeMessagesOptions(t *testing.T) {
 	cipher, err := security.NewCipher(base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	if err != nil {

--- a/backend/internal/infra/provider/cli/responses_advanced_test.go
+++ b/backend/internal/infra/provider/cli/responses_advanced_test.go
@@ -403,6 +403,78 @@ func TestResponsesBuild02110NativeAndUnsupportedToolMatrix(t *testing.T) {
 	}
 }
 
+func TestResponsesViewImageFunctionIsAliasedForBuild(t *testing.T) {
+	normalized, compatibility, err := normalizeResponsesRequest([]byte(`{
+		"model":"grok-4.6","input":"hello","tools":[
+			{"type":"function","name":"view_image","description":"View a local image","parameters":{"type":"object","properties":{}}}
+		],"tool_choice":{"type":"function","name":"view_image"}
+	}`), "grok-4.6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compatibility == nil || !strings.Contains(compatibility.warningHeader(), "view_image_name_normalized") {
+		t.Fatalf("compatibility = %#v", compatibility)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tools := request["tools"].([]any)
+	tool := tools[0].(map[string]any)
+	if tool["name"] != "grok2api_view_image" {
+		t.Fatalf("Build tool name = %#v", tool["name"])
+	}
+	choice := request["tool_choice"].(map[string]any)
+	if choice["name"] != "grok2api_view_image" {
+		t.Fatalf("Build tool_choice = %#v", choice)
+	}
+
+	restored, err := compatibility.normalizeResponseJSON([]byte(`{
+		"tools":[{"type":"function","name":"grok2api_view_image"}],
+		"output":[{"type":"function_call","call_id":"call_1","name":"grok2api_view_image","arguments":"{}"}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(restored, &response); err != nil {
+		t.Fatal(err)
+	}
+	visibleTool := response["tools"].([]any)[0].(map[string]any)
+	if visibleTool["name"] != "view_image" {
+		t.Fatalf("visible tool name = %#v", visibleTool["name"])
+	}
+	call := response["output"].([]any)[0].(map[string]any)
+	if call["name"] != "view_image" {
+		t.Fatalf("restored call name = %#v", call["name"])
+	}
+}
+
+func TestResponsesViewImageAliasAvoidsFunctionNameCollision(t *testing.T) {
+	normalized, _, err := normalizeResponsesRequest([]byte(`{
+		"model":"grok-4.6","input":"hello","tools":[
+			{"type":"function","name":"view_image","parameters":{"type":"object"}},
+			{"type":"function","name":"grok2api_view_image","parameters":{"type":"object"}}
+		]
+	}`), "grok-4.6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request map[string]any
+	if err := json.Unmarshal(normalized, &request); err != nil {
+		t.Fatal(err)
+	}
+	tools := request["tools"].([]any)
+	if len(tools) != 2 {
+		t.Fatalf("Build tools = %#v", tools)
+	}
+	first := tools[0].(map[string]any)["name"]
+	second := tools[1].(map[string]any)["name"]
+	if first == second || first != "grok2api_view_image" || second == "grok2api_view_image" {
+		t.Fatalf("view_image alias collision was not resolved: %#v", tools)
+	}
+}
+
 func TestResponsesXSearchDateBounds(t *testing.T) {
 	normalized, _, err := normalizeResponsesRequest([]byte(`{
 		"model":"public","input":"search",

--- a/backend/internal/infra/provider/cli/responses_history.go
+++ b/backend/internal/infra/provider/cli/responses_history.go
@@ -225,8 +225,8 @@ func (c *responsesToolCompatibility) normalizeFunctionCallInput(item map[string]
 		return nil, &responsesRequestError{Message: param + ".arguments 无法编码", Param: param + ".arguments", Code: "invalid_parameter"}
 	}
 	namespace := strings.TrimSpace(stringField(item, "namespace"))
-	if namespace != "" {
-		name = c.alias(responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name})
+	if namespace != "" || strings.EqualFold(name, "view_image") {
+		name = c.functionAlias(responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name})
 	}
 	// 按官方 Build 回放结构仅保留四个输入字段，避免输出态字段和私有元数据
 	// 干扰 Grok 的 untagged ModelInput 反序列化。

--- a/backend/internal/infra/provider/cli/responses_tool_choice.go
+++ b/backend/internal/infra/provider/cli/responses_tool_choice.go
@@ -108,6 +108,23 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 	if function, nested := object["function"].(map[string]any); nested {
 		name = strings.TrimSpace(stringField(function, "name"))
 		namespace = strings.TrimSpace(stringField(function, "namespace"))
+		if name != "" {
+			identity := responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name}
+			if alias, exists := c.identityAliases[identity.key()]; exists {
+				function["name"] = alias
+				if namespace == "" && alias != name {
+					c.changed = true
+					payload["tool_choice"] = mustJSON(object)
+					return nil
+				}
+				if name != "" && namespace != "" {
+					delete(function, "namespace")
+					c.changed = true
+					payload["tool_choice"] = mustJSON(object)
+					return nil
+				}
+			}
+		}
 		if name != "" && namespace != "" {
 			identity := responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name}
 			alias, exists := c.identityAliases[identity.key()]
@@ -116,6 +133,15 @@ func (c *responsesToolCompatibility) normalizeToolChoice(payload map[string]json
 			}
 			function["name"] = alias
 			delete(function, "namespace")
+			c.changed = true
+			payload["tool_choice"] = mustJSON(object)
+		}
+		return nil
+	}
+	if name != "" && namespace == "" {
+		identity := responsesToolIdentity{Kind: responsesFunctionTool, Name: name}
+		if alias, exists := c.identityAliases[identity.key()]; exists && alias != name {
+			object["name"] = alias
 			c.changed = true
 			payload["tool_choice"] = mustJSON(object)
 		}

--- a/backend/internal/infra/provider/cli/responses_tool_declarations.go
+++ b/backend/internal/infra/provider/cli/responses_tool_declarations.go
@@ -184,7 +184,13 @@ func (c *responsesToolCompatibility) normalizeTool(raw any, namespace string, cl
 			}
 		}
 		identity := responsesToolIdentity{Kind: responsesFunctionTool, Namespace: namespace, Name: name}
-		alias := c.alias(identity)
+		alias := c.functionAlias(identity)
+		if alias != name {
+			c.changed = true
+			if strings.EqualFold(name, "view_image") && namespace == "" {
+				c.addWarning("view_image_name_normalized")
+			}
+		}
 		if parameters, exists := tool["parameters"]; exists && schemaContainsInteger(parameters) {
 			c.functionSchemas[alias] = cloneJSONValue(parameters)
 		}

--- a/backend/internal/infra/provider/cli/responses_tool_state.go
+++ b/backend/internal/infra/provider/cli/responses_tool_state.go
@@ -91,6 +91,21 @@ func (c *responsesToolCompatibility) alias(identity responsesToolIdentity) strin
 		}
 		base = identity.Namespace + separator + identity.Name
 	}
+	return c.aliasWithBase(identity, base)
+}
+
+func (c *responsesToolCompatibility) functionAlias(identity responsesToolIdentity) string {
+	if identity.Kind == responsesFunctionTool && identity.Namespace == "" && strings.EqualFold(identity.Name, "view_image") {
+		return c.aliasWithBase(identity, "grok2api_view_image")
+	}
+	return c.alias(identity)
+}
+
+func (c *responsesToolCompatibility) aliasWithBase(identity responsesToolIdentity, base string) string {
+	key := identity.key()
+	if alias, exists := c.identityAliases[key]; exists {
+		return alias
+	}
 	alias := truncateToolAlias(base, key)
 	if existing, collision := c.aliases[alias]; collision && existing.key() != key {
 		alias = hashedToolAlias(base, key)


### PR DESCRIPTION
## Summary

- 将 Codex Responses 顶层函数 `view_image` 以请求级安全别名 `grok2api_view_image` 发送给 Grok Build，避免上游因工具名冲突返回 HTTP 400。
- 在普通响应和 SSE 工具调用中恢复客户端原始名称 `view_image`。
- 同步处理显式 `tool_choice`、历史 `function_call` 和别名冲突，不删除工具、不改变客户端工具语义。
- 仅影响 Grok Build 的 native Responses 兼容路径；Web、Console、Chat/Anthropic 转换和重试策略不变。

## Testing

- `go test ./internal/infra/provider/cli -count=1`
- `go test ./...`
- `git diff --check`
- 新增完整 `ForwardResponse` 回归测试，验证：
  - Build 实际收到 `grok2api_view_image`
  - `tool_choice: "auto"` 保持不变
  - 返回客户端的工具声明和函数调用恢复为 `view_image`
  - 响应包含 `view_image_name_normalized` 兼容性警告
- 未使用真实 Build 凭据进行线上手工回放。

## Related

Closes #1017