### PR TITLE
feat: Chat Completions 可选自动注入 web_search（chat.autoWebSearch）

### DIFF
--- a/backend/internal/app/application.go
+++ b/backend/internal/app/application.go
@@ -355,6 +355,7 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*Applicat
 	gatewayService.UpdateQualityRetry(qualityRetryRuntime(cfg.QualityGuard.RequestRetry))
 	gatewayService.UpdateVideoMaxAttempts(cfg.Routing.VideoMaxAttempts)
 	gatewayService.UpdateMarkBuildChatDeniedAsReauth(cfg.Routing.MarkBuildChatDeniedAsReauth)
+	gatewayService.UpdateAutoWebSearch(cfg.Chat.AutoWebSearch)
 	gatewayService.SetLogger(logger)
 	egressService.SetQualityProber(gatewayService)
 	gatewayService.UpdateBuildForbiddenReauthPolicy(cfg.Accounts.MarkBuildForbiddenReauth, cfg.Accounts.BuildForbiddenReauthCodes)

--- a/backend/internal/application/gateway/auto_web_search.go
+++ b/backend/internal/application/gateway/auto_web_search.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+func maybeInjectAutoWebSearch(body []byte) []byte {
+	var source map[string]json.RawMessage
+	if json.Unmarshal(body, &source) != nil {
+		return body
+	}
+	if toolChoiceDisablesTools(source["tool_choice"]) {
+		return body
+	}
+	if len(bytes.TrimSpace(source["web_search_options"])) > 0 && string(bytes.TrimSpace(source["web_search_options"])) != "null" {
+		return body
+	}
+	tools, ok := decodeChatTools(source["tools"])
+	if !ok {
+		return body
+	}
+	if containsWebSearchTool(tools) {
+		return body
+	}
+	var payload map[string]any
+	if json.Unmarshal(body, &payload) != nil {
+		return body
+	}
+	payload["tools"] = append(tools, map[string]any{"type": "web_search"})
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return encoded
+}
+
+func decodeChatTools(raw json.RawMessage) ([]any, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, true
+	}
+	var tools []any
+	if json.Unmarshal(trimmed, &tools) != nil {
+		return nil, false
+	}
+	return tools, true
+}
+
+func containsWebSearchTool(tools []any) bool {
+	for _, raw := range tools {
+		tool, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind, _ := tool["type"].(string)
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(kind)), "web_search") {
+			return true
+		}
+	}
+	return false
+}
+
+func toolChoiceDisablesTools(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return false
+	}
+	var asString string
+	if json.Unmarshal(trimmed, &asString) == nil {
+		return strings.EqualFold(strings.TrimSpace(asString), "none")
+	}
+	var asObject map[string]any
+	if json.Unmarshal(trimmed, &asObject) != nil {
+		return false
+	}
+	kind, _ := asObject["type"].(string)
+	return strings.EqualFold(strings.TrimSpace(kind), "none")
+}

--- a/backend/internal/application/gateway/auto_web_search_test.go
+++ b/backend/internal/application/gateway/auto_web_search_test.go
@@ -1,0 +1,65 @@
+package gateway
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMaybeInjectAutoWebSearch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		body     string
+		injected bool
+	}{
+		{name: "empty tools", body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}]}`, injected: true},
+		{name: "null tools", body: `{"model":"grok-4.5","tools":null}`, injected: true},
+		{name: "existing web_search", body: `{"tools":[{"type":"web_search"}]}`, injected: false},
+		{name: "existing preview", body: `{"tools":[{"type":"web_search_preview"}]}`, injected: false},
+		{name: "web_search_options", body: `{"web_search_options":{}}`, injected: false},
+		{name: "tool_choice none string", body: `{"tool_choice":"none"}`, injected: false},
+		{name: "tool_choice none object", body: `{"tool_choice":{"type":"none"}}`, injected: false},
+		{name: "function tools append", body: `{"tools":[{"type":"function","function":{"name":"lookup"}}]}`, injected: true},
+		{name: "invalid json", body: `{not-json`, injected: false},
+		{name: "invalid tools type", body: `{"tools":"oops"}`, injected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maybeInjectAutoWebSearch([]byte(tc.body))
+			if !tc.injected {
+				if string(got) != tc.body {
+					t.Fatalf("body changed: %s", got)
+				}
+				return
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(got, &payload); err != nil {
+				t.Fatalf("injected body is not JSON: %v", err)
+			}
+			tools, _ := payload["tools"].([]any)
+			if !containsWebSearchTool(tools) {
+				t.Fatalf("missing web_search: %s", got)
+			}
+		})
+	}
+}
+
+func TestMaybeInjectAutoWebSearchPreservesExistingFunctions(t *testing.T) {
+	t.Parallel()
+	got := maybeInjectAutoWebSearch([]byte(`{"tools":[{"type":"function","function":{"name":"lookup"}}]}`))
+	var payload map[string]any
+	if err := json.Unmarshal(got, &payload); err != nil {
+		t.Fatal(err)
+	}
+	tools, _ := payload["tools"].([]any)
+	if len(tools) != 2 {
+		t.Fatalf("tools = %#v", tools)
+	}
+	first, _ := tools[0].(map[string]any)
+	if first["type"] != "function" {
+		t.Fatalf("original function tool lost: %#v", tools)
+	}
+}

--- a/backend/internal/application/gateway/service.go
+++ b/backend/internal/application/gateway/service.go
@@ -228,6 +228,7 @@ type Service struct {
 	modelSyncing                map[uint64]struct{}
 	markBuildChatDeniedAsReauth atomic.Bool
 	qualityRetry                atomic.Pointer[QualityRetryRuntime]
+	autoWebSearch               atomic.Bool
 }
 
 type teamModelRateLimit struct {
@@ -486,6 +487,10 @@ func (s *Service) UpdateMarkBuildChatDeniedAsReauth(enabled bool) {
 	s.markBuildChatDeniedAsReauth.Store(enabled)
 }
 
+func (s *Service) UpdateAutoWebSearch(enabled bool) {
+	s.autoWebSearch.Store(enabled)
+}
+
 func (s *Service) UpdateRequestTimeout(value time.Duration) {
 	if value <= 0 {
 		value = minimumTextBillingReservationTTL
@@ -526,6 +531,9 @@ func (s *Service) CreateResponse(ctx context.Context, input Input) (*Result, err
 
 func (s *Service) CreateChatCompletion(ctx context.Context, input Input) (*Result, error) {
 	input.Operation = audit.OperationChat
+	if s.autoWebSearch.Load() {
+		input.Body = maybeInjectAutoWebSearch(input.Body)
+	}
 	return s.createResponseAt(ctx, input, "/responses")
 }
 

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -70,6 +70,11 @@ type Config struct {
 	QualityGuard      QualityGuardConfig      `yaml:"qualityGuard"`
 	ClientKeyDefaults ClientKeyDefaultsConfig `yaml:"clientKeyDefaults"`
 	Accounts          AccountsConfig          `yaml:"-"`
+	Chat              ChatConfig              `yaml:"chat"`
+}
+
+type ChatConfig struct {
+	AutoWebSearch bool `yaml:"autoWebSearch"`
 }
 
 type ServerConfig struct {
@@ -946,6 +951,7 @@ func defaultConfig() Config {
 				AccountCooldown: Duration(12 * time.Hour), IdleAccountCooldown: Duration(15 * time.Minute),
 			},
 		},
+		Chat:              ChatConfig{AutoWebSearch: true},
 		ClientKeyDefaults: ClientKeyDefaultsConfig{RPMLimit: clientkeydomain.DefaultRPMLimit, MaxConcurrent: clientkeydomain.DefaultMaxConcurrent},
 		Accounts: AccountsConfig{
 			MarkBuildForbiddenReauth:             false,

--- a/backend/internal/infra/provider/web/chat.go
+++ b/backend/internal/infra/provider/web/chat.go
@@ -232,7 +232,7 @@ func (a *Adapter) ForwardResponse(ctx context.Context, request provider.Response
 		parallelTools = *input.ParallelToolCalls
 	}
 	if modelKnown && spec.Capability == modeldomain.CapabilityImage {
-		if len(tools.ResponseTools) > 0 {
+		if len(tools.Functions) > 0 {
 			return invalidImageRequest("图片生成模型不支持 tools")
 		}
 		return a.forwardImageChatCompletion(ctx, request, input, normalized, spec)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -88,6 +88,10 @@ media:
     # [按需修改] 图片二进制目录；数据库只保存资源元数据。
     path: "./data/media"
 
+chat:
+  # [按需修改] Chat Completions 未声明 web_search 时自动注入该工具。
+  autoWebSearch: true
+
 routing:
   # [按需修改] 服务端推理回放缓存：多轮时自动补回客户端未携带的 encrypted_content。
   reasoningReplayEnabled: true


### PR DESCRIPTION
## 解决什么问题

现在网络搜索是"显式声明制"：客户端必须在请求里带 `tools: [{"type": "web_search"}]` 才会搜，不带就纯聊天。很多下游（聚合网关、老客户端）没法方便地带这个字段，用户只能得到过时的回答，还以为是模型不行。

## 怎么做的

新增 `chat.autoWebSearch` 配置（默认 true）。开启后，网关在 Chat Completions 入口检查请求：只要没声明搜索工具，就自动补一个 `web_search` 进去再转发。Web / Build / Console 三条通道都生效。

## 不该动的情况一个不动

- 请求里已经有 `web_search` / `web_search_preview` → 不重复加
- 带了 `web_search_options` → 交给原有逻辑处理
- `tool_choice` 是 `"none"`（含对象形态 `{"type":"none"}`）→ 用户明确不要工具，尊重之
- `/v1/messages` 和 `/v1/responses` 路径完全不受影响

## 顺手修的一个边界

Web 通道图片模型原本"带任何 tools 就报错"。自动注入的 web_search 是 hosted 工具（不进 Functions），会把图片请求误杀，因此把拒绝条件从 ResponseTools 收紧为 Functions——真正的函数工具照旧拒绝，hosted 搜索声明不再挡路。

## 测试

- 新增表驱动单测覆盖：注入、已有工具、none 跳过、函数工具共存、非法 JSON 等分支
- `go test ./internal/application/gateway/ ./internal/infra/config/` 通过
- 实测：无 tools 的 grok-4.5 请求返回真实 url_citation 引用；`tool_choice:"none"` 返回纯模型回答（无引用），行为符合预期

## 配置示例

```yaml
chat:
  autoWebSearch: true
```

不想用就设 false，或删掉该段（默认值在代码里也是 true，显式写 false 即可关闭）。