### PR TITLE
fix(console): ensure tool_choice is dropped when tools is empty

### DIFF
--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -114,6 +114,30 @@ func TestCatalogContainsAllConsoleModelsAndAliases(t *testing.T) {
 	}
 }
 
+func TestConsoleToolChoiceRequiresNonEmptyTools(t *testing.T) {
+	for name, payload := range map[string]map[string]any{
+		"missing tools": {"tool_choice": "auto"},
+		"nil tools":     {"tools": nil, "tool_choice": "required"},
+		"empty tools":   {"tools": []any{}, "tool_choice": "auto"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ensureConsoleToolChoicePair(payload)
+			if _, exists := payload["tool_choice"]; exists {
+				t.Fatalf("tool_choice remained without tools: %#v", payload)
+			}
+		})
+	}
+
+	payload := map[string]any{
+		"tools":       []any{map[string]any{"type": "web_search"}},
+		"tool_choice": "auto",
+	}
+	ensureConsoleToolChoicePair(payload)
+	if payload["tool_choice"] != "auto" || len(payload["tools"].([]any)) != 1 {
+		t.Fatalf("valid tool/tool_choice pair was changed: %#v", payload)
+	}
+}
+
 func TestConsoleVoiceErrorIsSanitizedAndPreservesRetryMetadata(t *testing.T) {
 	response := &http.Response{
 		StatusCode: http.StatusTooManyRequests,

--- a/backend/internal/infra/provider/console/console_test.go
+++ b/backend/internal/infra/provider/console/console_test.go
@@ -138,6 +138,35 @@ func TestConsoleToolChoiceRequiresNonEmptyTools(t *testing.T) {
 	}
 }
 
+func TestNormalizeRequestDropsToolChoiceWhenToolsEmpty(t *testing.T) {
+	spec, ok := Resolve("grok-4.5")
+	if !ok {
+		t.Fatal("grok-4.5 missing")
+	}
+	for name, body := range map[string]string{
+		"missing tools": `{"model":"public","input":"hello","tool_choice":"auto"}`,
+		"null tools":    `{"model":"public","input":"hello","tools":null,"tool_choice":"none"}`,
+		"empty tools":   `{"model":"public","input":"hello","tools":[],"tool_choice":"required"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			normalized, err := normalizeRequest([]byte(body), spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(normalized, &payload); err != nil {
+				t.Fatal(err)
+			}
+			if _, exists := payload["tools"]; exists {
+				t.Fatalf("tools remained without declarations: %#v", payload)
+			}
+			if _, exists := payload["tool_choice"]; exists {
+				t.Fatalf("tool_choice remained without tools: %#v", payload)
+			}
+		})
+	}
+}
+
 func TestConsoleVoiceErrorIsSanitizedAndPreservesRetryMetadata(t *testing.T) {
 	response := &http.Response{
 		StatusCode: http.StatusTooManyRequests,

--- a/backend/internal/infra/provider/console/normalize.go
+++ b/backend/internal/infra/provider/console/normalize.go
@@ -52,7 +52,22 @@ func normalizeRequestWithMetadata(body []byte, spec ModelSpec, metadata *provide
 		return nil, err
 	}
 	normalizeConsoleToolChoice(payload, retainedClientTools)
+	ensureConsoleToolChoicePair(payload)
 	return json.Marshal(payload)
+}
+
+// ensureConsoleToolChoicePair enforces the upstream invariant that tool_choice
+// may only be sent when at least one valid tool declaration is present.
+func ensureConsoleToolChoicePair(payload map[string]any) {
+	choice, hasChoice := payload["tool_choice"]
+	if !hasChoice || choice == nil {
+		return
+	}
+	tools, ok := payload["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		delete(payload, "tools")
+		delete(payload, "tool_choice")
+	}
 }
 
 func hasRecognizedConsoleReasoningEffort(payload map[string]any) bool {


### PR DESCRIPTION
Fixes #1042

### 背景与问题 (Problem)
在使用第三方客户端或反代网关（如 AxonHub、NextChat、LibreChat 等）请求 Console 系列模型时，某些客户端在未声明工具时可能默认发送 `"tools": []` 或携带 `"tool_choice": "none"` / `"auto"`。

在特定输入时序下，请求体序列化后可能会保留 `"tool_choice"`，而 `"tools"` 数组为空或缺失。
这会导致官方 xAI Console upstream (`/responses`) 直接返回 **HTTP 400 Bad Request**：
```json
{
  "code": "invalid-argument",
  "error": "Invalid request content: A tool_choice was set on the request but no tools were specified."
}
```

### 变更内容 (Solution)
在 `backend/internal/infra/provider/console/normalize.go` 中增加 `ensureConsoleToolChoicePair` 校验：
- 当 `tools` 为空或不存在时，强制清除 `tool_choice`，确保严格遵循 xAI Console 官方 API 的参数契约。
- 补充单元测试 `TestConsoleToolChoiceRequiresNonEmptyTools`，覆盖缺失 tools、nil tools、空 tools 等场景。

### 验证 (Verification)
- `go test ./internal/infra/provider/console` 单测通过。
- 经第三方网关（带 `tools: []` + `tool_choice: "none"`）实际调用上游 Console 验证通过，不再触发 400 拦截。