### PR TITLE
fix: cap account cooldown from upstream Retry-After

### DIFF
--- a/backend/internal/application/gateway/selector.go
+++ b/backend/internal/application/gateway/selector.go
@@ -1271,6 +1271,7 @@ func (s *Selector) markMissingThinking(ctx context.Context, credential account.C
 }
 
 func (s *Selector) MarkFailure(ctx context.Context, credential account.Credential, status int, retryAfter time.Duration) {
+	retryAfter = s.boundUpstreamRetryAfter(retryAfter)
 	_ = s.markFailure(ctx, credential, credential.FailureCount, credential.FailureCount+1, status, retryAfter, status == 0)
 }
 
@@ -1285,7 +1286,19 @@ func (s *Selector) MarkFailureAfterSuccess(ctx context.Context, credential accou
 // applying the bounded, non-accumulating health penalty used for transient
 // network and provider-wide failures.
 func (s *Selector) markSoftFailure(ctx context.Context, credential account.Credential, status int, retryAfter time.Duration) error {
+	retryAfter = s.boundUpstreamRetryAfter(retryAfter)
 	return s.markFailure(ctx, credential, credential.FailureCount, credential.FailureCount+1, status, retryAfter, true)
+}
+
+func (s *Selector) boundUpstreamRetryAfter(retryAfter time.Duration) time.Duration {
+	if retryAfter <= 0 {
+		return retryAfter
+	}
+	_, _, cooldownMax, _ := s.routingConfig()
+	if cooldownMax > 0 && retryAfter > cooldownMax {
+		return cooldownMax
+	}
+	return retryAfter
 }
 
 func (s *Selector) markFailure(ctx context.Context, credential account.Credential, baselineFailureCount, nextFailureCount, status int, retryAfter time.Duration, soft bool) error {

--- a/backend/internal/application/gateway/selector_test.go
+++ b/backend/internal/application/gateway/selector_test.go
@@ -1800,6 +1800,133 @@ func TestMarkFailureSoftNetworkCooldown(t *testing.T) {
 	}
 }
 
+func TestBoundUpstreamRetryAfter(t *testing.T) {
+	selector := &Selector{cooldownMax: time.Minute}
+	tests := []struct {
+		name string
+		input time.Duration
+		want  time.Duration
+	}{
+		{name: "empty", input: 0, want: 0},
+		{name: "negative", input: -time.Second, want: -time.Second},
+		{name: "within maximum", input: 30 * time.Second, want: 30 * time.Second},
+		{name: "above maximum", input: 2 * time.Minute, want: time.Minute},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := selector.boundUpstreamRetryAfter(test.input); got != test.want {
+				t.Fatalf("boundUpstreamRetryAfter(%s) = %s, want %s", test.input, got, test.want)
+			}
+		})
+	}
+}
+
+func TestMarkFailureBoundsUpstreamRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "retry-after-bound.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "retry-after-bound", SourceKey: "retry-after-bound", EncryptedAccessToken: "encrypted", Enabled: true,
+		AuthStatus: account.AuthStatusActive, Priority: 10, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute, 500*time.Millisecond)
+	before := time.Now().UTC()
+	selector.MarkFailure(ctx, credential, http.StatusTooManyRequests, 24*time.Hour)
+	updated, err := accounts.Get(ctx, credential.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.CooldownUntil == nil {
+		t.Fatal("expected cooldown")
+	}
+	cooldown := updated.CooldownUntil.Sub(before)
+	if cooldown < 50*time.Second || cooldown > 70*time.Second {
+		t.Fatalf("upstream Retry-After cooldown = %s, want at most cooldownMax (~1m)", cooldown)
+	}
+}
+
+func TestMarkSoftFailureBoundsUpstreamRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "soft-retry-after-bound.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "soft-retry-after-bound", SourceKey: "soft-retry-after-bound", EncryptedAccessToken: "encrypted", Enabled: true,
+		AuthStatus: account.AuthStatusActive, Priority: 10, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute, 500*time.Millisecond)
+	before := time.Now().UTC()
+	if err := selector.markSoftFailure(ctx, credential, http.StatusServiceUnavailable, 24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := accounts.Get(ctx, credential.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.CooldownUntil == nil {
+		t.Fatal("expected cooldown")
+	}
+	cooldown := updated.CooldownUntil.Sub(before)
+	if cooldown < 50*time.Second || cooldown > 70*time.Second {
+		t.Fatalf("soft upstream Retry-After cooldown = %s, want at most cooldownMax (~1m)", cooldown)
+	}
+}
+
+func TestMarkFailureAfterSuccessPreservesExplicitCooldown(t *testing.T) {
+	ctx := context.Background()
+	database, err := relational.OpenSQLite(ctx, filepath.Join(t.TempDir(), "after-success-cooldown.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if err := database.InitializeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	accounts := relational.NewAccountRepository(database)
+	credential, _, err := accounts.UpsertByIdentity(ctx, account.Credential{
+		Provider: account.ProviderBuild, Name: "after-success-cooldown", SourceKey: "after-success-cooldown", EncryptedAccessToken: "encrypted", Enabled: true,
+		AuthStatus: account.AuthStatusActive, Priority: 10, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := NewSelector(accounts, memory.NewConcurrencyLimiter(), memory.NewStickyStore(), nil, time.Hour, time.Second, time.Minute, 500*time.Millisecond)
+	before := time.Now().UTC()
+	if err := selector.MarkFailureAfterSuccess(ctx, credential, http.StatusGatewayTimeout, 2*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := accounts.Get(ctx, credential.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.CooldownUntil == nil {
+		t.Fatal("expected cooldown")
+	}
+	cooldown := updated.CooldownUntil.Sub(before)
+	if cooldown < 119*time.Minute || cooldown > 121*time.Minute {
+		t.Fatalf("explicit after-success cooldown = %s, want ~2h", cooldown)
+	}
+}
+
 func TestConsoleRateLimitReconciliationUsesNonAccumulatingCooldown(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary

- 上游 `Retry-After` 写入账号健康状态前增加上限保护。
- 异常过大的 `Retry-After` 不再覆盖 `routing.cooldownMax`。
- 账号不会因异常响应头进入数小时甚至数天的冷却。
- 合法的短重试时间保持不变。
- 质量策略显式设置的冷却时间不受影响。
- 不修改请求重试次数、客户端状态码或上游报文。

## Context

网关之前允许上游返回的 `Retry-After` 直接覆盖账号冷却最大值。部分异常或过大的响应头会让账号长时间无法调度，表现为冷却不会自动解除，只能通过后台手动清除。

本次仅限制普通账号失败和软失败路径中的上游重试提示，避免单个异常响应头拖垮账号调度。质量策略使用的显式冷却仍保留原有语义。

## Test plan

- [x] `TestBoundUpstreamRetryAfter`
- [x] `TestMarkFailureBoundsUpstreamRetryAfter`
- [x] `TestMarkSoftFailureBoundsUpstreamRetryAfter`
- [x] `TestMarkFailureAfterSuccessPreservesExplicitCooldown`
- [x] `go test ./internal/application/gateway/`
- [x] `go test -race ./internal/application/gateway/`