### PR TITLE
fix: allow manual routes to reuse compatibility aliases

### DIFF
--- a/backend/internal/infra/persistence/relational/model_multi_public_id_test.go
+++ b/backend/internal/infra/persistence/relational/model_multi_public_id_test.go
@@ -250,6 +250,44 @@ func TestManualRouteTargetsMaySharePublicID(t *testing.T) {
 	}
 }
 
+func TestManualRouteMayReuseCompatibilityAlias(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDatabase(t)
+	repo := NewModelRepository(database)
+
+	renamed, err := repo.Create(ctx, model.Route{
+		PublicID: "gpt-5.6-sol", Provider: account.ProviderBuild, UpstreamModel: "grok-4.5",
+		Capability: model.CapabilityResponses, Origin: model.OriginManual, Enabled: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	renamed.PublicID = "renamed-model"
+	if _, err := repo.Update(ctx, renamed, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := repo.Create(ctx, model.Route{
+		PublicID: "gpt-5.6-sol", Provider: account.ProviderBuild, UpstreamModel: "grok-4.6",
+		Capability: model.CapabilityResponses, Origin: model.OriginManual, Enabled: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("manual route reusing compatibility alias: %v", err)
+	}
+
+	routes, err := findModelRoutesByPublicID(database.db.WithContext(ctx), "gpt-5.6-sol")
+	if err != nil || len(routes) != 2 {
+		t.Fatalf("legacy model routes = %#v, err = %v", routes, err)
+	}
+	if routes[0].ID != created.ID || routes[1].ID != renamed.ID {
+		t.Fatalf("legacy model route order = %#v, want direct route before alias route", routes)
+	}
+	created.PublicID = "another-model"
+	if _, err := repo.Update(ctx, created, nil); err != nil {
+		t.Fatalf("manual route rename after compatibility alias reuse: %v", err)
+	}
+}
+
 func TestReplaceProviderRoutesKeepsManualAliasesWithSharedUpstream(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDatabase(t)

--- a/backend/internal/infra/persistence/relational/model_public_id.go
+++ b/backend/internal/infra/persistence/relational/model_public_id.go
@@ -80,6 +80,13 @@ func preserveModelRouteAlias(tx *gorm.DB, alias string, routeID uint64) error {
 		if existing.ModelRouteID == routeID {
 			return nil
 		}
+		var current modelRouteModel
+		if err := tx.Select("origin").Where("id = ?", routeID).First(&current).Error; err != nil {
+			return err
+		}
+		if current.Origin == string(modeldomain.OriginManual) {
+			return nil
+		}
 		return fmt.Errorf("%w: 模型兼容名称 %q 已绑定路由 %d", repository.ErrConflict, alias, existing.ModelRouteID)
 	}
 	if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/backend/internal/infra/persistence/relational/model_repository.go
+++ b/backend/internal/infra/persistence/relational/model_repository.go
@@ -1076,9 +1076,6 @@ func (r *ModelRepository) Create(ctx context.Context, value model.Route, account
 		Capability: string(value.Capability), Origin: string(model.OriginManual), Enabled: value.Enabled,
 	}
 	err := r.db.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := ensureModelPublicIDNotAlias(tx, value.PublicID, 0); err != nil {
-			return err
-		}
 		if err := tx.Create(&row).Error; err != nil {
 			return mapError(err)
 		}
@@ -1112,8 +1109,10 @@ func (r *ModelRepository) Update(ctx context.Context, value model.Route, account
 			return fmt.Errorf("模型路由公开 ID 无效")
 		}
 		value.PublicID = publicID
-		if err := ensureModelPublicIDNotAlias(tx, value.PublicID, existing.ID); err != nil {
-			return err
+		if existing.Origin != string(model.OriginManual) {
+			if err := ensureModelPublicIDNotAlias(tx, value.PublicID, existing.ID); err != nil {
+				return err
+			}
 		}
 		if existing.PublicID != value.PublicID {
 			if err := preserveModelRouteAlias(tx, existing.PublicID, existing.ID); err != nil {


### PR DESCRIPTION
## Summary

- Manual model routes can now reuse public names retained in `model_route_aliases`.
- Creating or renaming a manual route no longer returns `modelConflict` solely because the name is a hidden compatibility alias.
- Direct public-ID routes remain preferred over compatibility aliases during lookup.
- Catalog and discovered routes keep their existing alias-conflict protection.

## Context

Manual routes support duplicate public names so multiple targets can form one scheduling pool. However, names retained after an earlier route rename were stored separately in `model_route_aliases` and were not shown in the model list.

The create path still treated those hidden aliases as globally reserved. As a result, a name such as `gpt-5.6-sol` could return `modelConflict` even though no current route with that name appeared in the admin UI.

The same conflict could also prevent a manual route from being renamed again after reusing a compatibility alias. Manual routes now follow the documented duplicate-name behavior, while managed catalog routes remain protected from alias collisions.

## Test plan

- [x] `TestManualRouteMayReuseCompatibilityAlias`
- [x] Verify direct routes are resolved before compatibility-alias routes
- [x] Verify a manual route can be renamed after reusing an alias
- [x] `go test ./internal/infra/persistence/relational ./internal/application/model ./internal/transport/http/model`
- [x] `go test ./...`
- [ ] Manual: create `gpt-5.6-sol` when `Build/gpt-5.6-sol` exists only in `model_route_aliases`

Fixes #1033