### PR TITLE
feat(console): forward TTS replace pronunciations

### DIFF
--- a/backend/internal/application/gateway/voice.go
+++ b/backend/internal/application/gateway/voice.go
@@ -30,6 +30,7 @@ type TTSInput struct {
 	Text                     string
 	VoiceID                  string
 	Language                 string
+	Replace                  map[string]string
 	OutputFormat             provider.TTSOutputFormat
 	Speed                    float64
 	OptimizeStreamingLatency int
@@ -97,7 +98,7 @@ func (s *Service) SynthesizeSpeech(ctx context.Context, input TTSInput) (*Result
 			return voiceExecutionResult{}, ErrNoAvailableAccount
 		}
 		result, err := adapter.SynthesizeSpeech(executionCtx, provider.TTSRequest{
-			Credential: credential, Model: upstream, Text: input.Text, VoiceID: input.VoiceID, Language: input.Language,
+			Credential: credential, Model: upstream, Text: input.Text, VoiceID: input.VoiceID, Language: input.Language, Replace: input.Replace,
 			OutputFormat: input.OutputFormat, Speed: input.Speed, OptimizeStreamingLatency: input.OptimizeStreamingLatency,
 			TextNormalization: input.TextNormalization, WithTimestamps: input.WithTimestamps,
 		})

--- a/backend/internal/infra/provider/console/voice.go
+++ b/backend/internal/infra/provider/console/voice.go
@@ -43,6 +43,9 @@ func (a *Adapter) SynthesizeSpeech(ctx context.Context, request provider.TTSRequ
 	if voiceID := strings.TrimSpace(request.VoiceID); voiceID != "" {
 		payload["voice_id"] = voiceID
 	}
+	if len(request.Replace) > 0 {
+		payload["replace"] = request.Replace
+	}
 	if format := normalizeTTSOutputFormat(request.OutputFormat); format != nil {
 		payload["output_format"] = format
 	}

--- a/backend/internal/infra/provider/provider.go
+++ b/backend/internal/infra/provider/provider.go
@@ -597,6 +597,7 @@ type TTSRequest struct {
 	Text                     string
 	VoiceID                  string
 	Language                 string
+	Replace                  map[string]string
 	OutputFormat             TTSOutputFormat
 	Speed                    float64
 	OptimizeStreamingLatency int

--- a/backend/internal/transport/http/inference/voice_handler.go
+++ b/backend/internal/transport/http/inference/voice_handler.go
@@ -17,15 +17,16 @@ import (
 )
 
 type ttsRequest struct {
-	Model                    string          `json:"model"`
-	Text                     string          `json:"text"`
-	VoiceID                  string          `json:"voice_id"`
-	Language                 string          `json:"language"`
-	OutputFormat             json.RawMessage `json:"output_format"`
-	Speed                    *float64        `json:"speed"`
-	OptimizeStreamingLatency json.RawMessage `json:"optimize_streaming_latency"`
-	TextNormalization        *bool           `json:"text_normalization"`
-	WithTimestamps           *bool           `json:"with_timestamps"`
+	Model                    string            `json:"model"`
+	Text                     string            `json:"text"`
+	VoiceID                  string            `json:"voice_id"`
+	Language                 string            `json:"language"`
+	Replace                  map[string]string `json:"replace"`
+	OutputFormat             json.RawMessage   `json:"output_format"`
+	Speed                    *float64          `json:"speed"`
+	OptimizeStreamingLatency json.RawMessage   `json:"optimize_streaming_latency"`
+	TextNormalization        *bool             `json:"text_normalization"`
+	WithTimestamps           *bool             `json:"with_timestamps"`
 }
 
 func (h *Handler) synthesizeSpeech(c *gin.Context) {
@@ -75,7 +76,7 @@ func (h *Handler) synthesizeSpeech(c *gin.Context) {
 	}
 	input := gateway.TTSInput{
 		RequestID: requestID, ClientKey: clientKey, PublicModel: model, Text: text, VoiceID: strings.TrimSpace(request.VoiceID),
-		Language: language, OutputFormat: format, Speed: speed, OptimizeStreamingLatency: optimize,
+		Language: language, Replace: request.Replace, OutputFormat: format, Speed: speed, OptimizeStreamingLatency: optimize,
 		Method: c.Request.Method, Path: c.Request.URL.Path, Headers: c.Request.Header.Clone(),
 	}
 	if request.TextNormalization != nil {


### PR DESCRIPTION
## Summary

* accept xAI `replace` pronunciation overrides on native `/v1/tts`
* pass `replace` through the HTTP transport, gateway, and provider layers
* forward the map unchanged to Console TTS when non-empty

This enables pronunciation overrides such as IPA values while preserving the original input text.

Example:

```json
{
  "text": "nginx is returning errors.",
  "replace": {
    "nginx": "/ˈɛndʒɪn ˈɛks/"
  }
}
```

## Testing

* `gofmt` on the touched Go files
* `go test ./...`
